### PR TITLE
Make GangaObject thread-safe

### DIFF
--- a/python/Ganga/GPIDev/Base/Objects.py
+++ b/python/Ganga/GPIDev/Base/Objects.py
@@ -147,10 +147,12 @@ class Node(object):
             p._lock.acquire()
             ancestors.append(p)
             p = p._parent
-        yield
-        for p in reversed(ancestors):
-            p._lock.release()
-        self._lock.release()
+        try:
+            yield
+        finally:
+            for p in reversed(ancestors):
+                p._lock.release()
+            self._lock.release()
 
     # get the root of the object tree
     # if parent does not exist then the root is the 'self' object

--- a/python/Ganga/GPIDev/Base/Objects.py
+++ b/python/Ganga/GPIDev/Base/Objects.py
@@ -13,6 +13,10 @@
 #   and followed by
 #    obj._setDirty()
 
+import threading
+from contextlib import contextmanager
+import functools
+
 import Ganga.Utility.logging
 
 from copy import deepcopy, copy
@@ -37,7 +41,7 @@ logger = Ganga.Utility.logging.getLogger(modulename=1)
 
 _imported_GangaList = None
 
-do_not_copy = ['_index_cache', '_parent', '_registry', '_data']
+do_not_copy = ['_index_cache', '_parent', '_registry', '_data', '_lock']
 
 def _getGangaList():
     global _imported_GangaList
@@ -47,6 +51,18 @@ def _getGangaList():
     return _imported_GangaList
 
 
+def synchronised(f):
+    """
+    This decorator must be attached to a method on a ``Node`` subclass
+    It uses the object's lock to make sure that the object is held for the duration of the decorated function
+    """
+    @functools.wraps(f)
+    def decorated(self, *args, **kwargs):
+        with self.lock:
+            return f(self, *args, **kwargs)
+    return decorated
+
+
 class Node(object):
     _ref_list = ['_parent', '_registry', '_index_cache']
 
@@ -54,6 +70,7 @@ class Node(object):
         self._data = {}
         self._parent = parent
         self._index_cache = {}
+        self._lock = threading.RLock()
         super(Node, self).__init__()
         #logger.info("Node __init__")
 
@@ -108,11 +125,32 @@ class Node(object):
         setattr(obj, '_registry', self._registry)
         return obj
 
+    @synchronised
     def _getParent(self):
         return self._parent
 
+    @synchronised
     def _setParent(self, parent):
         setattr(self, '_parent', parent)
+
+    @property
+    @contextmanager
+    def lock(self):
+        """
+        This is a context manager which acquires the lock on the object and all it's ancestors.
+        When the context manager exits, all the locks are released in the reverse order to that which they were acquired.
+        """
+        self._lock.acquire()
+        ancestors = []
+        p = self._parent
+        while p is not None:
+            p._lock.acquire()
+            ancestors.append(p)
+            p = p._parent
+        yield
+        for p in reversed(ancestors):
+            p._lock.release()
+        self._lock.release()
 
     # get the root of the object tree
     # if parent does not exist then the root is the 'self' object
@@ -339,6 +377,19 @@ class Node(object):
 ##########################################################################
 
 
+def synchronised_descriptor(get_or_set):
+    """
+    This decorator should only be used on ``__get__`` or ``__set__`` methods of a ``Descriptor``.
+    """
+    @functools.wraps(get_or_set)
+    def decorated(self, obj, type_or_value):
+        if obj is None:
+            return get_or_set(self, obj, type_or_value)
+        with obj.lock:
+            return get_or_set(self, obj, type_or_value)
+    return decorated
+
+
 class Descriptor(object):
 
     def __init__(self, name, item):
@@ -362,6 +413,7 @@ class Descriptor(object):
         if self._getter_name:
             raise AttributeError('cannot modify or delete "%s" property (declared as "getter")' % _getName(self))
 
+    @synchronised_descriptor
     def __get__(self, obj, cls):
         name = _getName(self)
 
@@ -473,6 +525,7 @@ class Descriptor(object):
 
         return v_copy
 
+    @synchronised_descriptor
     def __set__(self, _obj, _val):
         ## self: attribute being changed or Ganga.GPIDev.Base.Objects.Descriptor in which case _getName(self) gives the name of the attribute being changed
         ## _obj: parent class which 'owns' the attribute

--- a/python/Ganga/new_tests/TestGangaObject.py
+++ b/python/Ganga/new_tests/TestGangaObject.py
@@ -155,8 +155,8 @@ class _ExcThread(threading.Thread):
         finally:
             del self.target, self.args, self.kwargs
 
-    def join(self, timeout=None, balancing=True):
-        threading.Thread.join(self, timeout, balancing)
+    def join(self, *args, **kwargs):
+        threading.Thread.join(self, *args, **kwargs)
         if self.exc:
             raise self.exc[0], self.exc[1], self.exc[2]
 

--- a/python/Ganga/new_tests/TestGangaObject.py
+++ b/python/Ganga/new_tests/TestGangaObject.py
@@ -1,6 +1,12 @@
 
 from unittest import TestCase
+import threading
+import time
+import random
 
+
+from Ganga.GPIDev.Base import GangaObject
+from Ganga.GPIDev.Schema import Schema, Version, SimpleItem, ComponentItem
 from Ganga.GPIDev.Base.Objects import Node, GangaObject, ObjectMetaclass
 
 
@@ -127,3 +133,214 @@ class TestObjectMetaclass(TestCase):
             @classmethod
             def _declared_property(cls, name):
                 return '_' + name in cls.__dict__
+
+
+class _ExcThread(threading.Thread):
+    def __init__(self, group=None, target=None, name=None, args=(), kwargs=None, verbose=None):
+        super(_ExcThread, self).__init__(group, target, name, args, kwargs, verbose)
+        if kwargs is None:
+            kwargs = {}
+        self.target = target
+        self.args = args
+        self.kwargs = kwargs
+        self.exc = None
+        self.daemon = True
+
+    def run(self):
+        try:
+            self.target(*self.args, **self.kwargs)
+        except Exception:
+            import sys
+            self.exc = sys.exc_info()
+        finally:
+            del self.target, self.args, self.kwargs
+
+    def join(self, timeout=None, balancing=True):
+        threading.Thread.join(self, timeout, balancing)
+        if self.exc:
+            raise self.exc[0], self.exc[1], self.exc[2]
+
+
+class MultiThreadedTestCase(TestCase):
+    """
+    This is a specialisation of the ``unittest.TestCase`` to provide a function which can run multiple threads at once.
+    These sorts of stress tests work best if each thread is relatively long-lived so make sure they either call a long-running function or loop many times within the function.
+    In your ``test_foo`` function you should define one or more functions which you want to be run in threads and then pass them to ``self.run_threads``.
+    Each function should take a single argument which is the thread number
+
+    For example::
+
+        class TestClass(MultiThreadedTestCase):
+            def test_read_write(self):
+
+                def a(thread_number):
+                    something_hopefully_threadsafe()
+
+                def b(thread_number):
+                    for _ in range(100):
+                        something_quicker_but_hopefully_threadsafe()
+
+                self.run_threads([a, b])
+
+    The timeout duration and the number of parallel threads to run can be customised
+    and any exception raised by the thread will be correctly propagated to the main thread with correct traceback for test failure reporting.
+    """
+
+    def run_threads(self, functions=None, num_threads=100, timeout=10):
+        """
+        Args:
+            functions: a list of functions which will be randomly chosen to run in threads. They will take one argument which is an integer thread id
+            num_threads: the number of total threads to run for this test case
+            timeout: When joining the threads at the end, how long to have as a timeout on each one.
+        Raises:
+            RuntimeError: if all the threads have not finished by the time the timeout ends.
+        """
+        if functions is None:
+            functions = []
+
+        # Start the threads where each one is running a function randomly chosen from ``threads``
+        threads = []
+        for i in range(num_threads):
+            target = random.choice(functions)
+            t = _ExcThread(target=target, args=[i])
+            threads.append(t)
+            t.start()
+
+        # Try to wait for each thread to finish
+        start = cur_time = time.time()
+        while cur_time <= (start + timeout):
+            for thread in threads:
+                if thread.is_alive():
+                    # If it's still running, try to finish it
+                    thread.join(timeout=0)
+            if all(not t.is_alive() for t in threads):
+                break  # If we're al done, finish the loop
+            time.sleep(0.1)
+            cur_time = time.time()
+        else:
+            # If we hit the timeout without all the threads finishing, raise an exception.
+            still_running = [t for t in threads if t.is_alive()]
+            num_threads = len(still_running)
+            names = [t.name for t in still_running]
+            raise RuntimeError('Timeout while waiting for {0} threads to finish: {1}'.format(num_threads, names))
+
+
+class SimpleGangaObject(GangaObject):
+    _schema = Schema(Version(1, 0), {
+        'a': SimpleItem(42, typelist=['int']),
+    })
+    _category = 'TestGangaObject'
+    _hidden = True
+    _enable_plugin = True
+
+
+class ThreadedTestGangaObject(GangaObject):
+    _schema = Schema(Version(1, 0), {
+        'a': SimpleItem(42, typelist=['int']),
+        'b': ComponentItem('TestGangaObject', defvalue='SimpleGangaObject'),
+    })
+    _category = 'TestGangaObject'
+    _hidden = True
+    _enable_plugin = True
+
+
+class TestThreadSafeGangaObject(MultiThreadedTestCase):
+    """
+    This test is to check that ``GangaObject`` is thread-safe as far as possible.
+    """
+
+    def test_read_write(self):
+        """
+        This tests whether claiming a lock on the object stops other threads overwriting our value
+        """
+        o = ThreadedTestGangaObject()
+        random.seed(time.gmtime())
+
+        def write_read(thread_number):
+            rand = random.Random()
+            rand.seed(time.clock() + thread_number)
+            for _ in range(100):
+                with o.lock:
+                    num = rand.randint(0, 1000)
+                    o.a = num
+                    time.sleep(rand.uniform(0, 1E-6))
+                    self.assertEqual(o.a, num)
+
+        def write(thread_number):
+            for _ in range(100):
+                o.a = -1  # Not in the range being set by other threads
+
+        self.run_threads([write_read, write])
+
+    def test_read_write_parent(self):
+        """
+        Are parent locks held correctly?
+
+        We make a parent and a child and then check whether claiming an explicit lock on the child will stop changes to the parent.
+        """
+        o = ThreadedTestGangaObject()
+        o.b = SimpleGangaObject()
+        child = o.b
+        random.seed(time.gmtime())
+
+        def write_read(thread_number):
+            rand = random.Random()
+            rand.seed(time.clock() + thread_number)
+            for _ in range(300):
+                with child.lock:
+                    num = rand.randint(0, 1000)
+                    o.a = num
+                    child_num = rand.randint(0, 1000)
+                    o.b.a = child_num
+                    time.sleep(rand.uniform(0, 1E-6))
+                    self.assertEqual(o.a, num)
+                    self.assertEqual(o.b.a, child_num)
+                    self.assertIs(o.b, child)
+
+        def write(thread_number):
+            for _ in range(300):
+                o.a = -1  # Not in the range being set by other threads
+                o.b.a = -1
+
+        self.run_threads([write_read, write])
+
+    def test_coarse_locks(self):
+        """
+        Make sure that the coarse locks work
+
+        In each thread we grab sole access of the object via its ``lock`` property and do things to it.
+        This is required for the cases where you need to do multiple things to an object before allowing anyone else to.
+        """
+        o = ThreadedTestGangaObject()
+
+        def change(thread_number):
+            rand = random.Random()
+            rand.seed(time.clock() + thread_number)
+            for _ in range(100):  # Run this thread many times to keep it running for long enough to see problems.
+                with o.lock:
+                    num = rand.randint(0, 1000)
+                    o.a = num
+                    time.sleep(rand.uniform(0, 1E-6))
+                    self.assertEqual(o.a, num)
+
+                with o.lock:
+                    o.b = rand.choice([ThreadedTestGangaObject, SimpleGangaObject])()
+                    child_num = rand.randint(0, 1000)
+                    o.b.a = child_num
+                    time.sleep(rand.uniform(0, 1E-6))
+                    self.assertEqual(o.b.a, child_num)
+
+                    if isinstance(o.b, ThreadedTestGangaObject):
+                        o.b.b.a = rand.choice([ThreadedTestGangaObject, SimpleGangaObject])()
+                        num = rand.randint(0, 1000)
+                        o.b.b.a = num
+                        time.sleep(rand.uniform(0, 1E-6))
+                        self.assertEqual(o.b.b.a, num)
+
+                with o.lock:
+                    num = rand.randint(0, 1000)
+                    o.b.a = num
+                    time.sleep(rand.uniform(0, 1E-6))
+                    self.assertEqual(o.b.a, num)
+
+        self.run_threads([change])

--- a/python/Ganga/new_tests/TestGangaObject.py
+++ b/python/Ganga/new_tests/TestGangaObject.py
@@ -203,6 +203,7 @@ class MultiThreadedTestCase(TestCase):
         for i in range(num_threads):
             target = random.choice(functions)
             t = _ExcThread(target=target, args=[i])
+            t.name = t.name + '-' + target.__name__
             threads.append(t)
             t.start()
 

--- a/python/Ganga/new_tests/TestGangaObject.py
+++ b/python/Ganga/new_tests/TestGangaObject.py
@@ -211,9 +211,8 @@ class MultiThreadedTestCase(TestCase):
         start = cur_time = time.time()
         while cur_time <= (start + timeout):
             for thread in threads:
-                if thread.is_alive():
-                    # If it's still running, try to finish it
-                    thread.join(timeout=0)
+                # If it's still running, try to finish it
+                thread.join(timeout=0)
             if all(not t.is_alive() for t in threads):
                 break  # If we're al done, finish the loop
             time.sleep(0.1)

--- a/python/Ganga/new_tests/TestGangaObject.py
+++ b/python/Ganga/new_tests/TestGangaObject.py
@@ -1,5 +1,8 @@
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
-from unittest import TestCase
 import threading
 import time
 import random
@@ -10,7 +13,7 @@ from Ganga.GPIDev.Schema import Schema, Version, SimpleItem, ComponentItem
 from Ganga.GPIDev.Base.Objects import Node, GangaObject, ObjectMetaclass
 
 
-class TestGangaObject(TestCase):
+class TestGangaObject(unittest.TestCase):
 
     def setUp(self):
         self.obj = GangaObject()
@@ -87,7 +90,7 @@ class TestGangaObject(TestCase):
         pass
 
 
-class TestNode(TestCase):
+class TestNode(unittest.TestCase):
 
     def setUp(self):
         self.obj = Node(None)
@@ -121,7 +124,7 @@ class TestNode(TestCase):
         pass
 
 
-class TestObjectMetaclass(TestCase):
+class TestObjectMetaclass(unittest.TestCase):
 
     def testObjectMetaclass(self):
         class GangaObject(Node):
@@ -161,7 +164,7 @@ class _ExcThread(threading.Thread):
             raise self.exc[0], self.exc[1], self.exc[2]
 
 
-class MultiThreadedTestCase(TestCase):
+class MultiThreadedTestCase(unittest.TestCase):
     """
     This is a specialisation of the ``unittest.TestCase`` to provide a function which can run multiple threads at once.
     These sorts of stress tests work best if each thread is relatively long-lived so make sure they either call a long-running function or loop many times within the function.
@@ -286,7 +289,7 @@ class TestThreadSafeGangaObject(MultiThreadedTestCase):
         def write_read(thread_number):
             rand = random.Random()
             rand.seed(time.clock() + thread_number)
-            for _ in range(300):
+            for _ in range(100):
                 with child.lock:
                     num = rand.randint(0, 1000)
                     o.a = num
@@ -298,7 +301,7 @@ class TestThreadSafeGangaObject(MultiThreadedTestCase):
                     self.assertIs(o.b, child)
 
         def write(thread_number):
-            for _ in range(300):
+            for _ in range(100):
                 o.a = -1  # Not in the range being set by other threads
                 o.b.a = -1
 
@@ -316,7 +319,7 @@ class TestThreadSafeGangaObject(MultiThreadedTestCase):
         def change(thread_number):
             rand = random.Random()
             rand.seed(time.clock() + thread_number)
-            for _ in range(100):  # Run this thread many times to keep it running for long enough to see problems.
+            for _ in range(50):  # Run this thread many times to keep it running for long enough to see problems.
                 with o.lock:
                     num = rand.randint(0, 1000)
                     o.a = num

--- a/python/Ganga/new_tests/TestGangaObject.py
+++ b/python/Ganga/new_tests/TestGangaObject.py
@@ -319,7 +319,7 @@ class TestThreadSafeGangaObject(MultiThreadedTestCase):
         def change(thread_number):
             rand = random.Random()
             rand.seed(time.clock() + thread_number)
-            for _ in range(50):  # Run this thread many times to keep it running for long enough to see problems.
+            for _ in range(10):  # Run this thread many times to keep it running for long enough to see problems.
                 with o.lock:
                     num = rand.randint(0, 1000)
                     o.a = num
@@ -346,4 +346,4 @@ class TestThreadSafeGangaObject(MultiThreadedTestCase):
                     time.sleep(rand.uniform(0, 1E-6))
                     self.assertEqual(o.b.a, num)
 
-        self.run_threads([change])
+        self.run_threads([change], num_threads=50)


### PR DESCRIPTION
This adds thread-safe locks to all `GangaObject`s for all schema attributes as well as getting and setting the parent. In addition to this you can, at any time, claim a lock on an object with a `with obj.lock:` context manager and have only the current thread be able to access it.

As well as locking the object itself, it will also claim the locks on all its parents and grandparents (etc.) for safety. This PR makes no distinction between read locks and write locks but I'm not convinced there's a need to distinguish.

This doesn't make any changes to the registry etc. yet but it would be very easy to use the locks here to guarantee thread-safety there too but I haven't yet seen any issues.

This PR obviously competes with some of @rob-c's work in #182 but I feel that this approach is simpler and this PR is much more focused.