### PR TITLE
Bugfix/utilchanges/fixes

### DIFF
--- a/python/Ganga/Utility/Shell.py
+++ b/python/Ganga/Utility/Shell.py
@@ -67,7 +67,11 @@ def expand_vars(env):
 class Shell(object):
 
     def __init__(self, setup=None, setup_args=[]):
-        """The setup script is sourced (with possible arguments) and the
+        """
+
+        THIS EXPECTS THE BASH SHELL TO AT LEAST BE AVAILABLE TO RUN THESE COMMANDS!
+
+        The setup script is sourced (with possible arguments) and the
         environment is captured. The environment variables are expanded
         automatically (this is a fix for bug #44259: GangaLHCb tests fail due to
         gridProxy check).
@@ -104,20 +108,18 @@ class Shell(object):
             logger.debug("Using CWD: %s" % this_cwd)
             command = 'source %s %s > /dev/null 2>&1; python -c "from __future__ import print_function; import os; print(os.environ)"' % (setup, " ".join(setup_args))
             logger.debug('Running:   %s' % command )
-            pipe = subprocess.Popen(command, env=env, cwd=this_cwd, shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
-            output = pipe.communicate()
+            pipe = subprocess.Popen('bash', env=env, cwd=this_cwd, shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+            output = pipe.communicate(command)
             rc = pipe.poll()
             if rc:
                 logger.warning('Unexpected rc %d from setup command %s', rc, setup)
 
-            # print output
-            # print eval(str(output)[0])
             try:
                 env2 = expand_vars(eval(eval(str(output))[0]))
             except Exception as err:
                 logger.debug("Err: %s" % str(err))
                 env2 = None
-                logger.error("Cannot construct environ:\n%s" % str(output)[0])
+                logger.error("Cannot construct environ:\n%s" % str(output))
                 try:
                     logger.error("eval: %s" % str(eval(str(output)[0])))
                 except Exception as err2:

--- a/python/Ganga/Utility/util.py
+++ b/python/Ganga/Utility/util.py
@@ -159,31 +159,6 @@ def hostname():
 # ------------------------
 
 
-class Borg(object):
-
-    """
-    *Python Cookbook recipe 6.16*
-    Borg implementation
-    """
-    _shared_state = {}
-
-    def __new__(cls, *args, **kw):
-        obj = object.__new__(cls, *args, **kw)
-        obj.__dict__ = cls._shared_state
-        return obj
-
-    def __eq__(self, other):
-        try:
-            return self.__dict__ is other.__dict__
-        except AttributeError:
-            return False
-
-    def __hash__(self):
-        return 0
-
-# ------------------------
-
-
 def setAttributesFromDict(d, prefix=None):
     """
     *Python Cookbook recipe 6.18*


### PR DESCRIPTION
This branch contains minor changes which are just within the Utility folder which addresses a bug I saw on startup for Python 2.6 systems.

This would just return an error on a feature which isn't used there but the Shall now correctly determines the env to be used to execute future tasks

This didn't turn on up for LHCb users due to another reason (probably related to issues addressed elsewhere)
I now see this error for LHCb in my private branch so I've fixed this.