### PR TITLE
Fix to expend environment variables in RUNTIME_PATH.

### DIFF
--- a/python/Ganga/Runtime/bootstrap.py
+++ b/python/Ganga/Runtime/bootstrap.py
@@ -766,10 +766,9 @@ under certain conditions; type license() for details.
 
             GangaRootPath = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe()))), '../..'))
             def transform(x):
-                return os.path.normpath(Ganga.Utility.files.expandfilename(
-                        os.path.join(GangaRootPath, expandvars(x))))
+                return os.path.normpath(Ganga.Utility.files.expandfilename(os.path.join(GangaRootPath,x)))
 
-            paths = map(transform, filter(lambda x: expandvars(expanduser(x)), config['RUNTIME_PATH'].split(':')))
+            paths = map(transform, filter(None, map(lambda x: expandvars(expanduser(x)), config['RUNTIME_PATH'].split(':'))))
 
             for path in paths:
                 r = RuntimePackage(path)

--- a/python/Ganga/Runtime/bootstrap.py
+++ b/python/Ganga/Runtime/bootstrap.py
@@ -762,14 +762,14 @@ under certain conditions; type license() for details.
 
             
             import inspect
-            GangaRootPath = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe()))), '../..'))
-            def transform(x):
-                return os.path.normpath(Ganga.Utility.files.expandfilename(os.path.join(GangaRootPath,x)))
-
             from os.path import expandvars, expanduser
 
-            paths = map(transform, filter(lambda x: expandvars(expanduser(x)), config['RUNTIME_PATH'].split(':')))
+            GangaRootPath = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe()))), '../..'))
+            def transform(x):
+                return os.path.normpath(Ganga.Utility.files.expandfilename(
+                        os.path.join(GangaRootPath, expandvars(x))))
 
+            paths = map(transform, filter(lambda x: expandvars(expanduser(x)), config['RUNTIME_PATH'].split(':')))
 
             for path in paths:
                 r = RuntimePackage(path)


### PR DESCRIPTION
Previously environment variables were not expanded, resulting in the GangaRootPath being prepended to paths beginning with an environment variable.