### PR TITLE
Auto-expanding variables and user tilde for RUNTIME_PATH

### DIFF
--- a/python/Ganga/Runtime/bootstrap.py
+++ b/python/Ganga/Runtime/bootstrap.py
@@ -879,7 +879,10 @@ If ANSI text colours are enabled, then individual colours may be specified like 
             def transform(x):
                 return os.path.normpath(Ganga.Utility.files.expandfilename(os.path.join(GangaRootPath,x)))
 
-            paths = map(transform, filter(lambda x: x, config['RUNTIME_PATH'].split(':')))
+            from os.path import expandvars, expanduser
+
+            paths = map(transform, filter(lambda x: expandvars(expanduser(x)), config['RUNTIME_PATH'].split(':')))
+
 
             for path in paths:
                 r = RuntimePackage(path)


### PR DESCRIPTION
Just a small branch to expand the paths within the RUNTIME_PATH so that user extensions will be loaded correctly without the user having to give the explicit full path to their extension.