### PR TITLE
Fixes for GangaUnitTest

### DIFF
--- a/python/Ganga/Core/GangaThread/WorkerThreads/ThreadPoolQueueMonitor.py
+++ b/python/Ganga/Core/GangaThread/WorkerThreads/ThreadPoolQueueMonitor.py
@@ -19,10 +19,12 @@ class ThreadPoolQueueMonitor(object):
     the getConfig('Queues')['NumWorkerThreads'] config option.
     '''
 
-    def __init__(self,
-                 user_threadpool=WorkerThreadPool(
-                     worker_thread_prefix="User_Worker_"),
-                 monitoring_threadpool=WorkerThreadPool(worker_thread_prefix="Ganga_Worker_")):
+    def __init__(self, user_threadpool=None, monitoring_threadpool=None):
+
+        if user_threadpool is None:
+            user_threadpool = WorkerThreadPool(worker_thread_prefix="User_Worker_")
+        if monitoring_threadpool is None:
+            monitoring_threadpool = WorkerThreadPool(worker_thread_prefix="Ganga_Worker_")
 
         global _user_threadpool
         global _monitoring_threadpool

--- a/python/Ganga/Core/GangaThread/WorkerThreads/WorkerThreadPool.py
+++ b/python/Ganga/Core/GangaThread/WorkerThreads/WorkerThreadPool.py
@@ -24,9 +24,9 @@ class WorkerThreadPool(object):
     __slots__ = ['__queue', '__worker_threads',
                  '_saved_num_worker', '_saved_thread_prefix', '_locked', '_shutdown']
 
-    def __init__(self,
-                 num_worker_threads=getConfig('Queues')['NumWorkerThreads'],
-                 worker_thread_prefix='Worker_'):
+    def __init__(self, num_worker_threads=None, worker_thread_prefix='Worker_'):
+        if num_worker_threads is None:
+            num_worker_threads=getConfig('Queues')['NumWorkerThreads']
         self.__queue = Queue.PriorityQueue()
         self.__worker_threads = []
 

--- a/python/Ganga/Core/GangaThread/WorkerThreads/__init__.py
+++ b/python/Ganga/Core/GangaThread/WorkerThreads/__init__.py
@@ -14,7 +14,7 @@ def startUpQueues():
         exportToGPI('queues', _global_queues, 'Objects')
 
         import atexit
-        atexit.register((-10., shutDownQueues), ())
+        atexit.register((-10., shutDownQueues))
 
     else:
         logger.error("Cannot Start queues if they've already started")

--- a/python/Ganga/new_tests/GPI/GangaUnitTest.py
+++ b/python/Ganga/new_tests/GPI/GangaUnitTest.py
@@ -179,7 +179,7 @@ class GangaUnitTest(unittest.TestCase):
         # This is called before each unittest
         if gangadir is None:
             import os
-            gangadir = os.path.join('$HOME/gangadir_testing', self.__class__.__name__)
+            gangadir = os.path.join('$HOME/gangadir_testing')  # TODO make separate dirs per test suite, `self.__class__.__name__`
             gangadir = os.path.expanduser(os.path.expandvars(gangadir))
             if not os.path.isdir(gangadir):
                 os.makedirs(gangadir)
@@ -204,7 +204,7 @@ class GangaUnitTest(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        if cls.wipe_repo is True:
+        if cls.wipe_repo:
             import shutil
             shutil.rmtree(cls.gangadir, ignore_errors=True)
 

--- a/python/Ganga/new_tests/GPI/GangaUnitTest.py
+++ b/python/Ganga/new_tests/GPI/GangaUnitTest.py
@@ -192,9 +192,6 @@ class GangaUnitTest(unittest.TestCase):
         self.__class__.wipe_repo = self.wipe_repo
         start_ganga(gangadir_for_test=gangadir, extra_opts=extra_opts)
 
-        from Ganga.GPI import config
-        print('gangadir', config['Configuration'].gangadir)
-
     def tearDown(self):
         unittest.TestCase.tearDown(self)
         # Stop ganga and mimick an exit to shutdown all internal processes

--- a/python/Ganga/new_tests/GPI/GangaUnitTest.py
+++ b/python/Ganga/new_tests/GPI/GangaUnitTest.py
@@ -79,6 +79,10 @@ def start_ganga(gangadir_for_test='$HOME/gangadir_testing', extra_opts=[]):
         else:
             logger.info("InternalServices still running")
 
+        # The queues are shut down by the atexit handlers so we need to start them here
+        from Ganga.Core.GangaThread.WorkerThreads import startUpQueues
+        startUpQueues()
+
     logger.info("Bootstrapping")
     Ganga.Runtime._prog.bootstrap(interactive=False)
 


### PR DESCRIPTION
In the process of fixing the registry lock-ups I've come across some bugs in the test suite which prevents the tests from running correctly. This primarily affects the queues starting and shutting down correctly but also makes the per-test config system work properly. These are all needed in order to run the `TestQueuedSubmit` test which will be incoming.

This will need to go in before I can merge my registry fixes as it allows the test to run correctly.