### PR TITLE
hacks to get outputfiles and sandboxes working

### DIFF
--- a/python/Ganga/Core/Sandbox/Sandbox.py
+++ b/python/Ganga/Core/Sandbox/Sandbox.py
@@ -33,9 +33,11 @@ def getGangaModulesAsSandboxFiles(modules):
     import inspect
     import sys
     from Ganga.Utility.files import remove_prefix
-    from Ganga.GPIDev.Lib.File import File
+    from Ganga.GPIDev.Lib.File import File, FileBuffer
 
     files = []
+    # HACK: append an empty __init__.py file for the Ganga base directory
+    files.append(FileBuffer("__init__.py", "", subdir=os.path.join(PYTHON_DIR, 'Ganga')))
     for m in modules:
         fullpath = os.path.realpath(inspect.getsourcefile(m))
         dir, fn = os.path.split(remove_prefix(fullpath, sys.path))

--- a/python/Ganga/Core/Sandbox/WNSandbox.py
+++ b/python/Ganga/Core/Sandbox/WNSandbox.py
@@ -37,7 +37,7 @@ def createOutputSandbox(output_patterns, filter, dest_dir):
 
     try:
         from Ganga.Utility.files import multi_glob, recursive_copy
-    except IOError as e:
+    except (IOError, ImportError) as e:
         import sys
 
         print("Failed to import files")
@@ -64,7 +64,7 @@ def createOutputSandbox(output_patterns, filter, dest_dir):
         try:
             from Ganga.Utility.files import multi_glob, recursive_copy
             print("Success!")
-        except IOError as e:
+        except (IOError, ImportError) as e:
             print("Fail!")
             raise e
 
@@ -89,7 +89,7 @@ def createPackedOutputSandbox(output_patterns, filter, dest_dir):
 
     try:
         from Ganga.Utility.files import multi_glob, recursive_copy
-    except IOError as e:
+    except (IOError, ImportError) as e:
         import sys
 
         print("Failed to import files")
@@ -116,7 +116,7 @@ def createPackedOutputSandbox(output_patterns, filter, dest_dir):
         try:
             from Ganga.Utility.files import multi_glob, recursive_copy
             print("Success!")
-        except IOError as e:
+        except (IOError, ImportError) as e:
             print("Fail!")
             raise e
 

--- a/python/Ganga/Utility/files.py
+++ b/python/Ganga/Utility/files.py
@@ -12,7 +12,7 @@ import os.path
 import Ganga
 try:
     from Ganga.Utility.logging import getLogger
-except IOError as e:
+except ImportError as e:
     # Running on a backend
     getLogger = None
 

--- a/python/Ganga/Utility/files.py
+++ b/python/Ganga/Utility/files.py
@@ -10,7 +10,11 @@ Helper functions for operations on files.
 
 import os.path
 import Ganga
-from Ganga.Utility.logging import getLogger
+try:
+    from Ganga.Utility.logging import getLogger
+except IOError as e:
+    # Running on a backend
+    getLogger = None
 
 def expandfilename(filename, force=False):
     """expand a path or filename in a standard way so that it may contain ~ and ${VAR} strings"""
@@ -18,7 +22,8 @@ def expandfilename(filename, force=False):
     if os.path.exists(expanded_path) or force:
         return expanded_path
 
-    getLogger().debug("Filename: %s doesn't exist using it anyway" % filename)
+    if getLogger:
+        getLogger().debug("Filename: %s doesn't exist using it anyway" % filename)
     return filename
 
 
@@ -28,7 +33,8 @@ def fullpath(path, force=False):
     if os.path.exists(full_path) or force:
         return full_path
 
-    getLogger().debug("path: %s doesn't exist using it anyway" % path)
+    if getLogger:
+        getLogger().debug("path: %s doesn't exist using it anyway" % path)
     return path
 
 


### PR DESCRIPTION
This fixes #125 , but it's not the most elegant.  Maybe it's worth breaking any ganga code shipped to a backend in the _python directory into standalone modules with no imports lurking within?