### PR TITLE
Bugfix/cleanup queues launch/shutdown

### DIFF
--- a/python/Ganga/Core/GangaThread/WorkerThreads/__init__.py
+++ b/python/Ganga/Core/GangaThread/WorkerThreads/__init__.py
@@ -1,0 +1,32 @@
+
+_global_queues = None
+
+def startUpQueues():
+    from Ganga.Utility.logging import getLogger
+    logger = getLogger()
+    global _global_queues
+    if _global_queues is None:
+        logger.debug("Starting Queues")
+        # start queues
+        from Ganga.Runtime.GPIexport import exportToGPI
+        from Ganga.Core.GangaThread.WorkerThreads.ThreadPoolQueueMonitor import ThreadPoolQueueMonitor
+        _global_queues = ThreadPoolQueueMonitor()
+        exportToGPI('queues', _global_queues, 'Objects')
+
+        import atexit
+        atexit.register((-10., shutDownQueues), ())
+
+    else:
+        logger.error("Cannot Start queues if they've already started")
+
+def shutDownQueues():
+    from Ganga.Utility.logging import getLogger
+    logger = getLogger()
+    logger.debug("Shutting Down Queues system")
+    global _global_queues
+    _global_queues.lock()
+    _global_queues._purge_all()
+    del _global_queues
+    _global_queues = None
+
+

--- a/python/Ganga/Core/InternalServices/ShutdownManager.py
+++ b/python/Ganga/Core/InternalServices/ShutdownManager.py
@@ -66,13 +66,6 @@ def _ganga_run_exitfuncs():
     from Ganga.Utility.Config import setConfigOption
     setConfigOption('Configuration', 'DiskIOTimeout', 1)
 
-    try:
-        from Ganga.GPI import queues
-        queues.lock()
-    except Exception as err:
-        logger.debug("This should only happen if Ganga filed to initialize correctly")
-        logger.debug("Err: %s" % str(err))
-
     ## Stop the Mon loop from iterating further!
     from Ganga.Core import monitoring_component
     if monitoring_component is not None:
@@ -97,13 +90,6 @@ def _ganga_run_exitfuncs():
     from Ganga.Core.MonitoringComponent.Local_GangaMC_Service import _purge_actions_queue, stop_and_free_thread_pool
     _purge_actions_queue()
     stop_and_free_thread_pool()
-
-    try:
-        from Ganga.GPI import queues
-        queues._purge_all()
-    except Exception as err:
-        logger.debug("This should only happen if Ganga filed to initialize correctly")
-        logger.debug("Err2: %s" % str(err))
 
     def priority_cmp(f1, f2):
         """
@@ -132,7 +118,7 @@ def _ganga_run_exitfuncs():
     atexit._exithandlers = map(add_priority, atexit._exithandlers)
     atexit._exithandlers.sort(priority_cmp)
 
-    logger.info("Stopping running tasks before shutting down Repositories")
+    logger.info("Stopping Job processing before shutting down Repositories")
 
     import inspect
     while atexit._exithandlers:

--- a/python/Ganga/GPIDev/Lib/Tasks/TaskRegistry.py
+++ b/python/Ganga/GPIDev/Lib/Tasks/TaskRegistry.py
@@ -171,9 +171,9 @@ class TaskRegistry(Registry):
     def stop(self):
         if self._main_thread is not None:
             self._main_thread.stop()
-        import time
-        while self._main_thread.isAlive():
-            time.sleep(0.5)
+            import time
+            while self._main_thread.isAlive():
+                time.sleep(0.5)
 
 from Ganga.GPIDev.Lib.Registry.RegistrySlice import RegistrySlice
 

--- a/python/Ganga/GPIDev/Lib/Tasks/TaskRegistry.py
+++ b/python/Ganga/GPIDev/Lib/Tasks/TaskRegistry.py
@@ -166,12 +166,14 @@ class TaskRegistry(Registry):
         self._main_thread.start()
 
     def shutdown(self):
-
         super(TaskRegistry, self).shutdown()
 
     def stop(self):
         if self._main_thread is not None:
             self._main_thread.stop()
+        import time
+        while self._main_thread.isAlive():
+            time.sleep(0.5)
 
 from Ganga.GPIDev.Lib.Registry.RegistrySlice import RegistrySlice
 

--- a/python/Ganga/Runtime/bootstrap.py
+++ b/python/Ganga/Runtime/bootstrap.py
@@ -830,11 +830,8 @@ under certain conditions; type license() for details.
         if 'GANGA_INTERNAL_PROCREEXEC' in os.environ:
             del os.environ['GANGA_INTERNAL_PROCREEXEC']
 
-        logger.debug("Starting Queues")
-        # start queues
-        from Ganga.Runtime.GPIexport import exportToGPI
-        from Ganga.Core.GangaThread.WorkerThreads.ThreadPoolQueueMonitor import ThreadPoolQueueMonitor
-        exportToGPI('queues', ThreadPoolQueueMonitor(), 'Objects')
+        from Ganga.Core.GangaThread.WorkerThreads import startUpQueues
+        startUpQueues()
 
     # bootstrap all system and user-defined runtime modules
     @staticmethod

--- a/python/Ganga/new_tests/GPI/GangaUnitTest.py
+++ b/python/Ganga/new_tests/GPI/GangaUnitTest.py
@@ -40,8 +40,6 @@ def start_ganga(gangadir_for_test='$HOME/gangadir_testing', extra_opts=[]):
         '-o[Configuration]user=testframework',
         '-o[Configuration]gangadir='+str(gangadir_for_test),
         '-o[Configuration]repositorytype=LocalXML',
-        #'-o[PollThread]autostart=False',
-        '-o[PollThread]autostart_monThreads=False',
         '-o[TestingFramework]ReleaseTesting=True',
     ]
 
@@ -84,11 +82,6 @@ def start_ganga(gangadir_for_test='$HOME/gangadir_testing', extra_opts=[]):
     logger.info("Bootstrapping")
     Ganga.Runtime._prog.bootstrap(interactive=False)
 
-    # [PollThread]autostart_monThreads=False has turned this off being done automatically.
-    # The thread pool is emptied by _ganga_run_exitfuncs
-    from Ganga.Core.MonitoringComponent.Local_GangaMC_Service import _makeThreadPool
-    _makeThreadPool()
-
     # Adapted from the Coordinator class, check for the required credentials and stop if not found
     # Hopefully stops us falling over due to no AFS access of something similar
     from Ganga.Core.InternalServices import Coordinator
@@ -98,9 +91,6 @@ def start_ganga(gangadir_for_test='$HOME/gangadir_testing', extra_opts=[]):
 
     if missing_cred:
         raise Exception("Failed due to missing credentials %s" % str(missing_cred))
-
-    from Ganga.GPI import queues
-    queues.unlock()
 
     logger.info("Passing to Unittest")
 


### PR DESCRIPTION
This PR deals with improving the startup/shutdown of the queues system.

All I've done is take the code from Shutdown/bootstrap and move it into a startup/shutdown method within the Queues section of the code which is more inline with how it should be handled.

There is still a check for only 1 running queues system but this should be correctly destroyed on shutdown now.

This means I can remove some custom code from the Shutdown method and cleanup the startup of the queues in the bootstrap as this appears to make use of the existing functionality already available.

As this was primarily to make the shutdown more sane I've also removed some lines from GangaUnitTest which are no-longer needed due to improvements in the shutdown of Ganga.