### PR TITLE
Cleanup/move proxy stuff into proxy

### DIFF
--- a/doc/dev/index.rst
+++ b/doc/dev/index.rst
@@ -40,13 +40,11 @@ Attributes on proxy objects
 
 Proxy classes and the object that they are proxying have a set number of attributes which should be present.
 
-If a ``GangaObject`` class has been registered as being proxyable then it will have the property ``_proxyclass`` set on it which will point to the relevant :class:`~.GPIProxyObject` subclass.
+If an object inherits from ``GangaObject`` the class can have the property ``_proxyClass`` set which will point to the relevant :class:`~.GPIProxyObject` subclass. This is created on demand in the ``addProxy`` and ``GPIProxyObjectFactory`` methods.
 The proxy class (which is a subclass of ``GPIProxyObject`` and created using :func:`~.GPIProxyClassFactory`) will have the attribute `_impl` set to be the relevant ``GangaObject`` subclass.
 
 When an instance of a proxy class is created, the `_impl` attribute of the instance will point to the instance of the ``GangaObject`` that is being proxied.
-This ``GangaObject`` instance will have an attribute ``_proxyObject`` which points back to the proxy.
 
-Simply making an instance of a proxyable ``GangaObject`` class will not automatically create a proxy object though and so will not have ``_proxyObject`` present.
 
 Repository
 ----------

--- a/python/Ganga/Core/GangaRepository/Registry.py
+++ b/python/Ganga/Core/GangaRepository/Registry.py
@@ -209,7 +209,11 @@ class Registry(object):
         while this_id in self._inprogressDict.keys():
             logger.debug("Getting item being operated on: %s" % this_id)
             logger.debug("Currently in state: %s" % self._inprogressDict[this_id])
-            time.sleep(0.05)
+            #import traceback
+            #traceback.print_stack()
+            #import sys
+            #sys.exit(-1)
+            #time.sleep(0.05)
         self._inprogressDict[this_id] = action
         if this_id not in self.hard_lock.keys():
             self.hard_lock[this_id] = threading.Lock()
@@ -652,7 +656,7 @@ class Registry(object):
         logger.debug("_reg_remove")
         u_id = self.find(obj)
 
-        obj_id = id(self.find(obj))
+        obj_id = id(obj)
 
         self.lock_transaction(obj_id, "_remove")
 
@@ -792,7 +796,8 @@ class Registry(object):
         Raise RegistryAccessError
         Raise RegistryKeyError"""
         logger.debug("_read_access")
-        if id(_obj) in self._accessLockDict.keys():
+        obj_id = id(stripProxy(_obj))
+        if obj_id in self._inprogressDict.keys() or obj_id in self._accessLockDict.keys():
             return
         else:
             self._accessLockDict[id(_obj)] = _obj
@@ -886,7 +891,7 @@ class Registry(object):
         logger.debug("_write_access")
         obj = stripProxy(_obj)
         obj_id = id(_obj)
-        if obj_id in self._accessLockDict.keys():
+        if obj_id in self._inprogressDict.keys() or obj_id in self._accessLockDict.keys():
             return
         else:
             self._accessLockDict[obj_id] = obj
@@ -907,7 +912,7 @@ class Registry(object):
         logger.debug("__write_acess")
         obj = stripProxy(_obj)
 
-        if self.find(obj) in self._inprogressDict.keys():
+        if id(obj) in self._inprogressDict.keys():
             this_id = self.find(obj)
             for this_d in self.changed_ids.itervalues():
                 this_d.add(this_id)

--- a/python/Ganga/Core/GangaRepository/SubJobXMLList.py
+++ b/python/Ganga/Core/GangaRepository/SubJobXMLList.py
@@ -232,7 +232,10 @@ class SubJobXMLList(GangaObject):
     def __len__(self):
         """ return length or lookup the last modified time compare against self._stored_len[0] and if nothings changed return self._stored_len[1]"""
         import os
-        this_time = os.stat(self._jobDirectory).st_ctime
+        try:
+            this_time = os.stat(self._jobDirectory).st_ctime
+        except OSError:
+            return 0
 
         if len(self._stored_len) == 2:
             last_time = self._stored_len[0]

--- a/python/Ganga/GPIDev/Base/Objects.py
+++ b/python/Ganga/GPIDev/Base/Objects.py
@@ -37,7 +37,7 @@ logger = Ganga.Utility.logging.getLogger(modulename=1)
 
 _imported_GangaList = None
 
-do_not_copy = ['_index_cache', '_parent', '_registry']
+do_not_copy = ['_index_cache', '_parent', '_registry', '_data']
 
 def _getGangaList():
     global _imported_GangaList
@@ -829,9 +829,10 @@ class GangaObject(Node):
 
         self_copy = cls()
 
+        global do_not_copy
         if self._schema is not None:
             for name, item in self._schema.allItems():
-                if not item['copyable']:
+                if not item['copyable'] or name in do_not_copy:
                     setattr(self_copy, name, self._schema.getDefaultValue(name))
                 else:
                     if hasattr(self, name):
@@ -846,10 +847,12 @@ class GangaObject(Node):
                 if item.isA(Schema.SharedItem):
                     self.__incrementShareRef(self_copy, name)
 
-        global do_not_copy
         for k, v in self.__dict__.iteritems():
             if k not in do_not_copy:
-                setattr(self_copy, k, deepcopy(v))
+                try:
+                    self_copy.__dict__[k] = deepcopy(v)
+                except:
+                    self_copy.__dict__[k] = v
 
         if true_parent is not None:
             self._setParent(true_parent)

--- a/python/Ganga/GPIDev/Base/Objects.py
+++ b/python/Ganga/GPIDev/Base/Objects.py
@@ -30,7 +30,7 @@ logger = Ganga.Utility.logging.getLogger(modulename=1)
 
 _imported_GangaList = None
 
-do_not_copy = ['_proxyObject', '_data', '_index_cache', '_parent', '_registry']
+do_not_copy = ['_index_cache', '_parent', '_registry']
 
 def _getGangaList():
     global _imported_GangaList
@@ -710,9 +710,6 @@ class ObjectMetaclass(type):
         if not cls._declared_property('hidden') or cls._declared_property('enable_config'):
             this_schema.createDefaultConfig()
 
-        # store generated proxy class
-        setattr(cls, '_proxyClass', GPIProxyClassFactory(name, cls))
-
 
 class GangaObject(Node):
     __metaclass__ = ObjectMetaclass
@@ -736,14 +733,12 @@ class GangaObject(Node):
     # _enable_config = 1 -> allow generation of [default_X] configuration
     # section with schema properties
 
-    # the constructor is directly used by the GPI proxy so the GangaObject
     # must be fully initialized
     def __init__(self):
         super(GangaObject, self).__init__(None)
 
         # IMPORTANT: if you add instance attributes like in the line below
         # make sure to update the __getstate__ method as well
-        # use cache to help preserve proxy objects identity in GPI
         # dirty flag is true if the object has been modified locally and its
         # contents is out-of-sync with its repository
         self._dirty = False

--- a/python/Ganga/GPIDev/Base/Objects.py
+++ b/python/Ganga/GPIDev/Base/Objects.py
@@ -20,11 +20,17 @@ import inspect
 
 import Ganga.GPIDev.Schema as Schema
 
-from Ganga.GPIDev.Base.Proxy import getName
 from Ganga.Core.exceptions import GangaValueError, GangaException
 
 from Ganga.Utility.Plugin import allPlugins
 
+def _getName(obj):
+    returnable = getattr(obj, '_name', getattr(obj, '__name__', None))
+    if returnable is None:
+        returnable = getattr(getattr(obj, '__class__', None), '__name__', None)
+    if returnable is None:
+        returnable = str(obj)
+    return returnable
 
 logger = Ganga.Utility.logging.getLogger(modulename=1)
 
@@ -187,7 +193,7 @@ class Node(object):
             raise GangaValueError("Can't copyFrom a non-class object: %s isclass: %s" % (str(_srcobj), str(inspect.isclass(_srcobj))))
 
         if not isinstance(self, _srcobj.__class__) and not isinstance(_srcobj, self.__class__):
-            raise GangaValueError("copyFrom: Cannot copy from %s to %s!" % (getName(_srcobj), getName(self)))
+            raise GangaValueError("copyFrom: Cannot copy from %s to %s!" % (_getName(_srcobj), _getName(self)))
 
         if not hasattr(self, '_schema'):
             logger.debug("No Schema found for myself")
@@ -224,7 +230,7 @@ class Node(object):
                     _app.incrementShareCounter(_app.is_prepared.name)
 
             if not self._schema.hasAttribute(name):
-                #raise ValueError('copyFrom: incompatible schema: source=%s destination=%s'%(getName(_srcobj),getName(self)))
+                #raise ValueError('copyFrom: incompatible schema: source=%s destination=%s'%(_getName(_srcobj), _getName(self)))
                 if not hasattr(self, name):
                     setattr(self, name, self._schema.getDefaultValue(name))
                 this_attr = getattr(self, name)
@@ -289,9 +295,9 @@ class Node(object):
         # Check each schema item in turn and check for equality
         for (name, item) in self._schema.allItems():
             if item['comparable'] == True:
-                #logger.info("testing: %s::%s" % (str(getName(self)), str(name)))
+                #logger.info("testing: %s::%s" % (str(_getName(self)), str(name)))
                 if getattr(self, name) != getattr(node, name):
-                    #logger.info( "diff: %s::%s" % (str(getName(self)), str(name)))
+                    #logger.info( "diff: %s::%s" % (str(_getName(self)), str(name)))
                     return 0
 
         return 1
@@ -355,10 +361,10 @@ class Descriptor(object):
 
     def _check_getter(self):
         if self._getter_name:
-            raise AttributeError('cannot modify or delete "%s" property (declared as "getter")' % getName(self))
+            raise AttributeError('cannot modify or delete "%s" property (declared as "getter")' % _getName(self))
 
     def __get__(self, obj, cls):
-        name = getName(self)
+        name = _getName(self)
 
         # If obj is None then the getter was called on the class so return the Item
         if obj is None:
@@ -399,7 +405,7 @@ class Descriptor(object):
 
     def __cloneVal(self, v, obj):
 
-        item = obj._schema[getName(self)]
+        item = obj._schema[_getName(self)]
 
         if v is None:
             if item.hasProperty('category'):
@@ -408,7 +414,7 @@ class Descriptor(object):
                 assertion = item['optional']
             #assert(assertion)
             if assertion is False:
-                logger.warning("Item: '%s'. of class type: '%s'. Has a Default value of 'None' but is NOT optional!!!" % (getName(self), type(obj)))
+                logger.warning("Item: '%s'. of class type: '%s'. Has a Default value of 'None' but is NOT optional!!!" % (_getName(self), type(obj)))
                 logger.warning("Please contact the developers and make sure this is updated!")
             return None
         elif isinstance(v, str):
@@ -448,7 +454,7 @@ class Descriptor(object):
     def __copyNodeObject(self, v, obj):
         """This deals with the actual deepcopy of an object which has inherited from Node class"""
 
-        item = obj._schema[getName(self)]
+        item = obj._schema[_getName(self)]
         GangaList = _getGangaList()
         if isinstance(v, GangaList):
             categories = v.getCategory()
@@ -456,11 +462,11 @@ class Descriptor(object):
             if (len_cat > 1) or ((len_cat == 1) and (categories[0] != item['category'])) and item['category'] != 'internal':
                 # we pass on empty lists, as the catagory is yet to be defined
                 from Ganga.GPIDev.Base.Proxy import GangaAttributeError
-                raise GangaAttributeError('%s: attempt to assign a list containing incompatible objects %s to the property in category "%s"' % (getName(self), v, item['category']))
+                raise GangaAttributeError('%s: attempt to assign a list containing incompatible objects %s to the property in category "%s"' % (_getName(self), v, item['category']))
         else:
             if v._category not in [item['category'], 'internal'] and item['category'] != 'internal':
                 from Ganga.GPIDev.Base.Proxy import GangaAttributeError
-                raise GangaAttributeError('%s: attempt to assign an incompatible object %s to the property in category "%s found cat: %s"' % (getName(self), v, item['category'], v._category))
+                raise GangaAttributeError('%s: attempt to assign an incompatible object %s to the property in category "%s found cat: %s"' % (_getName(self), v, item['category'], v._category))
 
 
         v_copy = deepcopy(v)
@@ -471,7 +477,7 @@ class Descriptor(object):
         return v_copy
 
     def __set__(self, _obj, _val):
-        ## self: attribute being changed or Ganga.GPIDev.Base.Objects.Descriptor in which case getName(self) gives the name of the attribute being changed
+        ## self: attribute being changed or Ganga.GPIDev.Base.Objects.Descriptor in which case _getName(self) gives the name of the attribute being changed
         ## _obj: parent class which 'owns' the attribute
         ## _val: value of the attribute which we're about to set
 
@@ -497,7 +503,7 @@ class Descriptor(object):
 
         if type(_val) is str:
             from Ganga.GPIDev.Base.Proxy import stripProxy, runtimeEvalString
-            new_val = stripProxy(runtimeEvalString(_obj, getName(self), _val))
+            new_val = stripProxy(runtimeEvalString(_obj, _getName(self), _val))
         else:
             new_val = _val
 
@@ -515,14 +521,14 @@ class Descriptor(object):
                 obj_reg.turnOnAutoFlushing()
 
     def __atomic_set__(self, _obj, _val):
-        ## self: attribute being changed or Ganga.GPIDev.Base.Objects.Descriptor in which case getName(self) gives the name of the attribute being changed
+        ## self: attribute being changed or Ganga.GPIDev.Base.Objects.Descriptor in which case _getName(self) gives the name of the attribute being changed
         ## _obj: parent class which 'owns' the attribute
         ## _val: value of the attribute which we're about to set
 
-        #if hasattr(_obj, getName(self)):
-        #    if not isinstance(getattr(_obj, getName(self)), GangaObject):
-        #        if type( getattr(_obj, getName(self)) ) == type(_val):
-        #            object.__setattr__(_obj, getName(self), deepcopy(_val))
+        #if hasattr(_obj, _getName(self)):
+        #    if not isinstance(getattr(_obj, _getName(self)), GangaObject):
+        #        if type( getattr(_obj, _getName(self)) ) == type(_val):
+        #            object.__setattr__(_obj, _getName(self), deepcopy(_val))
         #            return
 #
 #        if not isinstance(_obj, GangaObject) and type(_obj) == type(_val):
@@ -552,7 +558,7 @@ class Descriptor(object):
 
         #self._check_getter()
 
-        item = obj._schema[getName(self)]
+        item = obj._schema[_getName(self)]
 
         def cloneVal(v):
             GangaList = _getGangaList()
@@ -600,12 +606,12 @@ class Descriptor(object):
         if isinstance(new_val, Node):
             new_val._setParent(obj)
 
-        obj.setNodeAttribute(getName(self), new_val)
+        obj.setNodeAttribute(_getName(self), new_val)
 
         obj._setDirty()
 
     def __delete__(self, obj):
-        obj.removeNodeAttribute(getName(self))
+        obj.removeNodeAttribute(_getName(self))
 
     @staticmethod
     def __createNewList(final_list, input_elements, action=None):
@@ -658,8 +664,6 @@ class ObjectMetaclass(type):
 
     def __init__(cls, name, bases, this_dict):
 
-        from Ganga.GPIDev.Base.Proxy import GPIProxyClassFactory
-
         super(ObjectMetaclass, cls).__init__(name, bases, this_dict)
 
         # all Ganga classes must have (even empty) schema
@@ -686,7 +690,7 @@ class ObjectMetaclass(type):
             cls._name = name
 
         if this_schema._pluginclass is not None:
-            logger.warning('Possible schema clash in class %s between %s and %s', name, getName(cls), getName(this_schema._pluginclass))
+            logger.warning('Possible schema clash in class %s between %s and %s', name, _getName(cls), _getName(this_schema._pluginclass))
 
         # export visible properties... do not export hidden properties
         for attr, item in this_schema.allItems():
@@ -704,7 +708,7 @@ class ObjectMetaclass(type):
 
         # if we've not even declared this we don't want to use it!
         if not cls._declared_property('hidden') or cls._declared_property('enable_plugin'):
-            allPlugins.add(cls, cls._category, getName(cls))
+            allPlugins.add(cls, cls._category, _getName(cls))
 
         # create a configuration unit for default values of object properties
         if not cls._declared_property('hidden') or cls._declared_property('enable_config'):
@@ -816,7 +820,7 @@ class GangaObject(Node):
         true_parent = self._getParent()
         ## This triggers a read of the job from disk
         self._getReadAccess()
-        classname = getName(self)
+        classname = _getName(self)
         category = self._category
         cls = self.__class__#allPlugins.find(category, classname)
 

--- a/python/Ganga/GPIDev/Base/Objects.py
+++ b/python/Ganga/GPIDev/Base/Objects.py
@@ -25,6 +25,7 @@ from Ganga.Core.exceptions import GangaValueError, GangaException
 from Ganga.Utility.Plugin import allPlugins
 
 def _getName(obj):
+    """ Return the name of an object based on what we prioritise"""
     returnable = getattr(obj, '_name', getattr(obj, '__name__', None))
     if returnable is None:
         returnable = getattr(getattr(obj, '__class__', None), '__name__', None)

--- a/python/Ganga/GPIDev/Base/Proxy.py
+++ b/python/Ganga/GPIDev/Base/Proxy.py
@@ -554,7 +554,8 @@ class ProxyMethodDescriptor(object):
 # helper to create a wrapper for an existing ganga object
 
 def addProxyClass(some_class):
-    class_name = getName(some_class)
+    ## CANNOT USE THE ._name (hence getName) HERE DUE TO REQUIREMENTS OF THE OBJECT IN GPI BEING SANE!!!
+    class_name = some_class.__name__
     setattr(some_class, proxyClass, GPIProxyClassFactory(class_name, some_class))
 
 def getProxyClass(some_class):

--- a/python/Ganga/GPIDev/Base/Proxy.py
+++ b/python/Ganga/GPIDev/Base/Proxy.py
@@ -10,7 +10,7 @@ from Ganga.Utility.Config import getConfig
 
 from Ganga.GPIDev.Schema import ComponentItem
 
-from Ganga.GPIDev.Base.Objects import GangaObject, ObjectMetaclass, _getName
+from Ganga.GPIDev.Base.Objects import Node, GangaObject, ObjectMetaclass, _getName
 from Ganga.Core import GangaAttributeError, ProtectedAttributeError, ReadOnlyObjectError, TypeMismatchError
 
 import os
@@ -196,7 +196,6 @@ def stripProxy(obj):
 
 def addProxy(obj):
     """Adds a proxy to a GangaObject"""
-    from Ganga.GPIDev.Base.Objects import GangaObject
     if isType(obj, GangaObject) and not isProxy(obj):
         return GPIProxyObjectFactory(obj)
     return obj
@@ -225,8 +224,6 @@ def export(method):
 
 
 def stripComponentObject(v, cfilter, item):
-
-    from Ganga.GPIDev.Base import GangaObject
 
     def getImpl(v):
         if v is None:
@@ -260,7 +257,6 @@ class ProxyDataDescriptor(object):
     def disguiseComponentObject(self, v):
         # get the proxy for implementation object
         def getProxy(v):
-            from Ganga.GPIDev.Base import GangaObject
             if not isType(v, GangaObject):
                 raise GangaAttributeError("invalid type: cannot assign '%s' to attribute '%s'" % (repr(v), getName(self)))
             return GPIProxyObjectFactory(v)
@@ -338,7 +334,7 @@ class ProxyDataDescriptor(object):
         # print '**** checking',v,v.__class__,
         # isinstance(val,GPIProxyObject)
         if isinstance(v, list):
-            from Ganga.GPI import GangaList
+            from Ganga.GPIDev.Lib.GangaList.GangaList import GangaList
             v_new = GangaList()
             for elem in v:
                 v_new.append(elem)
@@ -404,8 +400,8 @@ class ProxyDataDescriptor(object):
 
         if type(val) is str:
             logger.error("Setting string type to 'is_prepared'")
-            import traceback
-            traceback.print_stack()
+            #import traceback
+            #traceback.print_stack()
 
     @staticmethod
     def __sequence_set__(stripper, obj, val, name):
@@ -576,7 +572,6 @@ def GPIProxyObjectFactory(_obj):
     Returns:
         a proxy object
     """
-    from Ganga.GPIDev.Base.Objects import GangaObject
     if not isType(_obj, GangaObject):
         from Ganga.Core.exceptions import GangaException
         raise GangaException("%s is NOT a Proxyable object" % type(_obj))
@@ -661,7 +656,6 @@ def GPIProxyClassFactory(name, pluginclass):
         instance._auto__init__()
 
         ## All objects with an _auto__init__ method need to have that method called and we set the various node attributes here based upon the schema
-        from Ganga.GPIDev.Base.Objects import GangaObject, Node
         for key, _val in stripProxy(self)._schema.allItems():
             if not _val['protected'] and not _val['hidden'] and isType(_val, ComponentItem) and key not in Node._ref_list:
                 val = stripProxy(getattr(self, key))

--- a/python/Ganga/GPIDev/Base/Proxy.py
+++ b/python/Ganga/GPIDev/Base/Proxy.py
@@ -891,7 +891,8 @@ def GPIProxyClassFactory(name, pluginclass):
         else:
             c = stripProxy(self).clone()
             stripProxy(c)._auto__init__()
-        return GPIProxyObjectFactory(c)
+
+        return addProxy(c)
 
     helptext(_copy, "Make an identical copy of self.")
 

--- a/python/Ganga/GPIDev/Base/Proxy.py
+++ b/python/Ganga/GPIDev/Base/Proxy.py
@@ -10,7 +10,7 @@ from Ganga.Utility.Config import getConfig
 
 from Ganga.GPIDev.Schema import ComponentItem
 
-from Ganga.GPIDev.Base.Objects import GangaObject, ObjectMetaclass
+from Ganga.GPIDev.Base.Objects import GangaObject, ObjectMetaclass, _getName
 from Ganga.Core import GangaAttributeError, ProtectedAttributeError, ReadOnlyObjectError, TypeMismatchError
 
 import os
@@ -184,12 +184,9 @@ def isType(_obj, type_or_seq):
         return isinstance(obj, bare_type_or_seq)
 
 def getName(_obj):
+    """Strip any proxy and then return an objects name"""
     obj = stripProxy(_obj)
-    returnable = getattr(obj, '_name', getattr(obj, '__name__', None))
-    if returnable is None:
-        returnable = getattr(getattr(obj, '__class__', None), '__name__', None)
-        if returnable is None:
-            returnable = str(obj)
+    returnable = _getName(obj)
     return returnable
 
 def stripProxy(obj):

--- a/python/Ganga/GPIDev/Base/Proxy.py
+++ b/python/Ganga/GPIDev/Base/Proxy.py
@@ -21,7 +21,6 @@ import types
 
 implRef = '_impl'
 proxyClass = '_proxyClass'
-proxyObject = '_proxyObject'
 
 prepconfig = getConfig('Preparable')
 
@@ -418,7 +417,7 @@ class ProxyDataDescriptor(object):
         else:
             # val is not iterable
             if item['strict_sequence']:
-                raise GangaAttributeError('cannot assign a simple value %s to a strict sequence attribute %s.%s (a list is expected instead)' % (repr(val), getattr(obj, proxyObject)._schema.name, name))
+                raise GangaAttributeError('cannot assign a simple value %s to a strict sequence attribute %s.%s (a list is expected instead)' % (repr(val), getName(obj), name))
             if stripper is not None:
                 val = makeGangaList(stripper(val))
             else:
@@ -433,10 +432,11 @@ class ProxyDataDescriptor(object):
                                                 unprepare() the application or copy the job/application (using j.copy(unprepare=True)) and modify that new instance.' % (name,))
 
     ## Inspect this given item to determine if it has editable attributes if it has been set as read-only
+    ## Curently Unused although may be useful to keep
     @staticmethod
     def __subitems_read_only(obj):
         can_be_modified = []
-        for name, item in getattr(obj, proxyObject)._schema.allItems():
+        for name, item in obj._schema.allItems():
             ## This object inherits from Node therefore likely has a schema too.
             obj_attr = getattr(obj, name)
             if isType(obj_attr, Node):
@@ -576,9 +576,6 @@ def GPIProxyObjectFactory(_obj):
         from Ganga.Core.exceptions import GangaException
         raise GangaException("%s is NOT a Proxyable object" % type(_obj))
 
-    if hasattr(_obj, proxyObject):
-        return getattr(_obj, proxyObject)
-    
     obj_class = _obj.__class__
 
     proxy_class = getProxyClass(obj_class)
@@ -643,9 +640,6 @@ def GPIProxyClassFactory(name, pluginclass):
 
         ## Need to avoid any setter methods for GangaObjects
         ## Would be very nice to remove this entirely as I'm not sure a GangaObject should worry about it's proxy (if any)
-        #instance.__dict__[proxyObject] = self
-        ## THIS SHOLD BE DONE HERE BUT IS DONE IN GANAGOBJECT, PLEASE ADDRESS
-        #instance.__dict__[proxyClass] = type(name, (GPIProxyObject,), d)
 
         if proxy_obj_str in kwds.keys():
             # wrapping not constructing so can exit after determining that the proxy attributes are setup correctly
@@ -901,9 +895,6 @@ def GPIProxyClassFactory(name, pluginclass):
             if hasattr(stripProxy(self), 'metadata') and isType(stripProxy(self).metadata, MetadataDict):
                 if x in stripProxy(self).metadata.data.keys():
                     raise GangaAttributeError("Metadata item '%s' cannot be modified" % x)
-
-            #if x not in [implRef, proxyObject, proxyClass]:
-            #    raise GangaAttributeError("'%s' has no attribute '%s'" % (getName(stripProxy(self)), x))
 
         new_v = stripProxy(runtimeEvalString(self, x, v))
         GPIProxyObject.__setattr__(self, x, stripProxy(new_v))

--- a/python/Ganga/GPIDev/Credentials/ICredential.py
+++ b/python/Ganga/GPIDev/Credentials/ICredential.py
@@ -238,9 +238,11 @@ class ICredential(GangaObject):
                 # Since self.inputPW_Widget is called, current arguments are
                 # ignored since renew() and create() in GUI mode will not be
                 # called with any arguments.
-                if self.inputPW_Widget.ask(self._proxyObject):
+                #proxy_obj = self._proxyObject ## This is removed to get rid of ref to _proxyObject
+                proxy_obj = self
+                if self.inputPW_Widget.ask(proxy_obj):
                     logger.dg("Proceeding to retrieve password from inputPW_Widget.")
-                    __pw = self.inputPW_Widget.getPassword(self._proxyObject)
+                    __pw = self.inputPW_Widget.getPassword(proxy_obj)
                     if not __pw:
                         logger.warning("Password/passphrase expected!")
                         return False
@@ -269,7 +271,7 @@ class ICredential(GangaObject):
                 tFile.close()
                 # self.inputPW_Widget dialog postprocessing.
                 # E.g. disable autorenew mechanism if status != 0.
-                self.inputPW_Widget.renewalStatus(self._proxyObject, status)
+                self.inputPW_Widget.renewalStatus(proxy_obj, status)
                 if status == 0:
                     logger.info("%s creation/renewal successful." % self._name)
                     return True

--- a/python/Ganga/GPIDev/Lib/GangaList/GangaList.py
+++ b/python/Ganga/GPIDev/Lib/GangaList/GangaList.py
@@ -260,12 +260,12 @@ class GangaList(GangaObject):
     def __contains__(self, obj):
         return self._list.__contains__(self.strip_proxy(obj))
 
-    def __clone__(self):
-        return makeGangaListByRef(_list=copy.copy(self._list), preparable=self._is_preparable)
+    #def __clone__(self):
+    #    return makeGangaListByRef(_list=copy.copy(self._list), preparable=self._is_preparable)
 
-    def __copy__(self):
-        """Bypass any checking when making the copy"""
-        return makeGangaListByRef(_list=copy.copy(self._list), preparable=self._is_preparable)
+    #def __copy__(self):
+    #    """Bypass any checking when making the copy"""
+    #    return makeGangaListByRef(_list=copy.copy(self._list), preparable=self._is_preparable)
 
     def __delitem__(self, obj):
         self._list.__delitem__(self.strip_proxy(obj))
@@ -281,17 +281,17 @@ class GangaList(GangaObject):
         self.checkReadOnly()
         self.__delslice__(start, end)
 
-    def __deepcopy__(self, memo):
-        """Bypass any checking when making the copy"""
-        #logger.info("memo: %s" % str(memo))
-        #logger.info("self.len: %s" % str(len(self._list)))
-        if self._list != []:
-            return makeGangaListByRef(_list=copy.deepcopy(self._list), preparable=self._is_preparable)
-        else:
-            new_list = GangaList()
-            new_list._is_preparable = self._is_preparable
-            return new_list
-        #super(GangaList, self).__deepcopy__(memo)
+    #def __deepcopy__(self, memo):
+    #    """Bypass any checking when making the copy"""
+    #    #logger.info("memo: %s" % str(memo))
+    #    #logger.info("self.len: %s" % str(len(self._list)))
+    #    if self._list != []:
+    #        return makeGangaListByRef(_list=copy.deepcopy(self._list), preparable=self._is_preparable)
+    #    else:
+    #        new_list = GangaList()
+    #        new_list._is_preparable = self._is_preparable
+    #        return new_list
+    #    #super(GangaList, self).__deepcopy__(memo)
 
     def __eq__(self, obj_list):
         if obj_list is self:  # identity check

--- a/python/Ganga/GPIDev/Lib/JobTree/JobTree.py
+++ b/python/Ganga/GPIDev/Lib/JobTree/JobTree.py
@@ -489,7 +489,4 @@ class _copy(object):
 
 
 JobTree.__str__ = JobTree._display
-JobTree._proxyClass._display = _proxy_display()
-JobTree._proxyClass.__str__ = _proxy_display()
-JobTree._proxyClass.copy = _copy()
 

--- a/python/Ganga/GPIDev/Lib/Registry/PrepRegistry.py
+++ b/python/Ganga/GPIDev/Lib/Registry/PrepRegistry.py
@@ -579,15 +579,5 @@ class _proxy_display(object):
             return stripProxy(cls)._proxy_display
         return stripProxy(obj)._proxy_display
 
-
-# class _copy(object):
-#    def __get__(self, obj, cls):
-#        if obj is None:
-#            return stripProxy(cls)._copy
-#        return stripProxy(obj)._copy
-
 ShareRef.__str__ = ShareRef._display
-ShareRef._proxyClass._display = _proxy_display()
-ShareRef._proxyClass.__str__ = _proxy_display()
-#ShareRef._proxyClass.copy = _copy()
 

--- a/python/Ganga/GPIDev/Schema/Schema.py
+++ b/python/Ganga/GPIDev/Schema/Schema.py
@@ -84,10 +84,6 @@ def defaultConfigSectionName(name):
 # possible  however   the  _pluginclass  objects   are  shared  unless
 # overriden explicitly.
 
-def _getName(_object):
-    from Ganga.GPIDev.Base.Proxy import getName
-    return getName(_object)
-
 class Schema(object):
     # Schema constructor is used by Ganga plugin developers.
     # Ganga will automatically set a reference to the plugin class which corresponds to this schema, hence
@@ -115,7 +111,8 @@ class Schema(object):
 
     @property
     def name(self):
-        return _getName(self._pluginclass)
+        from Ganga.GPIDev.Base.Proxy import getName
+        return getName(self._pluginclass)
 
     def allItems(self):
         if self.datadict is None: return zip()

--- a/python/Ganga/Runtime/GPIexport.py
+++ b/python/Ganga/Runtime/GPIexport.py
@@ -14,9 +14,9 @@ import Ganga.GPI
 
 from .gangadoc import adddoc
 
-from Ganga.GPIDev.Base.Proxy import isType, addProxy
+from Ganga.GPIDev.Base.Proxy import isType, addProxy, getProxyClass
 from Ganga.GPIDev.Base.Objects import GangaObject
-
+from inspect import isclass
 
 def exportToGPI(name, _object, doc_section, docstring=None):
     '''
@@ -33,6 +33,8 @@ def exportToGPI(name, _object, doc_section, docstring=None):
 
     if isType(_object, GangaObject):
         setattr(Ganga.GPI, name, addProxy(_object))
+    elif isclass(_object) and issubclass(_object, GangaObject):
+        setattr(Ganga.GPI, name, getProxyClass(_object))
     else:
         setattr(Ganga.GPI, name, _object)
 

--- a/python/Ganga/Runtime/bootstrap.py
+++ b/python/Ganga/Runtime/bootstrap.py
@@ -872,7 +872,6 @@ under certain conditions; type license() for details.
 
         from Ganga.Runtime.GPIexport import exportToGPI
 
-        from Ganga.GPIDev.Base.Proxy import getProxyClass
         from Ganga.Utility.Plugin import allPlugins
         # make all plugins visible in GPI
         for k in allPlugins.allCategories():
@@ -880,7 +879,7 @@ under certain conditions; type license() for details.
                 cls = allPlugins.find(k, n)
                 if not cls._declared_property('hidden'):
                     ## exportToGPI as ._name and hence the 'n' or 'getName' value is bad
-                    exportToGPI(cls.__name__, getProxyClass(cls), 'Classes')
+                    exportToGPI(cls.__name__, cls, 'Classes')
 
         # set the default value for the plugins
         from Ganga.Utility.Config import getConfig
@@ -911,7 +910,7 @@ under certain conditions; type license() for details.
             raise Ganga.Utility.Config.ConfigError('Check configuration. Unable to set default Batch backend alias (%s)' % str(x))
         else:
             allPlugins.add(batch_default, 'backends', 'Batch')
-            exportToGPI('Batch', batch_default._proxyClass, 'Classes')
+            exportToGPI('Batch', batch_default, 'Classes')
 
         from Ganga.GPIDev.Base import ProtectedAttributeError, ReadOnlyObjectError, GangaAttributeError
         from Ganga.GPIDev.Lib.Job.Job import JobError

--- a/python/Ganga/Runtime/bootstrap.py
+++ b/python/Ganga/Runtime/bootstrap.py
@@ -879,7 +879,8 @@ under certain conditions; type license() for details.
             for n in allPlugins.allClasses(k):
                 cls = allPlugins.find(k, n)
                 if not cls._declared_property('hidden'):
-                    exportToGPI(n, getProxyClass(cls), 'Classes')
+                    ## exportToGPI as ._name and hence the 'n' or 'getName' value is bad
+                    exportToGPI(cls.__name__, getProxyClass(cls), 'Classes')
 
         # set the default value for the plugins
         from Ganga.Utility.Config import getConfig

--- a/python/Ganga/Runtime/bootstrap.py
+++ b/python/Ganga/Runtime/bootstrap.py
@@ -878,8 +878,7 @@ under certain conditions; type license() for details.
             for n in allPlugins.allClasses(k):
                 cls = allPlugins.find(k, n)
                 if not cls._declared_property('hidden'):
-                    ## exportToGPI as ._name and hence the 'n' or 'getName' value is bad
-                    exportToGPI(cls.__name__, cls, 'Classes')
+                    exportToGPI(n, cls, 'Classes')
 
         # set the default value for the plugins
         from Ganga.Utility.Config import getConfig
@@ -1097,8 +1096,7 @@ under certain conditions; type license() for details.
         import Ganga.GPIDev.Lib.Config
         exportToGPI('config', Ganga.GPIDev.Lib.Config.config,
                     'Objects', 'access to Ganga configuration')
-        exportToGPI(
-            'ConfigError', Ganga.GPIDev.Lib.Config.ConfigError, 'Exceptions')
+        exportToGPI('ConfigError', Ganga.GPIDev.Lib.Config.ConfigError, 'Exceptions')
 
         from Ganga.Utility.feedback_report import report
 

--- a/python/Ganga/Runtime/bootstrap.py
+++ b/python/Ganga/Runtime/bootstrap.py
@@ -878,6 +878,8 @@ under certain conditions; type license() for details.
             for n in allPlugins.allClasses(k):
                 cls = allPlugins.find(k, n)
                 if not cls._declared_property('hidden'):
+                    if n != cls.__name__:
+                        exportToGPI(cls.__name__, cls, 'Classes')
                     exportToGPI(n, cls, 'Classes')
 
         # set the default value for the plugins

--- a/python/Ganga/Runtime/bootstrap.py
+++ b/python/Ganga/Runtime/bootstrap.py
@@ -872,13 +872,14 @@ under certain conditions; type license() for details.
 
         from Ganga.Runtime.GPIexport import exportToGPI
 
+        from Ganga.GPIDev.Base.Proxy import getProxyClass
         from Ganga.Utility.Plugin import allPlugins
         # make all plugins visible in GPI
         for k in allPlugins.allCategories():
             for n in allPlugins.allClasses(k):
                 cls = allPlugins.find(k, n)
                 if not cls._declared_property('hidden'):
-                    exportToGPI(n, cls._proxyClass, 'Classes')
+                    exportToGPI(n, getProxyClass(cls), 'Classes')
 
         # set the default value for the plugins
         from Ganga.Utility.Config import getConfig

--- a/python/Ganga/new_tests/TestProxy.py
+++ b/python/Ganga/new_tests/TestProxy.py
@@ -47,35 +47,29 @@ class TestProxy(unittest.TestCase):
     def test_dict_attributes(self):
         # Non-proxied GangaObject class
         # self.assertFalse(hasattr(NonProxiedGangaObject, '_proxyClass'))  # This is currently know to fail. Should be fixed when class decorators are used for export
-        self.assertFalse(hasattr(NonProxiedGangaObject, '_proxyObject'))
         self.assertFalse(hasattr(NonProxiedGangaObject, '_impl'))
 
         # Proxied GangaObject class
         self.assertTrue(hasattr(TestGangaObject, '_proxyClass'))
-        self.assertFalse(hasattr(TestGangaObject, '_proxyObject'))
         self.assertFalse(hasattr(TestGangaObject, '_impl'))
 
         # Non-proxied GangaObject instance
         non_proxied_instance = TestGangaObject()
         self.assertTrue(hasattr(non_proxied_instance, '_proxyClass'))
-        self.assertFalse(hasattr(non_proxied_instance, '_proxyObject'))
         self.assertFalse(hasattr(non_proxied_instance, '_impl'))
 
         # Proxy class
         proxy_class = TestGangaObject._proxyClass
         self.assertFalse(hasattr(proxy_class, '_proxyClass'))
-        self.assertFalse(hasattr(proxy_class, '_proxyObject'))
         self.assertTrue(hasattr(proxy_class, '_impl'))
 
         # Proxy class instance
         self.assertFalse(hasattr(self.p, '_proxyClass'))
-        self.assertFalse(hasattr(self.p, '_proxyObject'))
         self.assertTrue(hasattr(self.p, '_impl'))
 
         # Proxied GangaObject instance
         proxied = self.p._impl
         self.assertTrue(hasattr(proxied, '_proxyClass'))
-        self.assertTrue(hasattr(proxied, '_proxyObject'))
         self.assertFalse(hasattr(proxied, '_impl'))
 
         # A proxy instance should only have _impl in its dict

--- a/python/GangaTest/Lib/TestSubmitter/TestSubmitter.py
+++ b/python/GangaTest/Lib/TestSubmitter/TestSubmitter.py
@@ -26,7 +26,7 @@ from Ganga.GPIDev.Adapters.IBackend import IBackend
 
 class TestSubmitter(IBackend):
     _schema = Schema(Version(1,0), {'time' : SimpleItem(defvalue=5,changable_at_resubmit=1),
-                                    'start_time' : SimpleItem(defvalue=0,protected=1,comparable=0),
+                                    'start_time' : SimpleItem(defvalue=0,protected=1,comparable=0,copyable=0),
                                     'update_delay' : SimpleItem(defvalue=0,doc="The time it takes to updateMonitoringInformation"),
                                     'fail' : SimpleItem(defvalue='',doc='Define the artificial runtime failures: "submit", "kill","monitor","resubmit"', changeable_at_resubmit=1 )
                                     


### PR DESCRIPTION
Hi all,

I'm expecting this to cause some debate as it's proxy related, but I'm very keen to get this PR in at the start of 6.1.16 as I think it helps smooth some things out.

This patch is intended to remove the standing proxy object from the Objects.py file and make the exporting of objects to the GPI more robust.

I've added ```getProxyClass``` to ```Proxy.py```.
This function will return a proxy object if the class has been expressly written with one. Aka the repositories.
If the class is a GangaObject subclass it will add a proxy as required constructing one on the fly.


If a ```GangaObject``` is exported to the ```GPI``` a proxy is automatically added.
If a class which is a subclass of ```GangaObject``` is exported to the ```GPI``` a proxy is automatically added to the class (if it's needed) through ```getProxyClass```.
If anything else is exported it is just exported to the ```GPI``` as normal.

I've moved the code which deals with constructing the proxy of object purely into Proxy.py as suggested above.


I have also removed the setting of ```_proxyObject``` for a ```GangaObject``` instance.
The only reason this was referred to in the Objects.py was to make sure that we avoid copying it and ending up in an inifinite loop.
I appear to be able to submit jobs and work with Ganga just fine without it so I'm strongly of the mind to promote dropping this entirely from within ```GangaObject```.

Unless someone knows of a good reason why the ```GangaObject``` should be able to access it's proxy?


In summary:

```GangaObject()._proxyObject``` I want to get rid of (I'm happy to keep it but I don't personally like it.
```GangaObject._proxyClass``` I want to keep as an optional property of the class. This allows for classes such as the Registries to overload the proxy with something more customised to their needs.
```exportToGPI``` will now automatically add proxies to objects and classes that need them when it's called.

I am now able to do a direct ```from Ganga.GPIDev.Base.Objects import GangaObject``` at the top of ```Proxy.py``` so I'm feeling a bit better about how these 2 systems are now separated,


I'm happy to have some conversation about keeping stubs for ```_proxyObject``` in the ```GangaObject``` and a few details but I'm keen to get most of this in as it gets rid of some horrible circular dependencies.