### PR TITLE
Fix atlas task import after config

### DIFF
--- a/python/GangaAtlas/Lib/Tasks/AnaTask.py
+++ b/python/GangaAtlas/Lib/Tasks/AnaTask.py
@@ -2,6 +2,8 @@ from Ganga.GPIDev.Lib.Tasks.common import *
 from Ganga.GPIDev.Lib.Tasks import Task
 from AnaTransform import AnaTransform
 from Ganga.GPIDev.Schema import *
+from Ganga.Utility.ColourText import ANSIMarkup
+markup = ANSIMarkup()
 
 from Ganga.Core.exceptions import ApplicationConfigurationError
 

--- a/python/GangaAtlas/Lib/Tasks/AnaTask.py
+++ b/python/GangaAtlas/Lib/Tasks/AnaTask.py
@@ -2,8 +2,10 @@ from Ganga.GPIDev.Lib.Tasks.common import *
 from Ganga.GPIDev.Lib.Tasks import Task
 from AnaTransform import AnaTransform
 from Ganga.GPIDev.Schema import *
-from Ganga.Utility.ColourText import ANSIMarkup
+from Ganga.Utility.ColourText import ANSIMarkup, fgcol, Effects
 markup = ANSIMarkup()
+fx = Effects()
+
 
 from Ganga.Core.exceptions import ApplicationConfigurationError
 

--- a/python/GangaAtlas/Lib/Tasks/MCTask.py
+++ b/python/GangaAtlas/Lib/Tasks/MCTask.py
@@ -3,6 +3,8 @@ from Ganga.GPIDev.Lib.Tasks import Task
 from MCTransforms import EvgenTransform, SimulTransform, ReconTransform
 from GangaAtlas.Lib.AthenaMC.AthenaMCDatasets import AthenaMCInputDatasets
 from Ganga.GPIDev.Schema import *
+from Ganga.Utility.ColourText import ANSIMarkup
+markup = ANSIMarkup()
 
 from Ganga.GPIDev.Base.Objects import Node
 

--- a/python/GangaAtlas/Lib/Tasks/MCTask.py
+++ b/python/GangaAtlas/Lib/Tasks/MCTask.py
@@ -3,8 +3,10 @@ from Ganga.GPIDev.Lib.Tasks import Task
 from MCTransforms import EvgenTransform, SimulTransform, ReconTransform
 from GangaAtlas.Lib.AthenaMC.AthenaMCDatasets import AthenaMCInputDatasets
 from Ganga.GPIDev.Schema import *
-from Ganga.Utility.ColourText import ANSIMarkup
+from Ganga.Utility.ColourText import ANSIMarkup, fgcol, Effects
 markup = ANSIMarkup()
+fx = Effects()
+
 
 from Ganga.GPIDev.Base.Objects import Node
 

--- a/python/GangaAtlas/Lib/Tasks/MCTransforms.py
+++ b/python/GangaAtlas/Lib/Tasks/MCTransforms.py
@@ -5,7 +5,8 @@ from Ganga.GPIDev.Lib.Tasks import Transform
 from TaskApplication import AthenaMCTask
 from GangaAtlas.Lib.AthenaMC.AthenaMCDatasets import AthenaMCOutputDatasets, AthenaMCInputDatasets, _usertag
 from Ganga.GPIDev.Schema import *
-from Ganga.Utility.ColourText import overview_colours, status_colours
+from Ganga.Utility.ColourText import overview_colours, status_colours, ANSIMarkup
+markup = ANSIMarkup()
 
 # Extract username from certificate
 from Ganga.GPIDev.Credentials import GridProxy

--- a/python/GangaAtlas/Lib/Tasks/MCTransforms.py
+++ b/python/GangaAtlas/Lib/Tasks/MCTransforms.py
@@ -5,6 +5,7 @@ from Ganga.GPIDev.Lib.Tasks import Transform
 from TaskApplication import AthenaMCTask
 from GangaAtlas.Lib.AthenaMC.AthenaMCDatasets import AthenaMCOutputDatasets, AthenaMCInputDatasets, _usertag
 from Ganga.GPIDev.Schema import *
+from Ganga.Utility.ColourText import overview_colours, status_colours
 
 # Extract username from certificate
 from Ganga.GPIDev.Credentials import GridProxy

--- a/python/GangaAtlas/Lib/Tasks/MultiTask.py
+++ b/python/GangaAtlas/Lib/Tasks/MultiTask.py
@@ -2,6 +2,7 @@ from GangaAtlas.Lib.ATLASDataset.DQ2Dataset import DQ2Dataset
 from Ganga.GPIDev.Lib.Tasks.common import *
 from Ganga.GPIDev.Lib.Tasks import Task
 from MultiTransform import MultiTransform
+from Ganga.Utility.ColourText import overview_colours, fgcol
 
 from Ganga.Core.exceptions import ApplicationConfigurationError
 from GangaAtlas.Lib.ATLASDataset.DQ2Dataset import dq2_lock, dq2

--- a/python/GangaAtlas/Lib/Tasks/MultiTask.py
+++ b/python/GangaAtlas/Lib/Tasks/MultiTask.py
@@ -2,7 +2,8 @@ from GangaAtlas.Lib.ATLASDataset.DQ2Dataset import DQ2Dataset
 from Ganga.GPIDev.Lib.Tasks.common import *
 from Ganga.GPIDev.Lib.Tasks import Task
 from MultiTransform import MultiTransform
-from Ganga.Utility.ColourText import overview_colours, fgcol
+from Ganga.Utility.ColourText import overview_colours, ANSIMarkup
+markup = ANSIMarkup()
 
 from Ganga.Core.exceptions import ApplicationConfigurationError
 from GangaAtlas.Lib.ATLASDataset.DQ2Dataset import dq2_lock, dq2

--- a/python/GangaAtlas/Lib/Tasks/MultiTask.py
+++ b/python/GangaAtlas/Lib/Tasks/MultiTask.py
@@ -2,8 +2,9 @@ from GangaAtlas.Lib.ATLASDataset.DQ2Dataset import DQ2Dataset
 from Ganga.GPIDev.Lib.Tasks.common import *
 from Ganga.GPIDev.Lib.Tasks import Task
 from MultiTransform import MultiTransform
-from Ganga.Utility.ColourText import overview_colours, ANSIMarkup
+from Ganga.Utility.ColourText import overview_colours, ANSIMarkup, fgcol, Effects
 markup = ANSIMarkup()
+fx = Effects()
 
 from Ganga.Core.exceptions import ApplicationConfigurationError
 from GangaAtlas.Lib.ATLASDataset.DQ2Dataset import dq2_lock, dq2

--- a/python/GangaAtlas/Lib/Tasks/MultiTransform.py
+++ b/python/GangaAtlas/Lib/Tasks/MultiTransform.py
@@ -6,6 +6,7 @@ from TaskApplication import AthenaTask, AnaTaskSplitterJob
 from GangaAtlas.Lib.ATLASDataset.ATLASDataset import ATLASLocalDataset,ATLASOutputDataset
 from GangaAtlas.Lib.Athena.Athena import AthenaSplitterJob
 from Ganga.GPIDev.Lib.Registry.JobRegistry import JobRegistrySlice, JobRegistrySliceProxy
+from Ganga.Utility.ColourText import overview_colours
 
 from dq2.clientapi.DQ2 import DQ2, DQUnknownDatasetException, DQDatasetExistsException, DQFileExistsInDatasetException, DQInvalidRequestException
 from dq2.container.exceptions import DQContainerAlreadyHasDataset, DQContainerDoesNotHaveDataset


### PR DESCRIPTION
Fixes #103. Note that all these files can really be removed in the long term as they are obsolete.