### PR TITLE
Fix node tests

### DIFF
--- a/python/Ganga/GPIDev/Base/Objects.py
+++ b/python/Ganga/GPIDev/Base/Objects.py
@@ -101,12 +101,10 @@ class Node(object):
         for elem in this_dict.keys():
             if elem not in do_not_copy:
                 this_dict[elem] = deepcopy(this_dict[elem], memo)  # FIXED
-            else:
-                this_dict[elem] = None
 
+        obj.__dict__ = this_dict
         if self._getParent() is not None:
             obj._setParent(self._getParent())
-        setattr(obj, '_index_cache', {})
         setattr(obj, '_registry', self._registry)
         return obj
 

--- a/python/Ganga/GPIDev/Schema/Schema.py
+++ b/python/Ganga/GPIDev/Schema/Schema.py
@@ -280,7 +280,13 @@ class Schema(object):
                 category = item['category']
 
                 if isinstance(defvalue, str) or defvalue is None:
-                    if category not in _found_components or config.hasModified():
+                    try:
+                        config = Config.getConfig(def_name, create=False)
+                        has_modified = config.hasModified()
+                    except KeyError:
+                        has_modified = False
+
+                    if category not in _found_components or has_modified:
                         _found_components[category] = allPlugins.find(category, defvalue)
                     return _found_components[category]()
 


### PR DESCRIPTION
These two changes fix bugs that I have come across in the course of working on the thread-safe `GangaObject`. They're both real bugs in the code which were just introduced by accident at some point.

The schema change is for those cases where you have a `GangaObject` which is hidden (and so has no `default_*` config) which has schema `ComponentItem`s items with default values. This fix allows these to work whereas before it would always try to look in the config system.

The second is a small bug which completely breaks `Node.__deepcopy__`. The reason this has not shown before is that no-one actually calls this function as `GangaObject` overrides it and doesn't call the base class. Really this whole method should be killed but while there's a test for it I thought it worth fixing. Longer-term I think we should just combine `GangaObject` and `Node` into one class but that's not for now.

These aren't directly stability fixes (as they would raise exceptions) but they are real bugs so I'd like to merge this as soon as possible as I don't want these fixes mixing with my up-coming PR for the thread-safe `GangaObject`.