### PR TITLE
Add support for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"
+  - "3.4"
+  - "3.5"
+install: pip install -r requirements.txt
+script: python setup.py tests --type=unit

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,8 @@ python:
 #  - "3.4"
 #  - "3.5"
 install: pip install -r requirements.txt
-script: python setup.py tests --type=unit
+script: python setup.py tests --type=unit --coverage
+before_install:
+  - pip install codecov
+after_success:
+  - codecov --root python

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - "2.6"
   - "2.7"
-  - "3.4"
-  - "3.5"
+#  - "3.4"
+#  - "3.5"
 install: pip install -r requirements.txt
 script: python setup.py tests --type=unit

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ script: python setup.py tests --type=unit --coverage
 before_install:
   - pip install codecov
 after_success:
-  - codecov --root python
+  - cd python && codecov

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@
 
 nose
 unittest2
+coverage

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+# This first line will grab the requirements from setup.py
+-e .
+
+nose
+unittest2


### PR DESCRIPTION
This adds support for running the unit tests on Travis CI which can be seen at https://travis-ci.org/ganga-devs/ganga. This gives us a secondary source of testing on a different system (Travis uses Ubuntu) which reduces the chance of faulty assumptions.

It will only run the unit tests (and maybe in future full GPI tests where limited to `Local`/`Executable`) but its better than nothing. There is a chance of using it in future to test running on OS X too.

I've also just added support for code coverage reporting using [Codecov](https://codecov.io). It's only based on the unit tests but it can supplement any other coverage reporting we have.