### PR TITLE
Cleanup ObjectMetaclass

### DIFF
--- a/python/Ganga/GPIDev/Base/Objects.py
+++ b/python/Ganga/GPIDev/Base/Objects.py
@@ -686,15 +686,8 @@ class ObjectMetaclass(type):
 
         super(ObjectMetaclass, cls).__init__(name, bases, this_dict)
 
-        # ignore the 'abstract' base class
-        # FIXME: this mechanism should be based on explicit getName(cls) or alike
-        #if name == 'GangaObject':
-        #    return
-
-        #logger.debug("Metaclass.__init__: class %s name %s bases %s", cls, name, bases)
-
         # all Ganga classes must have (even empty) schema
-        if not hasattr(cls, '_schema') or cls._schema is None:
+        if cls._schema is None:
             cls._schema = Schema.Schema(None, None)
 
         this_schema = cls._schema
@@ -732,9 +725,6 @@ class ObjectMetaclass(type):
         # create reference in schema to the pluginclass
         this_schema._pluginclass = cls
 
-        # store generated proxy class
-        setattr(cls, '_proxyClass', proxyClass)
-
         # register plugin class
         if hasattr(cls, '_declared_property'):
             # if we've not even declared this we don't want to use it!
@@ -744,6 +734,9 @@ class ObjectMetaclass(type):
             # create a configuration unit for default values of object properties
             if not cls._declared_property('hidden') or cls._declared_property('enable_config'):
                 this_schema.createDefaultConfig()
+
+        # store generated proxy class
+        setattr(cls, '_proxyClass', GPIProxyClassFactory(name, cls))
 
 
 

--- a/python/Ganga/GPIDev/Base/Objects.py
+++ b/python/Ganga/GPIDev/Base/Objects.py
@@ -15,7 +15,6 @@
 
 import Ganga.Utility.logging
 
-import types
 from copy import deepcopy
 import inspect
 
@@ -39,16 +38,6 @@ def _getGangaList():
         from Ganga.GPIDev.Lib.GangaList.GangaList import GangaList
         _imported_GangaList = GangaList
     return _imported_GangaList
-
-
-class PreparedStateError(GangaException):
-
-    def __init__(self, txt=''):
-        GangaException.__init__(self, txt)
-        self.txt = txt
-
-    def __str__(self):
-        return "PreparedStateError: %s" % str(self.txt)
 
 
 class Node(object):

--- a/python/Ganga/GPIDev/Base/Objects.py
+++ b/python/Ganga/GPIDev/Base/Objects.py
@@ -676,13 +676,6 @@ class Descriptor(object):
 
         return
 
-def export(method):
-    """
-    Decorate a GangaObject method to be exported to the GPI
-    """
-    method.exported_method = True
-    return method
-
 
 class ObjectMetaclass(type):
     _descriptor = Descriptor

--- a/python/Ganga/GPIDev/Base/Proxy.py
+++ b/python/Ganga/GPIDev/Base/Proxy.py
@@ -207,6 +207,14 @@ def runProxyMethod(obj, method_name, *args):
     fp = getProxyAttr(obj, method_name)
     return fp(*args)
 
+
+def export(method):
+    """
+    Decorate a GangaObject method to be exported to the GPI
+    """
+    method.exported = True
+    return method
+
 # apply object conversion or if it fails, strip the proxy and extract the
 # object implementation
 

--- a/python/Ganga/GPIDev/Base/__init__.py
+++ b/python/Ganga/GPIDev/Base/__init__.py
@@ -2,6 +2,6 @@
 Definition of GPI base objects and proxies.
 """
 
-from Ganga.GPIDev.Base.Objects import GangaObject, export
+from Ganga.GPIDev.Base.Objects import GangaObject
 from Ganga.Core.exceptions import GangaException
 from Ganga.GPIDev.Base.Proxy import GangaAttributeError, ProtectedAttributeError, ReadOnlyObjectError

--- a/python/Ganga/GPIDev/Lib/Job/Job.py
+++ b/python/Ganga/GPIDev/Lib/Job/Job.py
@@ -91,16 +91,6 @@ class JobError(GangaException):
         return "JobError: %s" % str(self.what)
 
 
-class PreparedStateError(GangaException):
-
-    def __init__(self, txt=''):
-        GangaException.__init__(self, txt)
-        self.txt = txt
-
-    def __str__(self):
-        return "PreparedStateError: %s" % str(self.txt)
-
-
 class FakeError(GangaException):
 
     def __init__(self):

--- a/python/Ganga/GPIDev/Lib/Job/__init__.py
+++ b/python/Ganga/GPIDev/Lib/Job/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import absolute_import
 from .MetadataDict import MetadataDict
-from .Job import JobInfo, Job, JobStatusError, JobError, PreparedStateError
+from .Job import JobInfo, Job, JobStatusError, JobError

--- a/python/Ganga/new_tests/TestGangaObject.py
+++ b/python/Ganga/new_tests/TestGangaObject.py
@@ -121,3 +121,8 @@ class TestObjectMetaclass(TestCase):
         class GangaObject(Node):
             __metaclass__ = ObjectMetaclass
             _schema = None
+            _category = None
+
+            @classmethod
+            def _declared_property(cls, name):
+                pass


### PR DESCRIPTION
Mostly this is just moving some code from `ObjectMetaclass.__init__` into `GPIProxyClassFactory` since it is only relevant to proxies.