### PR TITLE
Typo fixes in Registry code, 6.1.X compatibility fixes to LHCbTasks code

### DIFF
--- a/python/Ganga/Core/GangaRepository/Registry.py
+++ b/python/Ganga/Core/GangaRepository/Registry.py
@@ -292,7 +292,7 @@ class Registry(object):
         #    self._lock.release()
 
     def updateLocksNow(self):
-        loger.debug("updateLocksNow")
+        logger.debug("updateLocksNow")
         #self._lock.acquire()
         try:
             self.repository.updateLocksNow()
@@ -846,7 +846,7 @@ class Registry(object):
     def __safe_read_access(self,  _obj, sub_obj):
         logger.debug("_safe_read_access")
         obj = stripProxy(_obj)
-        self._start_check("The object #%i in registry '%s' is not fully loaded and the registry is disconnected! Type 'reactivate()' if you want to reconnect." % (self.find(obj), self.name)
+        self._start_check("The object #%i in registry '%s' is not fully loaded and the registry is disconnected! Type 'reactivate()' if you want to reconnect." % (self.find(obj), self.name))
         if self.find(obj) in self._inprogressDict.keys():
             return
 

--- a/python/GangaLHCb/Lib/Tasks/LHCbTransform.py
+++ b/python/GangaLHCb/Lib/Tasks/LHCbTransform.py
@@ -150,8 +150,8 @@ class LHCbTransform(ITransform):
 
             if len(self.units) == 0:
                 # check for appropriate splitter
-                from GPI import GaussSplitter
-                if not self.splitter or isType(self.splitter, GaussSplitter):
+                from Ganga.GPI import GaussSplitter
+                if not self.splitter or not isType(self.splitter, GaussSplitter):
                     logger.warning("No GaussSplitter specified - first event info ignored")
 
                 # create units for MC generation

--- a/python/GangaLHCb/Lib/Tasks/LHCbUnit.py
+++ b/python/GangaLHCb/Lib/Tasks/LHCbUnit.py
@@ -46,7 +46,7 @@ class LHCbUnit(IUnit):
             if isType(trf.splitter, GaussSplitter):
                 events_per_unit = j.splitter.eventsPerJob * \
                     j.splitter.numberOfJobs
-                j.splitter.firstEventNumber = self.getID() * events_per_unit
+                j.splitter.firstEventNumber += self.getID() * events_per_unit
 
         else:
             j.splitter = SplitByFiles()


### PR DESCRIPTION
- Fix two typos in Registry.py
- Fix import and when a warning is printed in LHCbTransform code
- Adjust handling of mc_num_units so the parent transform's GaussSplitter can be used to change the first event number.