### PR TITLE
Fix backward-compatibility for config versions

### DIFF
--- a/python/Ganga/Runtime/bootstrap.py
+++ b/python/Ganga/Runtime/bootstrap.py
@@ -300,7 +300,7 @@ under certain conditions; type license() for details.
         with open(os.path.join(os.path.dirname(Ganga.Runtime.__file__), 'HEAD_CONFIG.INI'), 'r') as config_head_file:
             new_config += config_head_file.read()
         new_config += config_file_as_text()
-        new_config = new_config.replace('Ganga-SVN', _gangaVersion)
+        new_config = new_config.replace('Ganga-SVN', 'Ganga-'+_gangaVersion.replace('.', '-'))  #Add in Ganga-x-y-z format so that it is backward compatible.
         with open(config_file, 'w') as new_config_file:
             new_config_file.write(new_config)
 
@@ -499,12 +499,10 @@ under certain conditions; type license() for details.
                     this_logger.error('file %s does not seem to be a Ganga config file', self.options.config_file)
                     this_logger.error('try -g option to create valid ~/.gangarc')
                 else:
-                    version = r.group('version')
-                    if version.startswith('Ganga-'): #The version string used to start with 'Ganga-'
-                        cv = r.group('version').split('-')
-                        if cv[1] != '6':
-                            this_logger.error('file %s was created by a development release (%s)', self.options.config_file, r.group('version'))
-                            this_logger.error('try -g option to create valid ~/.gangarc')
+                    cv = r.group('version').split('-')
+                    if cv[1] != '6':
+                        this_logger.error('file %s was created by a development release (%s)', self.options.config_file, r.group('version'))
+                        this_logger.error('try -g option to create valid ~/.gangarc')
         except IOError as x:
             # ignore all I/O errors (e.g. file does not exist), this is just an
             # advisory check

--- a/python/Ganga/Runtime/bootstrap.py
+++ b/python/Ganga/Runtime/bootstrap.py
@@ -43,10 +43,10 @@ def new_version_format_to_old(version):
     Convert from 'x.y.z'-style format to 'Ganga-x-y-z'
 
     Example:
-        >>> new_version_format_to_old('Ganga-6-1-11')
-        '6.1.11'
+        >>> new_version_format_to_old('6.1.11')
+        'Ganga-6-1-11'
     """
-    return 'Ganga-'+version.replace('.', '')
+    return 'Ganga-'+version.replace('.', '-')
 
 # store a path to Ganga libraries
 import Ganga


### PR DESCRIPTION
Due to an mistake on my part when converting the version strings for Git (trying to use 'x.y.z' consistently everywhere rather than 'Ganga-x-y-z') it now breaks to run 6.1.11 and then go back and run 6.0.44 (for example). This is because the new_user_wizard runs and regenerates the config and places:

    # Ganga configuration file ($Name: 6.1.11 $). DO NOT remove this line.

on the first line which, when read by 6.0.44, fails to do a `version.split('-')[1]` on it and crashes.

Since we can't go back and change 6.0.44 etc. we need to make sure the config file from 6.1.12 can be read by earlier versions.

@rob-c did warn me about changing this version code but I thought I'd caught all the issues. However, this one slipped through.