### PR TITLE
Bugfix/minor xml init changes

### DIFF
--- a/python/Ganga/Core/GangaRepository/GangaRepository.py
+++ b/python/Ganga/Core/GangaRepository/GangaRepository.py
@@ -193,13 +193,14 @@ class GangaRepository(object):
         """Internal helper: adds an empty GangaObject of the given class to the repository.
         Raise RepositoryError
         Raise PluginManagerError if the class name is not found"""
-        if (category, classname) not in self._found_classes:
+        compound_name = str(category+"_"+classname)
+        if compound_name not in self._found_classes:
             cls = allPlugins.find(category, classname)
-            self._found_classes[(category, classname)] = cls
-        cls = self._found_classes[(category, classname)]
-        obj = super(cls, cls).__new__(cls)
-        setattr(obj, '_parent', None)
-        obj.__init__()
+            self._found_classes[compound_name] = cls
+        cls = self._found_classes[compound_name]
+        obj = cls()#super(cls, cls).__new__(cls)
+        #setattr(obj, '_parent', None)
+        #obj.__init__()
         obj._proxyObject = None
         obj.setNodeData({})
         obj.setNodeAttribute('id', this_id)

--- a/python/Ganga/Core/GangaRepository/Registry.py
+++ b/python/Ganga/Core/GangaRepository/Registry.py
@@ -587,10 +587,11 @@ class Registry(object):
 
         self._lock.acquire()
         this_id = None
-        returnable = None
+        returnable_id = None
 
         try:
-            returnable = self.__safe_add(obj, force_index)
+            returnable_id = self.__safe_add(obj, force_index)
+            self._loaded_ids.append(returnable_id)
         except (RepositoryError) as err:
             raise err
         except Exception as err:
@@ -609,7 +610,7 @@ class Registry(object):
 
         self._updateIndexCache(obj)
 
-        return returnable
+        return returnable_id
 
     def _remove(self, obj, auto_removed=0):
         """ Private method removing the obj from the registry. This method always called.
@@ -892,7 +893,7 @@ class Registry(object):
             try:
                 if this_id in self.dirty_objs.keys() and self.checkShouldFlush():
                     self._flush([self._objects[this_id]])
-                    self._load([this_id])
+                    #self._load([this_id])
                     #self._updateIndexCache(self._objects[this_id])
                 if this_id not in self._loaded_ids:
                     self._load([this_id])
@@ -987,7 +988,7 @@ class Registry(object):
                     try:
                         if this_id in self.dirty_objs.keys() and self.checkShouldFlush():
                             self._flush([self._objects[this_id]])
-                            self._load([this_id])
+                            #self._load([this_id])
                         if this_id not in self._loaded_ids:
                             self._load([this_id])
                             self._loaded_ids.append(this_id)


### PR DESCRIPTION
This reduces the amount of object loading that happens which is not required.

The workflow of flushing an object then reloading it from disk doesn't offer any real benefit over flushing the object to disk and then continuing with other work and in some scenarios causes some real slow down to occur.
Fixes #84

This also adds an object to the list of 'already loaded' objects in the Registry which should prevent the first call to getReadAccess or getWriteAccess from possibly losing some data if an object has incorrectly NOT been labelled as _dirty.
(When in doubt an object should rely on the methods in Core for deciding if it's become dirty or not and shouldn't be subverting this)
Possibly effects #96