### PR TITLE
Bugfix/push session lock to back of thread shutdown

### DIFF
--- a/python/Ganga/Core/GangaRepository/SessionLock.py
+++ b/python/Ganga/Core/GangaRepository/SessionLock.py
@@ -114,7 +114,7 @@ def getGlobalSessionFiles():
 class SessionLockRefresher(GangaThread):
 
     def __init__(self, session_name, sdir, fn, repo, afs):
-        GangaThread.__init__(self, name='SessionLockRefresher', critical=False)
+        GangaThread.__init__(self, name='SessionLockRefresher', critical=True)
         self.session_name = session_name
         self.sdir = sdir
         self.fns = [fn]

--- a/python/Ganga/Core/GangaThread/GangaThreadPool.py
+++ b/python/Ganga/Core/GangaThread/GangaThreadPool.py
@@ -169,9 +169,9 @@ class GangaThreadPool(object):
 
         logger.debug("ExternalTasks still running: %s" % queues.threadStatus())
 
-        logger.debug('Service threads to shutdown: %s' % list(_all_threads))
+        logger.debug('Service threads to shutdown: %s' % ([i for i in reversed(list(_all_threads))]))
 
-        logger.debug('Service threads to shutdown: %s' % list(_all_threads))
+        logger.debug('Service threads to shutdown: %s' % ([i for i in reversed(list(_all_threads))]))
 
         # shutdown each individual threads in the pool
         nonCritThreads = []


### PR DESCRIPTION
This makes sure that the SessionLocks are kept right up until the end of the thread shutdowns.

Maybe this shouldn't be being monitored by the GangaThreads since the Repos (could in principle) rely on this for shutdown.

At least now this is stopped after the Monitoring loop has finished it's work.