### PR TITLE
Don't overwrite the existing documentation for a proxied GangaObject

### DIFF
--- a/python/Ganga/GPIDev/Base/Proxy.py
+++ b/python/Ganga/GPIDev/Base/Proxy.py
@@ -690,8 +690,6 @@ def GPIProxyClassFactory(name, pluginclass):
 
     publicdoc = pluginclass.__doc__ + itbuf.getString()
 
-    helptext(pluginclass, 'This is a Ganga.GPI.%(classname)s implementation class. Refer to Ganga.GPI.%(classname)s.__doc__ for documentation.')
-
     helptext(_init, """GPI %(classname)s object constructor:
     %(classname)s() : create %(objname)s with default settings;
     %(classname)s(%(shortvarname)s) : make a copy of %(shortvarname)s;


### PR DESCRIPTION
Currently, when a `GangaObject` is proxy-wrapped, its `__doc__` attribute is reset to a generic string pointing the reader towards the proxy object. In the process of auto-generating API and GPI docs, this is getting in the way.

Does anyone have a objection to removing this? I don't see that it adds any value.