### PR TITLE
Fix registry deadlocks

### DIFF
--- a/python/Ganga/Core/GangaRepository/Registry.py
+++ b/python/Ganga/Core/GangaRepository/Registry.py
@@ -244,44 +244,13 @@ class Registry(object):
             Raise RegistryKeyError"""
         logger.debug("__getitem__")
         try:
-            self.lock_transaction( this_id, "_getitem")
-
-            real_id = None
-            if type(this_id) is int:
-                if this_id >= 0:
-                    ## +ve integer, should be in dictionary
-                    real_id = this_id
-                    this_obj = self._objects[this_id]
-                else:
-                    ## -ve integer should be a relative object in dictionary
-                    real_id = self._objects.keys()[this_id]
-                    this_obj = self._objects[real_id]
-            else:
-                ## NOT an integer, maybe it's a slice or other?
-                this_obj = self._objects[this_id]
-
-            logger.debug("found_object")
-
-            found_id = None
-            if hasattr(this_obj, _id_str):
-                found_id = getattr(this_obj, _id_str)
-            if hasattr(this_obj, _reg_id_str):
-                found_id = getattr(this_obj, _reg_id_str)
-            if found_id is not None and real_id is not None:
-                assert( found_id == real_id )
-
-            logger.debug("Checked ID")
-
-            return this_obj
-
+            return self._objects[this_id]
         except KeyError as err:
-            logger.debug("Repo KeyError: %s" % str(err))
-            logger.debug("Keys: %s id: %s" % (str(self._objects.keys()), str(this_id)))
+            logger.debug("Repo KeyError: %s" % err)
+            logger.debug("Keys: %s id: %s" % (self._objects.keys(), this_id))
             if this_id in self._incomplete_objects:
                 return IncompleteObject(self, this_id)
             raise RegistryKeyError("Could not find object #%s" % this_id)
-        finally:
-            self.unlock_transaction(this_id)
 
     @synchronised
     def __len__(self):

--- a/python/Ganga/Core/GangaRepository/Registry.py
+++ b/python/Ganga/Core/GangaRepository/Registry.py
@@ -612,20 +612,6 @@ class Registry(object):
 
             self.unlock_transaction(obj_id)
 
-    def _backgroundFlush(self, _objs=None):
-
-        if _objs is not None:
-            objs = [stripProxy(obj) for obj in _objs]
-        else:
-            objs = [obj for obj in self.dirty_objs.itervalues()]
-
-        if False:
-            thread = threading.Thread(target=self._flush, args=())
-            thread.daemon = True
-            thread.run()
-        else:
-            self._flush(objs)
-
     @synchronised
     def _flush(self, objs):
         """

--- a/python/Ganga/Core/GangaRepository/Registry.py
+++ b/python/Ganga/Core/GangaRepository/Registry.py
@@ -296,8 +296,6 @@ class Registry(object):
 
     def turnOnAutoFlushing(self):
         self._autoFlush = True
-        if self.checkShouldFlush():
-            self._backgroundFlush()
 
     def isAutoFlushEnabled(self):
         return self._autoFlush
@@ -354,7 +352,6 @@ class Registry(object):
         returnable = self._objects
         return returnable
 
-    @synchronised
     def ids(self):
         """ Returns the list of ids of this registry """
         logger.debug("ids")

--- a/python/Ganga/Core/GangaRepository/Registry.py
+++ b/python/Ganga/Core/GangaRepository/Registry.py
@@ -236,7 +236,6 @@ class Registry(object):
         self.hard_lock[this_id].release()
 
     # Methods intended to be called from ''outside code''
-    @synchronised
     def __getitem__(self, this_id):
         """ Returns the Ganga Object with the given id.
             Raise RegistryKeyError"""
@@ -352,6 +351,7 @@ class Registry(object):
         returnable = self._objects
         return returnable
 
+    @synchronised
     def ids(self):
         """ Returns the list of ids of this registry """
         logger.debug("ids")
@@ -406,12 +406,14 @@ class Registry(object):
                 raise
         return
 
+    @synchronised
     def keys(self):
         """ Returns the list of ids of this registry """
         logger.debug("keys")
         returnable = self.ids()
         return returnable
 
+    @synchronised
     def values(self):
         """ Return the objects in this registry, in order of ID.
         Besides items() this is also recommended for iteration."""
@@ -424,7 +426,6 @@ class Registry(object):
         returnable = iter(self.values())
         return returnable
 
-    @synchronised
     def find(self, _obj):
         """Returns the id of the given object in this registry, or 
         Raise ObjectNotInRegistryError if the Object is not found"""

--- a/python/Ganga/Core/GangaRepository/Registry.py
+++ b/python/Ganga/Core/GangaRepository/Registry.py
@@ -678,7 +678,7 @@ class Registry(object):
         finally:
             self._lock.release()
 
-    @synchronised_nonblocking
+    @synchronised
     def _flush(self, objs):
         """
         Flush a set of objects to the persistency layer immediately

--- a/python/Ganga/Core/GangaRepository/Registry.py
+++ b/python/Ganga/Core/GangaRepository/Registry.py
@@ -792,9 +792,8 @@ class Registry(object):
     def __write_access(self, _obj):
         logger.debug("__write_acess")
         obj = stripProxy(_obj)
-
-        if id(obj) in self._inprogressDict.keys():
-            this_id = self.find(obj)
+        this_id = self.find(obj)
+        if this_id in self._inprogressDict.keys():
             for this_d in self.changed_ids.itervalues():
                 this_d.add(this_id)
             return

--- a/python/Ganga/Core/GangaRepository/Registry.py
+++ b/python/Ganga/Core/GangaRepository/Registry.py
@@ -635,6 +635,7 @@ class Registry(object):
 
         for obj in objs:
             with obj.lock:
+                obj._getWriteAccess()
                 obj_id = getattr(obj, _reg_id_str)
                 if not obj._dirty:
                     continue

--- a/python/Ganga/Core/GangaRepository/Registry.py
+++ b/python/Ganga/Core/GangaRepository/Registry.py
@@ -707,6 +707,14 @@ class Registry(object):
                 self.repository.flush([obj_id])
                 self.repository.unlock([obj_id])
 
+    @synchronised
+    def flush_all(self):
+        """
+        This will attempt to flush all the jobs in the registry.
+        It does this via ``_flush`` so the same conditions apply.
+        """
+        if self.hasStarted():
+            self._flush(self.values())
 
     def _read_access(self, _obj, sub_obj=None):
         """Obtain read access on a given object.
@@ -988,7 +996,7 @@ class Registry(object):
             try:
                 if not self.metadata is None:
                     try:
-                        self._flush()
+                        self.flush_all()
                     except Exception, err:
                         logger.debug("shutdown _flush Exception: %s" % str(err))
                     self.metadata.shutdown()
@@ -997,7 +1005,7 @@ class Registry(object):
             #finally:
             #    pass
             try:
-                self._flush()
+                self.flush_all()
             except Exception as err:
                 logger.error("Exception on flushing '%s' registry: %s", self.name, str(err))
                 #raise err

--- a/python/Ganga/Core/GangaRepository/SessionLock.py
+++ b/python/Ganga/Core/GangaRepository/SessionLock.py
@@ -6,6 +6,9 @@
 
 from __future__ import print_function
 
+import functools
+import threading
+
 import os
 import time
 import errno
@@ -295,6 +298,14 @@ class SessionLockRefresher(GangaThread):
         assert(len(self.fns) == len(self.repos))
 
 
+def synchronised(f):
+    @functools.wraps(f)
+    def decorated(self, *args, **kwargs):
+        with self._lock:
+            return f(self, *args, **kwargs)
+    return decorated
+
+
 class SessionLockManager(object):
 
     """ Class with thread that keeps a global lock file that synchronizes
@@ -349,6 +360,7 @@ class SessionLockManager(object):
         self.name = name
         self.realpath = realpath
         #logger.debug( "Initializing SessionLockManager: " + self.fn )
+        self._lock = threading.RLock()
 
     @staticmethod
     def delay_init_open(filename):
@@ -364,6 +376,7 @@ class SessionLockManager(object):
                 i += 1
         return value
 
+    @synchronised
     def startup(self):
         # Ensure directories exist
         self.mkdir(os.path.join(self.realpath, "sessions"))
@@ -414,6 +427,7 @@ class SessionLockManager(object):
         global session_lock_refresher
         session_lock_refresher.updateNow()
 
+    @synchronised
     def shutdown(self):
         """Shutdown the thread and locking system (on ganga shutdown or repo error)"""
         #logger.debug( "Shutting Down SessionLockManager, self.fn = %s" % (self.fn) )
@@ -455,6 +469,7 @@ class SessionLockManager(object):
         return value
 
     # Global lock function
+    @synchronised
     def global_lock_setup(self):
 
         if self.afs:
@@ -552,6 +567,7 @@ class SessionLockManager(object):
         except IOError as x:
             raise RepositoryError(self.repo, "IOError on unlock ('%s'): %s" % (self.lockfn, x))
 
+    @synchronised
     def delay_session_open(self, filename):
         value = None
         i = 0
@@ -568,6 +584,7 @@ class SessionLockManager(object):
         return value
 
     # Session read-write functions
+    @synchronised
     def session_read(self, fn):
         """ Reads a session file and returns a set of IDs locked by that session.
             The global lock MUST be held for this function to work, although on NFS additional
@@ -598,6 +615,7 @@ class SessionLockManager(object):
     # This function attempts to grab the ctime from a file which should exist
     # As we don't want this to fail outright it attempts to re-read every 1s
     # for 30sec before failing
+    @synchronised
     def delayopen(self, filename):
         value = None
         i = 0
@@ -619,6 +637,7 @@ class SessionLockManager(object):
     # This function attempts to grab the ctime from a file which should exist
     # As we don't want this to fail outright it attempts to re-read every 1s
     # for 30sec before failing
+    @synchronised
     def delaywrite(self, filename, data):
         value = None
         i = 0
@@ -637,6 +656,7 @@ class SessionLockManager(object):
 
         return value
 
+    @synchronised
     def session_write(self):
         """ Writes the locked set to the session file. 
             The global lock MUST be held for this function to work, although on NFS additional
@@ -715,6 +735,7 @@ class SessionLockManager(object):
             raise RepositoryError(
                 self.repo, "Locking error on count file '%s' write: %s" % (self.cntfn, x))
 
+    @synchronised
     def cnt_write(self):
         """ Writes the counter to the counter file. 
             The global lock MUST be held for this function to work correctly
@@ -750,6 +771,7 @@ class SessionLockManager(object):
                     last_count_access[1] = self.count
 
     # "User" functions
+    @synchronised
     def make_new_ids(self, n):
         """ Locks the next n available ids and returns them as a list 
             Raise RepositoryError on fatal error"""
@@ -795,6 +817,7 @@ class SessionLockManager(object):
                 # self.reap_locks()
                 pass
 
+    @synchronised
     def lock_ids(self, ids):
 
         self.safe_LockCheck()
@@ -826,6 +849,7 @@ class SessionLockManager(object):
         finally:
             self.global_lock_release()
 
+    @synchronised
     def release_ids(self, ids):
         #logger.debug( "releasing : %s" % str(ids) )
         self.global_lock_acquire()
@@ -837,6 +861,7 @@ class SessionLockManager(object):
         finally:
             self.global_lock_release()
 
+    @synchronised
     def check(self):
         self.global_lock_acquire()
         try:
@@ -874,6 +899,7 @@ class SessionLockManager(object):
         finally:
             self.global_lock_release()
 
+    @synchronised
     def get_lock_session(self, id):
         """get_lock_session(id)
         Tries to determine the session that holds the lock on id for information purposes, and return an informative string.
@@ -905,6 +931,7 @@ class SessionLockManager(object):
         finally:
             self.global_lock_release()
 
+    @synchronised
     def get_other_sessions(self):
         """get_session_list()
         Tries to determine the other sessions that are active and returns an informative string for each of them.
@@ -917,6 +944,7 @@ class SessionLockManager(object):
         finally:
             self.global_lock_release()
 
+    @synchronised
     def reap_locks(self):
         """reap_locks() --> True/False
         Remotely clear all foreign locks from the session.

--- a/python/Ganga/Core/GangaRepository/SessionLock.py
+++ b/python/Ganga/Core/GangaRepository/SessionLock.py
@@ -361,9 +361,7 @@ class SessionLockManager(object):
                 time.sleep(0.1)
                 if i >= 60:
                     raise x
-                else:
-                    continue
-            i = i + 1
+                i += 1
         return value
 
     def startup(self):

--- a/python/Ganga/GPIDev/Base/Objects.py
+++ b/python/Ganga/GPIDev/Base/Objects.py
@@ -183,6 +183,7 @@ class Node(object):
                 return None
 
     # accept a visitor pattern
+    @synchronised
     def accept(self, visitor):
 
         if not hasattr(self, '_schema'):
@@ -908,10 +909,6 @@ class GangaObject(Node):
             self_copy._setParent(true_parent)
         return self_copy
 
-    def accept(self, visitor):
-        self._getReadAccess()
-        super(GangaObject, self).accept(visitor)
-
     def _getIOTimeOut(self):
         from Ganga.Utility.Config.Config import getConfig, ConfigError
         try:
@@ -1006,8 +1003,6 @@ class GangaObject(Node):
         parent = self._getParent()
         if parent is not None:
             parent._setDirty()
-        if self._registry is not None:
-            self._registry._dirty(self)
 
     def _setFlushed(self):
         self._dirty = False

--- a/python/Ganga/GPIDev/Lib/Job/Job.py
+++ b/python/Ganga/GPIDev/Lib/Job/Job.py
@@ -634,8 +634,8 @@ class Job(GangaObject):
 
         if self.status != saved_status and self.master is None:
             logger.info('job %s status changed to "%s"', self.getFQID('.'), self.status)
-            if stripProxy(self)._getRegistry() is not None:
-                stripProxy(self)._getRegistry()._dirty(stripProxy(self)._getRoot())
+            self._setDirty()
+            # TODO try to force a flush here maybe?
         if update_master and self.master is not None:
             self.master.updateMasterJobStatus()
 

--- a/python/Ganga/GPIDev/Lib/Registry/PrepRegistry.py
+++ b/python/Ganga/GPIDev/Lib/Registry/PrepRegistry.py
@@ -72,7 +72,7 @@ class PrepRegistry(Registry):
         except Exception as x:
             logger.error("Exception on shutting down metadata repository '%s' registry: %s", self.name, x)
         try:
-            self._flush()
+            self.flush_all()
         except Exception as x:
             logger.error("Exception on flushing '%s' registry: %s", self.name, x)
         #self._hasStarted = False

--- a/python/Ganga/Runtime/Repository_runtime.py
+++ b/python/Ganga/Runtime/Repository_runtime.py
@@ -186,7 +186,7 @@ def flush_all():
         try:
             if registry.hasStarted() is True:
                 logger.debug("Flushing: %s" % thisName)
-                registry._flush()
+                registry.flush_all()
         except Exception as err:
             logger.debug("Failed to flush: %s" % str(thisName))
             logger.debug("Err: %s" % str(err))

--- a/python/Ganga/new_tests/GPI/Parallel/TestQueuedSubmit.py
+++ b/python/Ganga/new_tests/GPI/Parallel/TestQueuedSubmit.py
@@ -1,0 +1,81 @@
+from __future__ import absolute_import, print_function
+
+from ..GangaUnitTest import GangaUnitTest
+
+import time
+
+global_num_threads = 20
+global_num_jobs = global_num_threads*5
+
+
+class TestQueuedSubmit(GangaUnitTest):
+
+    def setUp(self):
+        extra_opts = [('Queues', 'NumWorkerThreads', global_num_threads)]
+        super(TestQueuedSubmit, self).setUp(extra_opts=extra_opts)
+        from Ganga.Utility.Config import setConfigOption
+        setConfigOption('TestingFramework', 'AutoCleanup', 'False')
+
+    def test_a_TestNumThreads(self):
+        from Ganga.GPI import queues
+        num_threads = len(queues._user_threadpool.worker_status())
+        print("num_threads: %s" % num_threads)
+        assert num_threads == global_num_threads
+
+    def test_b_SetupJobs(self):
+        from Ganga.GPI import Job, jobs, Executable
+
+        # Just in-case, I know this shouldn't be here, but if the repo gets polluted this is a sane fix
+        for j in jobs:
+            try:
+                j.remove()
+            except:
+                pass
+
+        for i in range(global_num_jobs):
+            print('creating job', end=' ')
+            j = Job()
+            print(j.id)
+
+        print('job len:', len(jobs))
+
+        assert len(jobs) == global_num_jobs
+
+    def test_c_QueueSubmits(self):
+        from Ganga.GPI import jobs, queues
+
+        for j in jobs:
+            print('adding job', j.id, 'to queue for submission')
+            queues.add(j.submit)
+
+        while queues.totalNumUserThreads() > 0:
+            print('remaining threads:', queues.totalNumUserThreads())
+            time.sleep(1)
+
+        print('remaining threads:', queues.totalNumUserThreads())
+
+        # All user threads should have terminated by now
+        for j in jobs:
+            print('checking job', j.id)
+            assert j.status != 'new'
+
+    def test_d_Finished(self):
+        from Ganga.GPI import jobs, queues
+        from GangaTest.Framework.utils import sleep_until_completed
+
+        print('waiting on job', end=' ')
+        for j in jobs:
+            print(j.id, end=' ')
+            import sys
+            sys.stdout.flush()
+            assert sleep_until_completed(j), 'Timeout on job submission: job is still not finished'
+            assert j.status == 'completed'
+
+    def test_e_Cleanup(self):
+        from Ganga.GPI import jobs
+
+        for j in jobs:
+            try:
+                j.remove()
+            except:
+                pass


### PR DESCRIPTION
This branch attempts to fix the various deadlocks surrounding the registry. It makes quite a few changes to the registry so it might be easier for some of them to go through commit-by-commit since they are logically grouped there,

Mostly this is making sure that the registry locks are all exception-safe as well as some simplification surrounding the flushing to avoid common deadlocks there. Overall this branch will be flushing to disk less often than before but it should still always be flushing everything on shutdown. I have a WIP for an auto-flushing thread for each registry but that will have to wait for another PR.