### PR TITLE
This reverts 320e247e1ad which was causing stale data to be displayed

### DIFF
--- a/python/Ganga/GPIDev/Lib/Job/Job.py
+++ b/python/Ganga/GPIDev/Lib/Job/Job.py
@@ -401,8 +401,6 @@ class Job(GangaObject):
         # Attempt to spend too long loading un-needed objects into memory in
         # order to read job status
         if name == 'status':
-            if stripProxy(self).getNodeIndexCache():
-                return stripProxy(self).getNodeIndexCache()['display:status']
             return object.__getattribute__(self, 'status')
 
         # FIXME Add some method of checking what objects are known in advance of calling the __getattribute__ method


### PR DESCRIPTION
Commit [320e247e1ad](https://github.com/ganga-devs/ganga/commit/320e247e1add935c09dfe3dede1b87e305f4ce66#diff-7056ed3fcb714dad4d540fcd686efe61R403) changed the behaviour of `j.status` so that it was *always* preferring the index cache (if present) over the real data, even if there was real data present and so was presenting stale information. This is what's been causing a lot of the problems of jobs 'reverting' to `submitted` when they should be `running` or `completed` etc. (at least as far as my testing can see).

The check for the index cache is done in `Descriptor.__get__` anyway so this shouldn't cause full loading.

In discussion with Mark we agreed that there shouldn't be any cases where the index cache is populated on a fully-loaded job, especially one that's only just been created in memory but it *was* happening. That will have to be a fix for another time.

This PR is against the release branch so I'll see if that works correctly.

If people could review this one quickly so that it can get put into the release, that'd be great.