### PR TITLE
Simplify descriptor get

### DIFF
--- a/python/Ganga/GPIDev/Base/Objects.py
+++ b/python/Ganga/GPIDev/Base/Objects.py
@@ -415,10 +415,6 @@ class Descriptor(object):
         if name in obj.getNodeData():
             return obj.getNodeAttribute(name)
 
-        # If this object doesn't exist and the object has been loaded then let's look around
-        if name in obj.__dict__:
-            return obj.__dict__[name]
-
         # Finally, get the default value from the schema
         if obj._schema.hasItem(name):
             return obj._schema.getDefaultValue(name)

--- a/python/Ganga/GPIDev/Base/Objects.py
+++ b/python/Ganga/GPIDev/Base/Objects.py
@@ -367,17 +367,9 @@ class Descriptor(object):
         self._checkset_name = None
         self._filter_name = None
 
-        if not hasattr( item, '_meta'):
-            return
-
-        if 'getter' in item._meta:
-            self._getter_name = item['getter']
-
-        if 'checkset' in item._meta:
-            self._checkset_name = item['checkset']
-
-        if 'filter' in item._meta:
-            self._filter_name = item['filter']
+        self._getter_name = item['getter']
+        self._checkset_name = item['checkset']
+        self._filter_name = item['filter']
 
     @staticmethod
     def _bind_method(obj, name):

--- a/python/Ganga/GPIDev/Base/Objects.py
+++ b/python/Ganga/GPIDev/Base/Objects.py
@@ -391,6 +391,8 @@ class Descriptor(object):
         if self._getter_name:
             return self._bind_method(obj, self._getter_name)()
 
+        # First we want to try to get the information without prompting a load from disk
+
         # ._data takes priority ALWAYS over ._index_cache
         # This access should not cause the object to be loaded
         obj_data = obj.getNodeData()
@@ -403,6 +405,8 @@ class Descriptor(object):
         if obj_index is not None:
             if name in obj_index:
                 return obj_index[name]
+
+        # Since we couldn't find the information in the cache, we will need to fully load the object
 
         # Guarantee that the object is now loaded from disk
         obj._getReadAccess()


### PR DESCRIPTION
This is a cleanup exercise in `Descriptor.__get__`. The code before was overly nested as well as calling lots of functions it did not need to. The logic in these functions should be clean and easy to follow and hopefully this is getting there now.

I've noticed some speed-ups in XML loading with this as well.