### PR TITLE
Bugfix/fix publisher problems

### DIFF
--- a/python/Ganga/Runtime/spyware.py
+++ b/python/Ganga/Runtime/spyware.py
@@ -76,8 +76,7 @@ def ganga_job_submitted(application_name, backend_name, plain_job, master_job, s
 
         # start publisher thread and enqueue usage message for sending
         p.start()
-        p.send(msg_config['job_submission_message_destination'], repr(
-            job_submitted_message), {'persistent': 'true'})
+        p.send(msg_config['job_submission_message_destination'], repr(job_submitted_message), {'persistent': 'true'})
         # p.send('/queue/test.ganga.jobsubmission',repr(job_submitted_message),{'persistent':'true'})
         # ask publisher thread to stop. it will send queued message anyway.
         p.stop()

--- a/python/Ganga/Utility/stomputil/publisher.py
+++ b/python/Ganga/Utility/stomputil/publisher.py
@@ -28,12 +28,12 @@ except (Exception, ImportError) as err:
             pass
 
         @staticmethod
-        def Connection(self, _server_and_port, user, password):
+        def Connection(self, _server_and_port={}, user='', password=''):
             ## DO NOTHING
             pass
 
     stomp_listener = object
-    stomp_major_version = 2
+    stomp_major_version = -999
 
 
 class LoggerListener(stomp_listener):
@@ -185,10 +185,14 @@ def createPublisher(T, server, port, user='', password='', logger=None,
                 self._log(logging_DEBUG, 'Connecting.')
                 # create connection
                 global stomp_major_version
-                if stomp_major_version > 2:
+                if stomp_major_version >= 2:
                     cx = stomp.Connection(self._cx_hostname_ports)
                 else:
                     cx = stomp.Connection(*self._cx_params)
+
+                if cx is None:
+                    self._cx = None
+                    return
                 # add logger listener to connection
                 if self._logger is not None:
                     cx.set_listener('logger', LoggerListener(self._logger))


### PR DESCRIPTION
Hi all,

This pull is to address running Ganga on a system where stomp has failed to load (or isn't available).

This can wait until 6.1.16 but is a fix which stops some (correctly caught) exceptions from slowing down Ganga on my test system.

Before this patch I observed submitting a job took ~30sec on a system with i5 and an ssd, after it takes only ~5sec or so. (Startup was also sped up a significantly with this due to not failing).