### PR TITLE
Use Python 2.7

### DIFF
--- a/bin/find-python2.7
+++ b/bin/find-python2.7
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+#Find a valid version of Python and run with it
+#First try the binary named 'python2.7'
+#Then check if 'python' is version 2.7
+#Finally try 'python27' from Software Collections
+if command -v python2.7 >/dev/null 2>&1; then
+    PYTHON="python2.7"
+elif python -c "import sys; exit(0) if sys.version_info[0:2]==(2,7) else exit(1)"; then
+    PYTHON="python"
+elif scl --list | grep -q python27; then
+    PYTHON="scl enable python27 -- python"
+else
+    exit 1
+fi
+
+echo $PYTHON

--- a/bin/ganga
+++ b/bin/ganga
@@ -8,11 +8,10 @@ while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symli
     [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
 done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
-
 BASEDIR=$( dirname "${DIR}" )
 
 #Add the path to the installed externals
-NEW_PYTHONPATH=`PYTHONPATH=$BASEDIR/python $DIR/ganga-external-env.py`
+NEW_PYTHONPATH=`$DIR/ganga-external-env.py $BASEDIR`
 export PYTHONPATH=$NEW_PYTHONPATH${PYTHONPATH:+:}${PYTHONPATH}
 
 if PYTHON=`$DIR/find-python2.7`; then

--- a/bin/ganga
+++ b/bin/ganga
@@ -1,57 +1,31 @@
-#!/usr/bin/env python
+#!/usr/bin/env bash
 
-################################################################################
-# Ganga Project. http://cern.ch/ganga
-#
-# $Id: ganga,v 1.1 2008-07-17 16:40:05 moscicki Exp $
-################################################################################
+#Get the directory where this script is stored
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+    DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
-"""Executable for starting Ganga
+BASEDIR=$( dirname "${DIR}" )
 
-   If a Python script is given as argument then it is executed
-   within the Ganga environment. 
+#Add the path to the installed externals
+NEW_PYTHONPATH=`PYTHONPATH=$BASEDIR/python $DIR/ganga-external-env.py`
+export PYTHONPATH=$NEW_PYTHONPATH${PYTHONPATH:+:}${PYTHONPATH}
 
-   If no argument is given then the Python interpreter is invoked
-   within the Ganga environment"""
-
-# %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-# Perform setup needed for using Ganga Public Interface (GPI)
-# This is a Copy/Paste logic which must stay in THIS file
-
-def standardSetup():
-   """Function to perform standard setup for Ganga.
-   """   
-   import sys, os.path
-
-   # insert the path to Ganga itself
-   exeDir = os.path.abspath(os.path.normpath(os.path.dirname(sys.argv[0])))
-   gangaDir = os.path.join(os.path.dirname(exeDir), 'python' )
-   sys.path.insert(0, gangaDir)
-
-   import Ganga.PACKAGE
-   Ganga.PACKAGE.standardSetup()
-
-standardSetup()
-del standardSetup
-# %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-from Ganga.Core import GangaException
-import sys
-
-try:
-   # Process options given at command line and in configuration file(s)
-   # Perform environment setup and bootstrap
-   import Ganga.Runtime
-   Ganga.Runtime._prog = Ganga.Runtime.GangaProgram()
-   Ganga.Runtime._prog.parseOptions()
-   Ganga.Runtime._prog.configure()
-   Ganga.Runtime._prog.initEnvironment(Ganga.Runtime._prog.options.rexec)
-   Ganga.Runtime._prog.bootstrap(Ganga.Runtime._prog.interactive)
-   Ganga.Runtime._prog.new_user_wizard()
-   # Import GPI and run Ganga
-   from Ganga.GPI import *
-   Ganga.Runtime._prog.run()
-except GangaException,x:
-   Ganga.Runtime._prog.log(x)
-   sys.exit(-1)
-
+#Find a valid version of Python and run with it
+#First try the binary named 'python2.7'
+#Then check if 'python' is version 2.7
+#Finally try 'python27' from Software Collections
+if command -v python2.7 >/dev/null 2>&1; then
+    python2.7 $DIR/ganga.py $@
+elif python -c "import sys; exit(0) if sys.version_info[0:2]==(2,7) else exit(1)"; then
+    python $DIR/ganga.py $@
+elif scl --list | grep -q python27; then
+    scl enable python27 -- python $DIR/ganga.py $@
+else
+    echo 'Cannot find Python 2.7'
+    exit 1
+fi

--- a/bin/ganga
+++ b/bin/ganga
@@ -17,6 +17,5 @@ export PYTHONPATH=$NEW_PYTHONPATH${PYTHONPATH:+:}${PYTHONPATH}
 if PYTHON=`$DIR/find-python2.7`; then
     $PYTHON $DIR/ganga.py $@
 else
-    echo 'Cannot find Python 2.7'
-    exit 1
+    python $DIR/ganga.py $@
 fi

--- a/bin/ganga
+++ b/bin/ganga
@@ -15,16 +15,8 @@ BASEDIR=$( dirname "${DIR}" )
 NEW_PYTHONPATH=`PYTHONPATH=$BASEDIR/python $DIR/ganga-external-env.py`
 export PYTHONPATH=$NEW_PYTHONPATH${PYTHONPATH:+:}${PYTHONPATH}
 
-#Find a valid version of Python and run with it
-#First try the binary named 'python2.7'
-#Then check if 'python' is version 2.7
-#Finally try 'python27' from Software Collections
-if command -v python2.7 >/dev/null 2>&1; then
-    python2.7 $DIR/ganga.py $@
-elif python -c "import sys; exit(0) if sys.version_info[0:2]==(2,7) else exit(1)"; then
-    python $DIR/ganga.py $@
-elif scl --list | grep -q python27; then
-    scl enable python27 -- python $DIR/ganga.py $@
+if PYTHON=`$DIR/find-python2.7`; then
+    $PYTHON $DIR/ganga.py $@
 else
     echo 'Cannot find Python 2.7'
     exit 1

--- a/bin/ganga-env-setup.sh
+++ b/bin/ganga-env-setup.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# TODO: check if everything's there already
+
+# setup the PYTHONPATH from the helper script
+BINDIR=$( dirname "${BASH_SOURCE[0]}" )
+BASEDIR=$( dirname "${BINDIR}" )
+export PYTHONPATH=$PYTHONPATH:$BASEDIR/python
+export PYTHONPATH=$PYTHONPATH:`$BINDIR/ganga-external-env.py`

--- a/bin/ganga-external-env.py
+++ b/bin/ganga-external-env.py
@@ -1,13 +1,20 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # Helper script to return the environment changes required to setup Ganga external packages
 
-# TODO: read config to decide which modules to query
-mod_list = ['Ganga']
+from __future__ import print_function
+
+import sys
+import os
+import os.path
+
+python_path = os.path.join(sys.argv[1], 'python')
+
+sys.path.insert(0, python_path)
 
 # Loop over modules
 syspath_list = []
-for mod in mod_list:
+for mod in ['Ganga', 'GangaAtlas']:#os.listdir(python_path):
 
     # import parent package
     mod_imp = __import__(mod + ".PACKAGE")
@@ -25,8 +32,8 @@ for mod in mod_list:
         try:
             test_imp = __import__(name)
         except:
-            syspath_list.append( path )
+            syspath_list.append(path)
 
 
 # print out the required env line
-print ":".join( syspath_list )
+print(":".join(syspath_list))

--- a/bin/ganga-external-env.py
+++ b/bin/ganga-external-env.py
@@ -1,0 +1,32 @@
+#!/usr/bin/python
+
+# Helper script to return the environment changes required to setup Ganga external packages
+
+# TODO: read config to decide which modules to query
+mod_list = ['Ganga']
+
+# Loop over modules
+syspath_list = []
+for mod in mod_list:
+
+    # import parent package
+    mod_imp = __import__(mod + ".PACKAGE")
+
+    # loop over all the required packages
+    for name in mod_imp.PACKAGE.setup.packages:
+
+        # ASSUME that if we have a syspath, this is a python package and can be imported
+        path = mod_imp.PACKAGE.setup.getPackagePath2(name, 'syspath')
+
+        if not path:
+            continue
+
+        # attempt the import - add the external path if the import fails for any reason
+        try:
+            test_imp = __import__(name)
+        except:
+            syspath_list.append( path )
+
+
+# print out the required env line
+print ":".join( syspath_list )

--- a/bin/ganga.py
+++ b/bin/ganga.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+
+################################################################################
+# Ganga Project. http://cern.ch/ganga
+#
+# $Id: ganga,v 1.1 2008-07-17 16:40:05 moscicki Exp $
+################################################################################
+
+"""Executable for starting Ganga
+
+   If a Python script is given as argument then it is executed
+   within the Ganga environment. 
+
+   If no argument is given then the Python interpreter is invoked
+   within the Ganga environment"""
+
+# %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+# Perform setup needed for using Ganga Public Interface (GPI)
+# This is a Copy/Paste logic which must stay in THIS file
+
+def standardSetup():
+   """Function to perform standard setup for Ganga.
+   """   
+   import sys, os.path
+
+   # insert the path to Ganga itself
+   exeDir = os.path.abspath(os.path.normpath(os.path.dirname(sys.argv[0])))
+   gangaDir = os.path.join(os.path.dirname(exeDir), 'python' )
+   sys.path.insert(0, gangaDir)
+
+   import Ganga.PACKAGE
+   Ganga.PACKAGE.standardSetup()
+
+standardSetup()
+del standardSetup
+# %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+from Ganga.Core import GangaException
+import sys
+
+try:
+   # Process options given at command line and in configuration file(s)
+   # Perform environment setup and bootstrap
+   import Ganga.Runtime
+   Ganga.Runtime._prog = Ganga.Runtime.GangaProgram()
+   Ganga.Runtime._prog.parseOptions()
+   Ganga.Runtime._prog.configure()
+   Ganga.Runtime._prog.initEnvironment(Ganga.Runtime._prog.options.rexec)
+   Ganga.Runtime._prog.bootstrap(Ganga.Runtime._prog.interactive)
+   Ganga.Runtime._prog.new_user_wizard()
+   # Import GPI and run Ganga
+   from Ganga.GPI import *
+   Ganga.Runtime._prog.run()
+except GangaException,x:
+   Ganga.Runtime._prog.log(x)
+   sys.exit(-1)
+

--- a/python/Ganga/Runtime/bootstrap.py
+++ b/python/Ganga/Runtime/bootstrap.py
@@ -105,6 +105,12 @@ if DEBUGFILES or MONITOR_FILES:
             if f not in safeFiles:
                 openfiles[f].close()
 
+if sys.hexversion < 0x020700F0:
+    version = '{0}.{1}'.format(sys.version_info[0], sys.version_info[1])
+    logger.warning('Ganga will soon be depending on Python 2.7. '
+                   'You have Python {version} installed. '
+                   'See https://github.com/ganga-devs/ganga/wiki/Python-2.7'.format(version=version))
+
 
 class GangaProgram(object):
 

--- a/release/tools/ganga-install-externals
+++ b/release/tools/ganga-install-externals
@@ -12,6 +12,7 @@ from __future__ import print_function
 
 import sys
 import os
+import os.path
 import argparse
 
 parser = argparse.ArgumentParser(description="Install Ganga's externals")
@@ -39,8 +40,13 @@ def error(what=None):
 
 def untar(tar_file_name, target_dir):
     print('Extracting {tar} to {dest}'.format(tar=tar_file_name, dest=target_dir))
-    tar_file_name = os.path.join(CONFIG['tarball_dir'], tar_file_name)
-    cmd = 'cd %s; tar xfz %s' % (target_dir, tar_file_name)
+    tar_file_path = os.path.join(CONFIG['tarball_dir'], tar_file_name)
+    if os.path.isfile(tar_file_path):
+        cmd = 'cd %s; tar xfz %s' % (target_dir, tar_file_path)
+    else:
+        remote_file = 'http://ganga.web.cern.ch/ganga/download/' + tar_file_name
+        print('Could not find tarball, downloading from %s' % remote_file)
+        cmd = 'cd %s; curl %s | tar xz' % (target_dir, remote_file)
 
     if os.system(cmd) != 0:
         error('Error untarring file: %s in directory %s' % (tar_file_name, target_dir))


### PR DESCRIPTION
The main change in the pull request is a Bash script which tries to find Python 2.7 on the system and use it if possible. If Python 2.7 is not found, it raises a warning.

The logic for finding Python 2.7 is in `bin/find-python2.7` where it cycles though `python2.7`, `python` and `scl`.

`bin/ganga` is the shell script which uses this to start the (now renamed) `bin/ganga.py` which is unchanged from before.

I've taken (and edited a little) `bin/ganga-external-env.py` from Mark's `feature/python-importing-new` branch which does the work of finding where the externals are located and adds them to the `PYTHON_PATH`.

Finally, in `bootstrap.py` I've added a warning message if the Python version is less than 2.7 to point the user towards [the wiki](/ganga-devs/ganga/wiki/Python-2.7).
