### PR TITLE
Restoring the use of proxyObject, now much cleaner

### DIFF
--- a/python/Ganga/GPIDev/Base/Objects.py
+++ b/python/Ganga/GPIDev/Base/Objects.py
@@ -41,7 +41,7 @@ logger = Ganga.Utility.logging.getLogger(modulename=1)
 
 _imported_GangaList = None
 
-do_not_copy = ['_index_cache', '_parent', '_registry', '_data', '_lock']
+do_not_copy = ['_index_cache', '_parent', '_registry', '_data', '_lock', '_proxyObject']
 
 def _getGangaList():
     global _imported_GangaList

--- a/python/Ganga/GPIDev/Base/Proxy.py
+++ b/python/Ganga/GPIDev/Base/Proxy.py
@@ -608,7 +608,7 @@ def GPIProxyObjectFactory(_obj):
     Returns:
         a proxy object
     """
-    if hasattr(_obj, proxyObject)
+    if hasattr(_obj, proxyObject):
         return getattr(_obj, proxyObject)
     if not isType(_obj, GangaObject):
         from Ganga.Core.exceptions import GangaException

--- a/python/Ganga/GPIDev/Base/Proxy.py
+++ b/python/Ganga/GPIDev/Base/Proxy.py
@@ -21,6 +21,7 @@ import types
 
 implRef = '_impl'
 proxyClass = '_proxyClass'
+proxyObject = '_proxyObject'
 
 prepconfig = getConfig('Preparable')
 
@@ -198,8 +199,12 @@ def stripProxy(obj):
 
 def addProxy(obj):
     """Adds a proxy to a GangaObject"""
-    if isType(obj, GangaObject) and not isProxy(obj):
-        return GPIProxyObjectFactory(obj)
+    if isType(obj, GangaObject)
+        if not isProxy(obj):
+            if hasattr(obj, proxyObject):
+                return getattr(obj, proxyObject)
+            else:
+                return GPIProxyObjectFactory(obj)
     return obj
 
 
@@ -603,6 +608,8 @@ def GPIProxyObjectFactory(_obj):
     Returns:
         a proxy object
     """
+    if hasattr(_obj, proxyObject)
+        return getattr(_obj, proxyObject)
     if not isType(_obj, GangaObject):
         from Ganga.Core.exceptions import GangaException
         raise GangaException("%s is NOT a Proxyable object" % type(_obj))
@@ -612,6 +619,9 @@ def GPIProxyObjectFactory(_obj):
     proxy_class = getProxyClass(obj_class)
 
     proxy_object = proxy_class(_proxy_impl_obj_to_wrap=_obj)
+
+    setattr(_obj, proxyObject, proxy_object)
+
     return proxy_object
 
 # this class serves only as a 'tag' for all generated GPI proxy classes

--- a/python/Ganga/GPIDev/Base/Proxy.py
+++ b/python/Ganga/GPIDev/Base/Proxy.py
@@ -199,7 +199,7 @@ def stripProxy(obj):
 
 def addProxy(obj):
     """Adds a proxy to a GangaObject"""
-    if isType(obj, GangaObject)
+    if isType(obj, GangaObject):
         if not isProxy(obj):
             if hasattr(obj, proxyObject):
                 return getattr(obj, proxyObject)

--- a/python/Ganga/GPIDev/Base/Proxy.py
+++ b/python/Ganga/GPIDev/Base/Proxy.py
@@ -678,6 +678,7 @@ def GPIProxyClassFactory(name, pluginclass):
 
         ## Avoid intercepting any of the setter method associated with the implRef as they could trigger loading from disk
         setattr(self, implRef, instance)
+        instance.__dict__[proxyObject] = self
 
         ## Need to avoid any setter methods for GangaObjects
         ## Would be very nice to remove this entirely as I'm not sure a GangaObject should worry about it's proxy (if any)


### PR DESCRIPTION
This should address #213.

I would call this a bugfix based upon the example of the discussion I give in the issue above.

As for whether this is included in 6.1.16 of 6.1.17 I leave that for others to decide.