### PR TITLE
Bugfix/close stomp threads early

### DIFF
--- a/python/Ganga/Runtime/spyware.py
+++ b/python/Ganga/Runtime/spyware.py
@@ -51,7 +51,10 @@ def ganga_started(session_type, **extended_attributes):
         p.send(msg_config['usage_message_destination'], repr(usage_message), {'persistent': 'true'})
         # ask publisher thread to stop. it will send queued message anyway.
         p.stop()
-
+        p._finalize(10.)
+        if hasattr(p, 'unregister'):
+            p.unregister()
+        del p
 
 def ganga_job_submitted(application_name, backend_name, plain_job, master_job, sub_jobs):
     host = getConfig('System')['GANGA_HOSTNAME']
@@ -78,4 +81,8 @@ def ganga_job_submitted(application_name, backend_name, plain_job, master_job, s
         # p.send('/queue/test.ganga.jobsubmission',repr(job_submitted_message),{'persistent':'true'})
         # ask publisher thread to stop. it will send queued message anyway.
         p.stop()
+        p._finalize(10.)
+        if hasattr(p, 'unregister'):
+            p.unregister()
+        del p
 

--- a/python/Ganga/Utility/stomputil/publisher.py
+++ b/python/Ganga/Utility/stomputil/publisher.py
@@ -131,6 +131,7 @@ def createPublisher(T, server, port, user='', password='', logger=None,
             self.backoff_max = 60
             # queue to hold (message, headers, keyword_headers) tuples
             self._message_queue = Queue()
+            self.__finalized = False
 
         def send(self, destination=None, message='', headers=None, **keyword_headers):
             """Add message to local queue for sending to MSG server.
@@ -301,6 +302,8 @@ def createPublisher(T, server, port, user='', password='', logger=None,
             @param timeout: Maximum seconds to clear message queue on exit.
                     Negative value indicates clear queue without timeout.
             """
+            if self.__finalized is True:
+                return
             self._log(logging.DEBUG, 'Finalizing.')
             finalize_time = 0
             while not self._message_queue.empty() or self.__sending:
@@ -310,6 +313,7 @@ def createPublisher(T, server, port, user='', password='', logger=None,
                 finalize_time += BEAT_TIME
             self._disconnect()
             self._log(logging.DEBUG, 'Finalized after %s second(s). Local message queue size is %s.', finalize_time, self._message_queue.qsize())
+            self.__finalized = True
 
         def _log(self, level, msg, *args, **kwargs):
             """Log message if logger is defined."""


### PR DESCRIPTION
I was observing that the STOMP related communication threads are used once and then left on the GangaThread monitoring list.
This means that in some of my tests I have >100 threads being killed by the shutdown manager and whilst it can cope correctly with shutting down these non-critical threads before the critical ones it creates a lot of noise I'd rather not have hanging around until shutdown.
This kills, shuts-down and deletes the threads once they've done their jobs of sending single messages to the stomp server.