### PR TITLE
Simplify logging in file utilities

### DIFF
--- a/python/Ganga/Utility/files.py
+++ b/python/Ganga/Utility/files.py
@@ -8,42 +8,28 @@
 Helper functions for operations on files.
 """
 
-## BE AWARE THIS IS LOADING Ganga.Utility.logging NOT python logging!! - rcurrie
-import logging
 import os.path
-import stat
 import Ganga
+from Ganga.Utility.logging import getLogger
 
 def expandfilename(filename, force=False):
-    "expand a path or filename in a standard way so that it may contain ~ and ${VAR} strings"
+    """expand a path or filename in a standard way so that it may contain ~ and ${VAR} strings"""
     expanded_path = os.path.expandvars(os.path.expanduser(filename))
     if os.path.exists(expanded_path) or force:
         return expanded_path
-    else:
-        from Ganga.Utility.logging import getLogger
-        logger = getLogger()
-        if logger.isEnabledFor(logging.DEBUG):
-            logger.warning("Filename: %s doesn't exist using it anyway" % filename)
-            import traceback
-            traceback.print_stack()
-        return filename
-    #return os.path.expandvars(os.path.expanduser(filename))
+
+    getLogger().debug("Filename: %s doesn't exist using it anyway" % filename)
+    return filename
 
 
 def fullpath(path, force=False):
-    "expandfilename() and additionally: strip leading and trailing whitespaces and expand symbolic links"
+    """expandfilename() and additionally: strip leading and trailing whitespaces and expand symbolic links"""
     full_path = os.path.realpath(expandfilename(path.strip(), True))
     if os.path.exists(full_path) or force:
         return full_path
-    else:
-        from Ganga.Utility.logging import getLogger
-        logger = getLogger()
-        if logger.isEnabledFor(logging.DEBUG):
-            logger.warning("path: %s doesn't exist using it anyway" % path)
-            import traceback
-            traceback.print_stack()
-        return path
-    #return os.path.realpath(expandfilename(path.strip()))
+
+    getLogger().debug("path: %s doesn't exist using it anyway" % path)
+    return path
 
 
 def previous_dir(path, cnt):


### PR DESCRIPTION
logging.DEBUG does not exist in our logging module and so this was causing
an exception. It wasn't really needed anyway so it has been removed from
here.

Without this, doing
```python
File('x')
```
would crash on latest `develop`.