### PR TITLE
Remove unreachable code

### DIFF
--- a/python/Ganga/Core/__init__.py
+++ b/python/Ganga/Core/__init__.py
@@ -124,27 +124,9 @@ Do you want to force the exit (y/[n])? """ % (t_total, len(critical_thread_ids),
 
 
 def should_wait_batch_cb(t_total, critical_thread_ids, non_critical_thread_ids):
-    from Ganga.Core.MonitoringComponent.Local_GangaMC_Service import config
     # if there are critical threads then wait or shutdown depending on
     # configuration
     return True
-    if critical_thread_ids:
-        if t_total < config['forced_shutdown_timeout']:
-            return True
-        else:
-            logger.warning('Shutdown was forced after waiting for %d seconds for background activities to finish\
-(monitoring, output download, etc). This may result in some jobs being corrupted.', t_total)
-            return False
-    # if there are non-critical threads then wait or shutdown depending on
-    # configuration
-    elif non_critical_thread_ids:
-        if t_total < config['forced_shutdown_first_prompt_time']:
-            return True
-        else:
-            return False
-    # if there are no threads then shutdown
-    else:
-        return False
 
 at_exit_should_wait_cb = None
 

--- a/python/Ganga/GPIDev/Lib/Registry/BoxRegistry.py
+++ b/python/Ganga/GPIDev/Lib/Registry/BoxRegistry.py
@@ -204,19 +204,10 @@ class BoxRegistrySlice(RegistrySlice):
 
     def __getitem__(self, id):
         if isinstance(id, str):
-            matches = []
             for o in self.objects:
                 if o._getRegistry()._getName(o) == id:
                     return o
-                    matches.append(o)
-            if len(matches) == 1:
-                return matches[0]
-            elif len(matches) > 1:
-                raise RegistryKeyError(
-                    "Multiple objects with name '%s' found in the box - use IDs!" % id)
-            else:
-                raise RegistryKeyError(
-                    "No object with name '%s' found in the box!" % id)
+            raise RegistryKeyError("No object with name '%s' found in the box!" % id)
         else:
             return super(BoxRegistrySlice, self).__getitem__(id)
 

--- a/python/Ganga/Utility/ColourText.py
+++ b/python/Ganga/Utility/ColourText.py
@@ -194,13 +194,3 @@ def getColour(name):
     """
     x, y = name.split('.')
     return getattr(colour_objects[x], y)
-
-    try:
-        x, y = name.split('.')
-    except Exception:
-        raise ValueError('unknown colour code %s' % str(name))
-
-    try:
-        return getattr(colour_objects[x], y)
-    except Exception:
-        raise ValueError('unknown colour code %s' % str(name))


### PR DESCRIPTION
There's three places where we currently have unreachable code. The first is in `should_wait_batch_cb` where in commit 9b78ad8 the function was made to always return `True`, regardless of anything. Perhaps this was just for testing, I'm not sure. @rob-c, do you remember?

The second is in `BoxRegsitrySlice` where the behaviour of `__getitem__` is such that it will always return the first match, regardless of how many there might have been. `RegistrySlice` however, will raise an warning if there is more than one match. This behaviour has been like this for many years now so I assume it's ok and so I removed the useless error checking.

The third case is trivial and is probably just vestigial.