### PR TITLE
Bugfix/lazy loading improvements

### DIFF
--- a/python/Ganga/Core/GangaRepository/Registry.py
+++ b/python/Ganga/Core/GangaRepository/Registry.py
@@ -233,10 +233,10 @@ class Registry(object):
                 this_obj = self._objects[this_id]
             found_id = None
             if hasattr(this_obj, 'id'):
-                logger.debug("Found ID: %s" % this_obj.id)
+                #logger.debug("Found ID: %s" % this_obj.id)
                 found_id = this_obj.id
             if hasattr(this_obj, '_registry_id'):
-                logger.debug("Found RegID: %s" % this_obj._registry_id)
+                #logger.debug("Found RegID: %s" % this_obj._registry_id)
                 found_id = this_obj._registry_id
             if found_id is not None and real_id is not None:
                 assert( found_id == real_id )
@@ -316,7 +316,7 @@ class Registry(object):
 
                  self.dirty_objs = {}
     
-            time.sleep(3.)
+            time.sleep(0.5)
 
     def turnOffAutoFlushing(self):
         self._autoFlush = False

--- a/python/Ganga/Core/GangaRepository/VStreamer.py
+++ b/python/Ganga/Core/GangaRepository/VStreamer.py
@@ -215,7 +215,7 @@ class VStreamer(object):
                 print(self.indent(), '<value>%s</value>' % escape(repr(s)), file=self.out)
             elif hasattr(stripProxy(s), 'accept'):
                 stripProxy(s).accept(self)
-            elif isType(s, list) or isType(s, GangaList):
+            elif isType(s, (list, tuple, GangaList)):
                 print(self.indent(), '<sequence>', file=self.out)
                 for sub_s in s:
                     self.acceptOptional(sub_s)

--- a/python/Ganga/GPIDev/Lib/GangaList/GangaList.py
+++ b/python/Ganga/GPIDev/Lib/GangaList/GangaList.py
@@ -38,11 +38,6 @@ def makeGangaList(_list, mapfunction=None, parent=None, preparable=False):
     if parent is not None:
         result._setParent(parent)
 
-        for r in result:
-            bare_r = stripProxy(r)
-            if isType(bare_r, GangaObject) and bare_r._getParent() is None:
-                bare_r._setParent(parent)
-
     return result
 
 
@@ -57,6 +52,8 @@ def stripGangaList(_list):
 def makeGangaListByRef(_list):
     """Faster version of makeGangaList. Does not make a copy of _list but use it by reference."""
     result = GangaList()
+    if len(_list) == 0:
+        return result
     temp_list = [stripProxy(element) for element in _list]
     result._list = temp_list
     result._is_a_ref = True

--- a/python/Ganga/GPIDev/Lib/Job/Job.py
+++ b/python/Ganga/GPIDev/Lib/Job/Job.py
@@ -47,6 +47,32 @@ import Ganga.Core.Sandbox as Sandbox
 logger = Ganga.Utility.logging.getLogger()
 config = Ganga.Utility.Config.getConfig('Configuration')
 
+def lazyLoadJobStatus(this_job):
+    return lazyLoadJobObject(this_job, 'status')
+
+def lazyLoadJobBackend(this_job):
+    return lazyLoadJobObject(this_job, 'backend')
+
+def lazyLoadJobApplication(this_job):
+    return lazyLoadJobObject(this_job, 'application')
+
+def lazyLoadJobObject(this_job, this_attr):
+
+    lzy_loading_str = 'display:'+ this_attr
+    job_index_cache = stripProxy(this_job).getNodeIndexCache()
+    if isinstance(job_index_cache, dict) and lzy_loading_str in job_index_cache.keys():
+        obj_name = job_index_cache[lzy_loading_str]
+        if obj_name is not None:
+            job_obj = getRuntimeGPIObject(obj_name, True)
+            if job_obj is None:
+                job_obj = getattr(this_job, this_attr)
+        else:
+            job_obj = getattr(this_job, this_attr)
+
+    else:
+        job_obj = getattr(this_job, this_attr)
+
+    return job_obj
 
 class JobStatusError(GangaException):
 
@@ -1811,51 +1837,26 @@ class Job(GangaObject):
             # this is used by Remote backend to remove the jobs remotely
             # bug #44256: Job in state "incomplete" is impossible to remove
 
-            lzy_loading_backend_str = 'display:backend'
-            lzy_loading_application_str = 'display:application'
+            backend_obj = lazyLoadJobBackend(self)
+            application_obj = lazyLoadJobApplication(self)
 
-            if stripProxy(self).getNodeIndexCache() is not None and lzy_loading_backend_str in stripProxy(self).getNodeIndexCache().keys():
-                name = stripProxy(self).getNodeIndexCache()[lzy_loading_backend_str]
-                if name is not None:
-                    new_backend = getRuntimeGPIObject(name)
-                    if hasattr(new_backend, 'remove'):
-                        self.backend.remove()
-                    del new_backend
-                else:
-                    if hasattr(stripProxy(self.backend), 'remove'):
-                        stripProxy(self.backend.remove())
+            if backend_obj is not None:
+                if hasattr(backend_obj, 'remove'):
+                    stripProxy(self.backend).remove()
             else:
-                if hasattr(stripProxy(self.backend), 'remove'):
+                if hasattr(self.backend, 'remove'):
                     stripProxy(self.backend).remove()
 
-            if stripProxy(self).getNodeIndexCache() is not None and lzy_loading_application_str in stripProxy(self).getNodeIndexCache().keys():
-                name = stripProxy(self).getNodeIndexCache()[lzy_loading_application_str]
-                if name is not None:
-                    new_app = getRuntimeGPIObject(name)
-                    if hasattr(new_app, 'transition_update'):
-                        self.application.transition_update("removed")
-                        for sj in self.subjobs:
-                            sj.application.transition_update("removed")
-                    del new_app
-                else:
-                    try:
-                        self.application.transition_update("removed")
-                        for sj in self.subjobs:
-                            sj.application.transition_update("removed")
-                    except AttributeError as err:
-                        logger.debug("AttributeError: %s" % str(err))
-                        # Some applications do not have transition_update
-                        pass
-            else:
-                # tell the application that the job was removed
-                try:
-                    self.application.transition_update("removed")
+            if application_obj is not None:
+                if hasattr(application_obj, 'transition_update'):
+                    stripProxy(self.application).transition_update('removed')
                     for sj in self.subjobs:
-                        sj.application.transition_update("removed")
-                except AttributeError as err:
-                    logger.debug("AttributeError: %s" % str(err))
-                    # Some applications do not have transition_update
-                    pass
+                        stripProxy(sj.application).transition_update('removed')
+            else:
+                stripProxy(self.application).transition_update('removed')
+                for sj in self.subjobs:
+                    stripProxy(sj.application).transition_update('removed')
+
 
         if self._registry:
             self._registry._remove(self, auto_removed=1)

--- a/python/Ganga/GPIDev/Lib/Registry/BoxRegistry.py
+++ b/python/Ganga/GPIDev/Lib/Registry/BoxRegistry.py
@@ -188,9 +188,8 @@ class BoxRegistrySlice(RegistrySlice):
         self._proxyClass = BoxRegistrySliceProxy
 
     def _getColour(self, _obj):
-        obj = stripProxy(_obj)
         try:
-            return self.status_colours.get(obj._category, self.fx.normal)
+            return self.status_colours.get(stripProxy(_obj)._category, self.fx.normal)
         except AttributeError as err:
             return self.status_colours['default']
 

--- a/python/Ganga/GPIDev/Lib/Registry/TransientRegistry.py
+++ b/python/Ganga/GPIDev/Lib/Registry/TransientRegistry.py
@@ -72,7 +72,10 @@ class TransientRegistrySlice(RegistrySlice):
         self._proxyClass = TransientRegistrySliceProxy
 
     def _getColour(self, obj):
-        return self.status_colours.get(obj._name, self.fx.normal)
+        try:
+            return self.status_colours.get(getName(obj), self.fx.normal)
+        except Exception as err:
+            return self.status_colours['default']
 
     def __call__(self, id):
         """


### PR DESCRIPTION
This branch includes some helper functions which have been implemented in Job.py
These are called:

```
lazyLoadingJobApplication
lazyLoadingJobBackend
lazyLoadingJobStatus
```

These functions will return an object which is of the same type as that within the job which is being inspected.
This object is not guaranteed to have the same attributes (where applicable) as the Job object of interest. In order to get access to this info calling ```job.application``` or ```job.backend``` explicitly is required.

These functions greatly simplify the task of requesting an object without triggering the full loading of a job because the information of interest is in the node ```_index_cache```.

I've also put in a lot of modifications into the SubJobXMLList class and RegistrySlice such that calling:
```
jobs(x).subjobs
```
Doesn't result in loading a job from disk as the information is available in the job index.


Additionally I've added some minor changes to the code in the IBackend which delays the loading of a subjob until just before the job is requesting to be monitored which speeds up the monitoring loop as it avoids loading a large job with many subjobs before monitoring potentially a small number of the subjobs.

Thanks,

Rob