### PR TITLE
Bugfix/fixing fqid bug/Subjobs not having Parent knowledge bug

### DIFF
--- a/python/Ganga/Core/GangaRepository/GangaRepositoryXML.py
+++ b/python/Ganga/Core/GangaRepository/GangaRepositoryXML.py
@@ -315,7 +315,7 @@ class GangaRepositoryLocal(GangaRepository):
             setattr(self.objects[this_id], '_registry_refresh', True)
             return True
         else:
-            logger.debug("Error, doubly loading of object with ID: %s" % this_id)
+            logger.debug("Doubly loading of object with ID: %s" % this_id)
             logger.debug("Just silently continuing")
         return False
 
@@ -486,7 +486,6 @@ class GangaRepositoryLocal(GangaRepository):
         locked_ids = self.sessionlock.locked
 
         for this_id in objs.keys():
-        #for this_id, idx in objs.iteritems():
             deleted_ids.discard(this_id)
             # Make sure we do not overwrite older jobs if someone deleted the
             # count file
@@ -512,9 +511,6 @@ class GangaRepositoryLocal(GangaRepository):
                 # will fail as well
                 summary.append((this_id, err))
                 continue
-
-            # print this_id
-            # print self.objects
 
             # this is bad - no or corrupted index but object not loaded yet!
             # Try to load it!

--- a/python/Ganga/Core/GangaRepository/Registry.py
+++ b/python/Ganga/Core/GangaRepository/Registry.py
@@ -395,8 +395,8 @@ class Registry(object):
                 self._update_index_timer = time.time()
 
             return sorted(self._objects.keys())
-        except Exception as err:
-            pass
+        #except Exception as err:
+        #    pass
         finally:
             self._lock.release()
 
@@ -421,8 +421,8 @@ class Registry(object):
                 self._update_index_timer = time.time()
 
             return sorted(self._objects.items())
-        except Exception as err:
-            pass
+        #except Exception as err:
+        #    pass
         finally:
             self._lock.release()
 

--- a/python/Ganga/GPIDev/Lib/Job/Job.py
+++ b/python/Ganga/GPIDev/Lib/Job/Job.py
@@ -1002,22 +1002,16 @@ class Job(GangaObject):
         else:
             return None
 
-        try:
-            if stripProxy(self).master is not None:
-                cur = stripProxy(self).master  # FIXME: or use master attribute?
-            else:
-                cur = None
-        except AssertionError:
+        if stripProxy(self).master is not None:
+            cur = stripProxy(self).master  # FIXME: or use master attribute?
+        else:
             cur = None
 
         while cur is not None:
             fqid.append(cur.id)
-            try:
-                if stripProxy(cur).master is not None:
-                    cur = stripProxy(cur).master
-                else:
-                    cur = None
-            except AssertionError:
+            if stripProxy(cur).master is not None:
+                cur = stripProxy(cur).master
+            else:
                 cur = None
         fqid.reverse()
 


### PR DESCRIPTION
Hi all,

After removing the extra load statements from the Registry commands I discovered an odd bug in the Jobs class which took a short while to solve.

When a Job containing subjobs was read from disk all of the information and parent knowledge was setup correctly for the objects created based upon the XML.

However, I discovered that once the subjobs are allocated within the Job class they have no immediate knowledge of their parent until the job is re-loaded from disk.

I've made a generic fix now such that when a subjob is added to job.subjobs the knowledge of the parent job is preserved. Hopefully this should prevent the strange oddities I was seeing from creeping up again.


This problem has only come to light now as the flushing is correctly delayed until the job is marked 'dirty enough'.

This primarily required some fixes to the Job and GangaList classes to maintain the parent knowledge.

Thanks,

Rob