### PR TITLE
Fix initialisation of IPython2 interactive shell

### DIFF
--- a/python/Ganga/Runtime/bootstrap.py
+++ b/python/Ganga/Runtime/bootstrap.py
@@ -1437,7 +1437,7 @@ default_backends = LCG
         ## Check which version of IPython we're running
         ipver = IPython.__version__
         ipver_major = int(ipver[0])
-        if ipver_major > 1:
+        if ipver_major > 2:
             ipshell = InteractiveShellEmbed(argv=args, config=cfg, banner1=banner, exit_msg=exit_msg)
         else:
             ipshell = InteractiveShellEmbed(config=cfg, banner1=banner, exit_msg=exit_msg)


### PR DESCRIPTION
Initialising the IPython InteractiveShellEmbed under IPython 2.3.1(python 2.7.9) complains of unexpected keyword so I bump the compatibility fallback for IPython2

The traceback I see is as below:
```python
Traceback (most recent call last):                                                                                 
  File "bin/ganga", line 64, in <module>                                                                           
    Ganga.Runtime._prog.run()                                                                                      
  File "/home/hep/arichard/git/ganga/python/Ganga/Runtime/bootstrap.py", line 1346, in run                         
    self.launch_IPython(local_ns, args, self._ganga_error_handler, self.ganga_prompt)                              
  File "/home/hep/arichard/git/ganga/python/Ganga/Runtime/bootstrap.py", line 1441, in launch_IPython              
    ipshell = InteractiveShellEmbed(argv=args, config=cfg, banner1=banner, exit_msg=exit_msg)                      
TypeError: __init__() got an unexpected keyword argument 'argv'
```