### PR TITLE
Fix testsafesave

### DIFF
--- a/python/Ganga/new_tests/TestSafeSave.py
+++ b/python/Ganga/new_tests/TestSafeSave.py
@@ -1,4 +1,6 @@
 import unittest
+from Ganga.GPIDev.Lib.File.LocalFile import LocalFile
+
 
 class TestSafeSave(unittest.TestCase):
 
@@ -16,11 +18,12 @@ class TestSafeSave(unittest.TestCase):
         testfn = '/tmp/xmltest.tmp'
         ths = []
 
+        o = LocalFile()
         if os.path.isfile(testfn):
             os.remove(testfn)
 
         for i in range(0, 500):
-            ths.append( threading.Thread(target=safe_save, args=(testfn, [], my_to_file ) ) )
+            ths.append(threading.Thread(target=safe_save, args=(testfn, o, my_to_file)))
 
         for th in ths:
             th.start()

--- a/python/Ganga/new_tests/TestSafeSave.py
+++ b/python/Ganga/new_tests/TestSafeSave.py
@@ -35,3 +35,4 @@ class TestSafeSave(unittest.TestCase):
         os.remove(testfn)
         self.assertTrue(os.path.isfile(testfn+'~'))
         os.remove(testfn+'~')
+        self.assertFalse(os.path.isfile(testfn+'.new'))

--- a/python/Ganga/new_tests/TestSafeSave.py
+++ b/python/Ganga/new_tests/TestSafeSave.py
@@ -7,7 +7,7 @@ from Ganga.GPIDev.Lib.File.LocalFile import LocalFile
 class TestSafeSave(unittest.TestCase):
 
     def test_safe_save_threadcalls(self):
-        "Test that XML files don't disappear - See Github Issue #185"
+        """Test that XML files don't disappear - See Github Issue #185"""
         import threading
         import os
 

--- a/python/Ganga/new_tests/TestSafeSave.py
+++ b/python/Ganga/new_tests/TestSafeSave.py
@@ -1,4 +1,6 @@
 import unittest
+import uuid
+
 from Ganga.GPIDev.Lib.File.LocalFile import LocalFile
 
 
@@ -15,12 +17,10 @@ class TestSafeSave(unittest.TestCase):
             fhandle.write("!" * 1000)
 
         # Create lots of threads that will keep hitting safe_save
-        testfn = '/tmp/xmltest.tmp'
+        testfn = '/tmp/xmltest.tmp' + str(uuid.uuid4())
         ths = []
 
         o = LocalFile()
-        if os.path.isfile(testfn):
-            os.remove(testfn)
 
         for i in range(0, 500):
             ths.append(threading.Thread(target=safe_save, args=(testfn, o, my_to_file)))
@@ -32,3 +32,6 @@ class TestSafeSave(unittest.TestCase):
             th.join()
 
         self.assertTrue(os.path.isfile(testfn))
+        os.remove(testfn)
+        self.assertTrue(os.path.isfile(testfn+'~'))
+        os.remove(testfn+'~')


### PR DESCRIPTION
This is few minor fixes to @drmarkwslater's `TestSafeSave` test to make sure that the things being passed around are valid for the `save_save` function. The main change is using a `LocalFile` instead of a `list`.