### PR TITLE
Don't bother checking for attributes we know exist

### DIFF
--- a/python/Ganga/Core/MonitoringComponent/Local_GangaMC_Service.py
+++ b/python/Ganga/Core/MonitoringComponent/Local_GangaMC_Service.py
@@ -961,25 +961,7 @@ class JobRegistry_Monitor(GangaThread):
             try:
                 log.debug("[Update Thread %s] Updating %s with %s." % (currentThread, getName(backendObj), [x.id for x in jobList_fromset]))
                 for j in jobList_fromset:
-
-            	    if hasattr(stripProxy(j), 'getNodeIndexCache') and\
-                        stripProxy(j).getNodeIndexCache() is not None and\
-                        'display:backend' in stripProxy(j).getNodeIndexCache().keys():
-
-                        name = stripProxy(j).getNodeIndexCache()['display:backend']
-                        if name is not None:
-                            import Ganga.GPI
-                            new_backend = eval(str(name)+'()', Ganga.GPI.__dict__)
-                            if hasattr(new_backend, 'setup'):
-                                j.backend.setup()
-                        else:
-                            if hasattr(j, 'backend'):
-                                if hasattr(j.backend, 'setup'):
-                                    j.backend.setup()
-                    else:
-                        if hasattr(j, 'backend'):
-                            if hasattr(j.backend, 'setup'):
-                                j.backend.setup()
+                    j.backend.setup()
 
                 if self.enabled is False and self.alive is False:
                     log.debug("NOT enabled, leaving")

--- a/python/Ganga/GPIDev/Lib/Job/Job.py
+++ b/python/Ganga/GPIDev/Lib/Job/Job.py
@@ -1772,50 +1772,11 @@ class Job(GangaObject):
             # this is used by Remote backend to remove the jobs remotely
             # bug #44256: Job in state "incomplete" is impossible to remove
 
-            if stripProxy(self).getNodeIndexCache() is not None and 'display:backend' in stripProxy(self).getNodeIndexCache().keys():
-                name = stripProxy(self).getNodeIndexCache()['display:backend']
-                if name is not None:
-                    import Ganga.GPI
-                    new_backend = eval(str(name)+'()', Ganga.GPI.__dict__)
-                    if hasattr(new_backend, 'remove'):
-                        self.backend.remove()
-                    del new_backend
-                else:
-                    if hasattr(stripProxy(self.backend), 'remove'):
-                        stripProxy(self.backend.remove())
-            else:
-                if hasattr(stripProxy(self.backend), 'remove'):
-                    stripProxy(self.backend).remove()
+            stripProxy(self.backend).remove()
 
-            if stripProxy(self).getNodeIndexCache() is not None and 'display:application' in stripProxy(self).getNodeIndexCache().keys():
-                name = stripProxy(self).getNodeIndexCache()['display:application']
-                if name is not None:
-                    import Ganga.GPI
-                    new_app = eval(str(name)+'()', Ganga.GPI.__dict__)
-                    if hasattr(new_app, 'transition_update'):
-                        self.application.transition_update("removed")
-                        for sj in self.subjobs:
-                            sj.application.transition_update("removed")
-                    del new_app
-                else:
-                    try:
-                        self.application.transition_update("removed")
-                        for sj in self.subjobs:
-                            sj.application.transition_update("removed")
-                    except AttributeError as err:
-                        logger.debug("AttributeError: %s" % str(err))
-                        # Some applications do not have transition_update
-                        pass
-            else:
-                # tell the application that the job was removed
-                try:
-                    self.application.transition_update("removed")
-                    for sj in self.subjobs:
-                        sj.application.transition_update("removed")
-                except AttributeError as err:
-                    logger.debug("AttributeError: %s" % str(err))
-                    # Some applications do not have transition_update
-                    pass
+            self.application.transition_update("removed")
+            for sj in self.subjobs:
+                sj.application.transition_update("removed")
 
         if self._registry:
             self._registry._remove(self, auto_removed=1)


### PR DESCRIPTION
As discussed in the meeting, I'm not sure we need to check for these things. It's probably best to wait until after 6.1.14 for this just to be safe though.

All `Job`s have a `backend`, all `IBackend`s have a `setup()` and `remove()` method and all `IApplication`s have a `transistion_update()` method.