### PR TITLE
Feature/monitor heartbeat checking

### DIFF
--- a/python/Ganga/Core/MonitoringComponent/Local_GangaMC_Service.py
+++ b/python/Ganga/Core/MonitoringComponent/Local_GangaMC_Service.py
@@ -69,8 +69,8 @@ def checkHeartBeat():
 
         if (latest_timeNow - last_time) > dead_time:
 
-            logger.warning("Thread: %s Has not updated the heartbeat in %ss!! It's possibly dead" %(thread_name, str(dead_time)))
-            logger.warning("Thread is attempting to execute: %s" % this_thread._running_cmd)
+            log.warning("Thread: %s Has not updated the heartbeat in %ss!! It's possibly dead" %(thread_name, str(dead_time)))
+            log.warning("Thread is attempting to execute: %s" % this_thread._running_cmd)
 
 class MonitoringWorkerThread(GangaThread):
 

--- a/python/Ganga/Core/MonitoringComponent/Local_GangaMC_Service.py
+++ b/python/Ganga/Core/MonitoringComponent/Local_GangaMC_Service.py
@@ -28,7 +28,6 @@ log = getLogger()
 
 config = getConfig("PollThread")
 THREAD_POOL_SIZE = config['update_thread_pool_size']
-heartbeat_stall_time = config['HeartBeatTimeOut']
 Qin = Queue.Queue()
 ThreadPool = []
 
@@ -70,7 +69,7 @@ def checkHeartBeat():
 
         last_time = heartbeat_times[thread_name]
 
-        dead_time = heartbeat_stall_time
+        dead_time = config['HeartBeatTimeOut']
 
         if (latest_timeNow - last_time) > dead_time and this_thread.isAlive() and this_thread._currently_running_command is True:
 

--- a/python/Ganga/Core/MonitoringComponent/Local_GangaMC_Service.py
+++ b/python/Ganga/Core/MonitoringComponent/Local_GangaMC_Service.py
@@ -163,6 +163,8 @@ def stop_and_free_thread_pool(fail_cb=None, max_retries=5):
              return resp.lower()=='y'
     """
 
+    global ThreadPool
+
     def join_worker_threads(threads, timeout=3):
         for t in threads:
             if t.isAlive():
@@ -187,6 +189,7 @@ def stop_and_free_thread_pool(fail_cb=None, max_retries=5):
             break
 
     del ThreadPool[:]
+    ThreadPool = []
 
 # purge Qin
 

--- a/python/Ganga/Core/MonitoringComponent/Local_GangaMC_Service.py
+++ b/python/Ganga/Core/MonitoringComponent/Local_GangaMC_Service.py
@@ -22,6 +22,8 @@ from Ganga.Utility.logging import getLogger, log_unknown_exception
 from Ganga.Core import BackendError
 from Ganga.Utility.Config import getConfig
 
+from collections import defaultdict
+
 log = getLogger()
 
 config = getConfig("PollThread")
@@ -29,7 +31,7 @@ THREAD_POOL_SIZE = config['update_thread_pool_size']
 Qin = Queue.Queue()
 ThreadPool = []
 
-heartbeat_times = {}
+heartbeat_times = None
 global_start_time = None
 
 # The JobAction class encapsulates a function, its arguments and its post result action
@@ -52,11 +54,11 @@ class JobAction(object):
         self.description = ''
 
 def getNumAliveThreads():
-    num_alive = 0
+    num_currently_running_command = 0
     for this_thread in ThreadPool:
-        if this_thread._alive:
-            num_alive += 1
-    return num_alive
+        if this_thread._currently_running_command:
+            num_currently_running_command += 1
+    return num_currently_running_command
 
 def checkHeartBeat():
 
@@ -64,14 +66,12 @@ def checkHeartBeat():
 
     for this_thread in ThreadPool:
         thread_name = this_thread._thread_name
-        if heartbeat_times[thread_name] > 0:
-            last_time = heartbeat_times[thread_name]
-        else:
-            last_time = global_start_time
+
+        last_time = heartbeat_times[thread_name]
 
         dead_time = 180.
 
-        if (latest_timeNow - last_time) > dead_time:
+        if (latest_timeNow - last_time) > dead_time and this_thread.isAlive() and this_thread._currently_running_command is True:
 
             log.warning("Thread: %s Has not updated the heartbeat in %ss!! It's possibly dead" %(thread_name, str(dead_time)))
             log.warning("Thread is attempting to execute: %s" % this_thread._running_cmd)
@@ -86,7 +86,6 @@ class MonitoringWorkerThread(GangaThread):
 
     def run(self):
         self._execUpdateAction()
-        heartbeat_times[self._thread_name] = time.time()
 
     # This function takes a JobAction object from the Qin queue,
     # executes the embedded function and runs post result actions.
@@ -98,6 +97,7 @@ class MonitoringWorkerThread(GangaThread):
             log.debug("%s waiting..." % threading.currentThread())
             #setattr(threading.currentThread(), 'action', None)
 
+            heartbeat_times[self._thread_name] = time.time()
 
             while not self.should_stop():
                 try:
@@ -112,7 +112,7 @@ class MonitoringWorkerThread(GangaThread):
             #setattr(threading.currentThread(), 'action', action)
             log.debug("Qin's size is currently: %d" % Qin.qsize())
             log.debug("%s running..." % threading.currentThread())
-            self._alive = True
+            self._currently_running_command = True
             if not isType(action, JobAction):
                 continue
             if action.function == 'stop':
@@ -132,27 +132,34 @@ class MonitoringWorkerThread(GangaThread):
                 else:
                     action.callback_Failure()
 
-            self._alive = False
+            self._currently_running_command = False
 
 # Create the thread pool
 
 
 def _makeThreadPool(threadPoolSize=THREAD_POOL_SIZE, daemonic=True):
-    global ThreadPool, heartbeat_times, global_start_time
+    global ThreadPool, global_start_time, heartbeat_times
     global_start_time = time.time()
     if ThreadPool and len(ThreadPool) != 0:
+
+        for this_thread in ThreadPool:
+            log.error("%s running: %s" % (this_thread._thread_name, this_thread._running_cmd))
+
         #from Ganga.Core.exceptions import GangaException
         #raise GangaException("Cannot doubbly init the ThreadPool! ThreadPool already populated with threads")
         log.error("Found a thread pool already in existance, wiping it and startig again!")
         del ThreadPool[:]
-        del heartbeat_times[:]
         ThreadPool = []
-        heartbeat_times = []
+
+    if heartbeat_times is not None:
+        heartbeat_times = None
+
+    heartbeat_times = defaultdict( lambda: global_start_time )
+
     for i in range(THREAD_POOL_SIZE):
         thread_name = "MonitoringWorker_%s_%s" % (str(i), str(int(time.time()*1000)))
         t = MonitoringWorkerThread(name=thread_name)
         ThreadPool.append(t)
-        heartbeat_times[thread_name] = -1
         t.start()
 
 
@@ -173,6 +180,7 @@ def stop_and_free_thread_pool(fail_cb=None, max_retries=5):
         for t in threads:
             if t.isAlive():
                 t.join(timeout)
+            t.stop()
 
     for i in range(len(ThreadPool)):
         Qin.put(JobAction('stop'))
@@ -213,7 +221,7 @@ def _purge_actions_queue():
         except Queue.Empty:
             break
 
-if config['autostart_monThreads']:
+if config['autostart_monThreads'] is True:
     _makeThreadPool()
 
 
@@ -764,6 +772,7 @@ class JobRegistry_Monitor(GangaThread):
         #if was_enabled:
         #    log.info("Monitoring Loop has stopped")
 
+        _purge_actions_queue()
         stop_and_free_thread_pool(fail_cb, max_retries)
 
         return True
@@ -808,6 +817,7 @@ class JobRegistry_Monitor(GangaThread):
         # wait for all worker threads to finish
         #self.__awaitTermination()
         # join the worker threads
+        _purge_actions_queue()
         stop_and_free_thread_pool(fail_cb, max_retries)
         ###log.info( 'Monitoring component stopped successfully!' )
 

--- a/python/Ganga/__init__.py
+++ b/python/Ganga/__init__.py
@@ -245,6 +245,8 @@ poll_config.addOption('forced_shutdown_prompt_time', 10,
 poll_config.addOption('forced_shutdown_first_prompt_time', 5,
                  "User will get the FIRST prompt after N seconds, as specified by this parameter. This parameter also defines the time that Ganga will wait before shutting down, if there are only non-critical threads alive, in both interactive and batch mode.")
 
+pol_config.addOption('HeartBeatTimeOut', 300, 'Time before the user gets the warning that a thread has locked up due to failing to update the heartbeat attribute')
+
 # ------------------------------------------------
 # Feedback
 feedback_config = makeConfig('Feedback', 'Settings for the Feedback plugin. Cannot be changed ruding the interactive Ganga session.')

--- a/python/Ganga/__init__.py
+++ b/python/Ganga/__init__.py
@@ -245,7 +245,7 @@ poll_config.addOption('forced_shutdown_prompt_time', 10,
 poll_config.addOption('forced_shutdown_first_prompt_time', 5,
                  "User will get the FIRST prompt after N seconds, as specified by this parameter. This parameter also defines the time that Ganga will wait before shutting down, if there are only non-critical threads alive, in both interactive and batch mode.")
 
-pol_config.addOption('HeartBeatTimeOut', 300, 'Time before the user gets the warning that a thread has locked up due to failing to update the heartbeat attribute')
+poll_config.addOption('HeartBeatTimeOut', 300, 'Time before the user gets the warning that a thread has locked up due to failing to update the heartbeat attribute')
 
 # ------------------------------------------------
 # Feedback


### PR DESCRIPTION
This branch attempts to pull out the heartbeat code from #182 as it's likely that this branch could be superseded by other code due to work performed elsewhere.

This PR includes the code to inform the user if a worker thread is working and has been performing the same task for > 3min.
This 3min is currently not user configurable and is hard-coded as 180.

This PR also includes some very minor changes to improve the shutdown of the Monitoring loop at the end of it's life and some minor changes relating to the construction/teardown of the thread-pool which effects the GangaUnitTests derived tests as well as elsewhere.

This has already been discussed for inclusion in 6.1.16.