### PR TITLE
Fix splitter

### DIFF
--- a/python/Ganga/GPIDev/Adapters/IBackend.py
+++ b/python/Ganga/GPIDev/Adapters/IBackend.py
@@ -484,7 +484,7 @@ class IBackend(GangaObject):
                     try:
                         subjobs_to_monitor = []
                         for sj_id in this_block:
-                            subjobs_to_monitor.append(j.subjobs(sj_id))
+                            subjobs_to_monitor.append(j.subjobs[sj_id])
                         stripProxy(j.backend).updateMonitoringInformation(subjobs_to_monitor)
                     except Exception as err:
                         logger.error("Monitoring Error: %s" % str(err))

--- a/python/Ganga/GPIDev/Adapters/IBackend.py
+++ b/python/Ganga/GPIDev/Adapters/IBackend.py
@@ -452,7 +452,7 @@ class IBackend(GangaObject):
                 else:
                     for sj in j.subjobs:
                         if sj.status in ['submitted', 'running']:
-                            monitorable_subjob_ids.append(sj_id)
+                            monitorable_subjob_ids.append(sj.id)
 
                 #logger.info('Monitoring subjobs: %s', str(monitorable_subjob_ids)
 

--- a/python/Ganga/new_tests/GPI/TestArgSplitter.py
+++ b/python/Ganga/new_tests/GPI/TestArgSplitter.py
@@ -1,0 +1,17 @@
+from __future__ import absolute_import
+
+from .GangaUnitTest import GangaUnitTest
+
+
+class TestArgSplitter(GangaUnitTest):
+    def TestArgSplitter(self):
+        from Ganga.GPI import Job, ArgSplitter
+        from GangaTest.Framework.utils import sleep_until_completed
+
+        j = Job()
+        j.splitter = ArgSplitter(args=[['1'], ['2'], ['3']])
+        j.submit()
+
+        self.assertTrue(sleep_until_completed(j, 60), 'Timeout on completing job')
+
+        self.assertEqual(len(j.subjobs), 3)


### PR DESCRIPTION
Running a simple job like seen in TestArgSplitter.py was failing with errors. This fixes them.

@rob-c The only question I have is that `j.subjobs` is a `GangaList` by line 487; I forget if that is expected at this point?