### PR TITLE
Make sure lock is released in monitoring

### DIFF
--- a/python/Ganga/Core/MonitoringComponent/Local_GangaMC_Service.py
+++ b/python/Ganga/Core/MonitoringComponent/Local_GangaMC_Service.py
@@ -2,6 +2,7 @@ import Queue
 import threading
 import time
 import copy
+from contextlib import contextmanager
 
 from Ganga.Core.GangaThread import GangaThread
 from Ganga.Core.GangaRepository import RegistryKeyError, RegistryLockError
@@ -220,6 +221,29 @@ class _DictEntry(object):
         return self.backendObj, self.jobSet, self.entryLock
 
 
+@contextmanager
+def release_when_done(rlock):
+    '''
+    A ``threading.Lock`` (or ``RLock`` etc.) object cannot be used in a context
+    manager if the lock acquisition is non-blocking because the acquisition can
+    fail and so the contents of the ``with`` block should not be run.
+
+    To allow sensible ``release()`` behaviour in these cases, acquire the lock
+    as usual with ``lock.acquire(False)`` and then wrap the required code with
+    this context manager::
+
+        if lock.acquire(blocking=False):
+            with release_when_done(lock):
+                #some code
+                pass
+
+    Attributes:
+        rlock: A lock object which can have ``release()`` called on it,
+    '''
+    yield rlock
+    rlock.release()
+
+
 class UpdateDict(object):
 
     """
@@ -292,24 +316,20 @@ class UpdateDict(object):
             # Initial value and subsequent resets by timeoutCheck() will set the timeoutCounter
             # to a value just short of the max value to ensure that it the timeoutCounter is
             # not decremented simply because there are no updates occuring.
-            if not entry.entryLock._RLock__count and \
-               entry.timeoutCounter == entry.timeoutCounterMax and \
-               entry.entryLock.acquire(False):
-                log.debug("%s has been reset. Acquired lock to begin countdown." % backend)
-                entry.timeLastUpdate = time.time()
-            # decrease timeout counter
-            if entry.entryLock._is_owned():
-                if entry.timeoutCounter <= 0.0:
-                    entry.timeoutCounter = entry.timeoutCounterMax - 0.01
+            if entry.timeoutCounter == entry.timeoutCounterMax and entry.entryLock.acquire(False):
+                with release_when_done(entry.entryLock):
+                    log.debug("%s has been reset. Acquired lock to begin countdown." % backend)
                     entry.timeLastUpdate = time.time()
-                    entry.entryLock.release()
-                    log.debug("%s backend counter timeout. Resetting to %s." % (backend, entry.timeoutCounter))
-                else:
-                    _l = time.time()
-                    entry.timeoutCounter -= _l - entry.timeLastUpdate
-                    entry.timeLastUpdate = _l
-                    entry.entryLock.release()
-#               log.debug( "%s backend counter is %s." % ( backend, entry.timeoutCounter ) )
+
+                    # decrease timeout counter
+                    if entry.timeoutCounter <= 0.0:
+                        entry.timeoutCounter = entry.timeoutCounterMax - 0.01
+                        entry.timeLastUpdate = time.time()
+                        log.debug("%s backend counter timeout. Resetting to %s." % (backend, entry.timeoutCounter))
+                    else:
+                        _l = time.time()
+                        entry.timeoutCounter -= _l - entry.timeLastUpdate
+                        entry.timeLastUpdate = _l
 
     def isBackendLocked(self, backend):
         if backend in self.table:

--- a/python/Ganga/Core/MonitoringComponent/Local_GangaMC_Service.py
+++ b/python/Ganga/Core/MonitoringComponent/Local_GangaMC_Service.py
@@ -240,8 +240,10 @@ def release_when_done(rlock):
     Attributes:
         rlock: A lock object which can have ``release()`` called on it,
     """
-    yield rlock
-    rlock.release()
+    try:
+        yield rlock
+    finally:
+        rlock.release()
 
 
 class UpdateDict(object):

--- a/python/Ganga/Core/MonitoringComponent/Local_GangaMC_Service.py
+++ b/python/Ganga/Core/MonitoringComponent/Local_GangaMC_Service.py
@@ -129,7 +129,7 @@ class MonitoringWorkerThread(GangaThread):
             try:
                 result = action.function(*action.args, **action.kwargs)
             except Exception as err:
-                logger.debug("_execUpdateAction: %s" % str(err))
+                log.debug("_execUpdateAction: %s" % str(err))
                 action.callback_Failure()
             else:
                 if result in action.success:
@@ -223,7 +223,7 @@ class _DictEntry(object):
 
 @contextmanager
 def release_when_done(rlock):
-    '''
+    """
     A ``threading.Lock`` (or ``RLock`` etc.) object cannot be used in a context
     manager if the lock acquisition is non-blocking because the acquisition can
     fail and so the contents of the ``with`` block should not be run.
@@ -239,7 +239,7 @@ def release_when_done(rlock):
 
     Attributes:
         rlock: A lock object which can have ``release()`` called on it,
-    '''
+    """
     yield rlock
     rlock.release()
 
@@ -1114,7 +1114,7 @@ class JobRegistry_Monitor(GangaThread):
             try:
                 Qin.put(_action)
             except Exception as err:
-                logger.debug("makeCred Err: %s" % str(err))
+                log.debug("makeCred Err: %s" % str(err))
                 cb_Failure("Put _action failure: %s" % str(_action), "unknown", True )
         return credCheckJobInsertor
 
@@ -1149,7 +1149,7 @@ class JobRegistry_Monitor(GangaThread):
         try:
             Qin.put(_action)
         except Exception as err:
-            logger.debug("diskSp Err: %s" % str(err))
+            log.debug("diskSp Err: %s" % str(err))
             cb_Failure()
 
     def updateJobs(self):

--- a/python/Ganga/Core/MonitoringComponent/Local_GangaMC_Service.py
+++ b/python/Ganga/Core/MonitoringComponent/Local_GangaMC_Service.py
@@ -308,6 +308,7 @@ class UpdateDict(object):
                     _l = time.time()
                     entry.timeoutCounter -= _l - entry.timeLastUpdate
                     entry.timeLastUpdate = _l
+                    entry.entryLock.release()
 #               log.debug( "%s backend counter is %s." % ( backend, entry.timeoutCounter ) )
 
     def isBackendLocked(self, backend):


### PR DESCRIPTION
When trying to get the new test system running in non-interactive mode (i.e. no active monitoring loop) I came across a race condition where a thread acquires a lock but never releases it. I wanted to check that this was a bug and not a feature that's malfunctioning elsewhere.

The lock is acquired on line 297 and is released on line 305 in the `if` block. However, in the `else` block it is never released and the function then returns, holding the lock forever.

I'd rather have changed this to a context manager but it's not possible to acquire a non-blocking `RLock` using a context manager.

@alexanderrichards, @rob-c Since you've been looking at the monitoring code before, perhaps you have a better idea?