### PR TITLE
Fix the GoogleFile Client

### DIFF
--- a/python/Ganga/GPIDev/Lib/File/GoogleFile.py
+++ b/python/Ganga/GPIDev/Lib/File/GoogleFile.py
@@ -79,9 +79,10 @@ class GoogleFile(IGangaFile):
             from oauth2client.client import OAuth2WebServerFlow
 
             # Copy your credentials from the APIs Console
-            CLIENT_ID = "54459939297.apps.googleusercontent.com"
-            CLIENT_SECRET = "mAToHx5RpXtwkeYR6nOIe_Yw"
-
+#            CLIENT_ID = "54459939297.apps.googleusercontent.com"
+#            CLIENT_SECRET = "mAToHx5RpXtwkeYR6nOIe_Yw"
+            CLIENT_ID = '776655306197-dirtoquqsm7cpqgepvamofg5t2b5f637.apps.googleusercontent.com'
+            CLIENT_SECRET = 'GpdEP-OBZZQLB3k-xxOpzFQG'
             # Check https://developers.google.com/drive/scopes for all
             # available scopes
             OAUTH_SCOPE = 'https://www.googleapis.com/auth/drive.file'


### PR DESCRIPTION
The GoogleFile Client ganga developer account didn't have the Drive API enabled. Clearly something at Google has changed as it used to work and therefore must have had it enabled at some point. Since I don't remember the password anymore to this account I have generated a drive enabled API credential against my work gmail account and used the credential in this fix to get things working again. Ultimately we should re-do the credential with the ganga developer account.