### PR TITLE
Fix validate method of MassStorageFile to allow resubmission of subjobs

### DIFF
--- a/python/Ganga/GPIDev/Lib/File/MassStorageFile.py
+++ b/python/Ganga/GPIDev/Lib/File/MassStorageFile.py
@@ -359,7 +359,7 @@ class MassStorageFile(IGangaFile):
 
                 isJob = True
 
-                if (self.getJobObject().splitter != None):
+                if self.getJobObject().fqid.find('.') > -1:
 
                     isSplitJob = True
                     searchFor.append('{sjid}')


### PR DESCRIPTION
This issue has been reported on JIRA ([GANGA-2002](https://its.cern.ch/jira/browse/GANGA-2002)).

When calling `resubmit` on a subjob ganga throws the following error if the job has a MassStorageFile associated with it:
```
Ganga.Runtime.bootstrap            : ERROR    JobError: Error in MassStorageFile.outputfilenameformat field :  job is non-split, but {'sjid'} keyword found
```

I've only tested this fix with the `6.1.13` tag as I was unable to start ganga under the `develop` branch on lxplus. Is there any up to date documentation for how to do this?