### PR TITLE
Make Job copy work correctly

### DIFF
--- a/python/Ganga/GPIDev/Base/Objects.py
+++ b/python/Ganga/GPIDev/Base/Objects.py
@@ -209,9 +209,6 @@ class Node(object):
 
         visitor.nodeEnd(self)
 
-    def __copy__(self):
-        copied_obj = self.clone()
-
     # clone self and return a properly initialized object
     def clone(self):
         new_obj = deepcopy(self)

--- a/python/Ganga/GPIDev/Base/Objects.py
+++ b/python/Ganga/GPIDev/Base/Objects.py
@@ -105,7 +105,8 @@ class Node(object):
             else:
                 this_dict[elem] = None
         #obj.__setstate__(this_dict)
-        obj.getParent(self._getParent())
+        if self._getParent() is not None:
+            obj._setParent(self._getParent())
         setattr(obj, '_index_cache', {})
         setattr(obj, '_registry', self._registry)
         return obj

--- a/python/Ganga/GPIDev/Base/Objects.py
+++ b/python/Ganga/GPIDev/Base/Objects.py
@@ -105,8 +105,7 @@ class Node(object):
             else:
                 this_dict[elem] = None
         #obj.__setstate__(this_dict)
-        if self._getParent() is not None:
-            obj._setParent(self._getParent())
+        obj._setParent(self._getParent())
         setattr(obj, '_index_cache', {})
         setattr(obj, '_registry', self._registry)
         return obj

--- a/python/Ganga/GPIDev/Lib/Job/Job.py
+++ b/python/Ganga/GPIDev/Lib/Job/Job.py
@@ -310,7 +310,7 @@ class Job(GangaObject):
         stripProxy(c.time).newjob()
         c.backend = copy.deepcopy(self.backend)
         c.application = copy.deepcopy(self.application)
-        c.inputdata = copy.copy(self.inputdata)
+        c.inputdata = copy.deepcopy(self.inputdata)
         c.name = self.name
         c.comment = self.comment
         c.postprocessors = copy.deepcopy(self.postprocessors)

--- a/python/Ganga/new_tests/GPI/TestJob.py
+++ b/python/Ganga/new_tests/GPI/TestJob.py
@@ -10,3 +10,94 @@ class TestJob(GangaUnitTest):
         from Ganga.GPI import Job
         j = Job()
         j.submit()
+
+    def testJobAssignment(self):
+        """Test assignment of all job properties"""
+        from Ganga.GPI import Job, ARC, GenericSplitter, GangaDataset, LocalFile, FileChecker
+        from Ganga.GPIDev.Base.Proxy import isType
+
+        j = Job()
+        j.application.exe = "sleep"
+        j.application.args = ['myarg']
+        j.backend = ARC()
+        j.backend.CE = "my.ce"
+        j.inputdata = GangaDataset()
+        j.inputdata.files = [ LocalFile("*.txt") ]
+        j.inputfiles = [ LocalFile("*.txt") ]
+        j.name = "testname"
+        j.outputfiles = [ LocalFile("*.txt") ]
+        j.postprocessors = FileChecker(files=['stdout'], searchStrings = ['my search'])
+        j.splitter = GenericSplitter()
+        j.splitter.attribute = "application.args"
+        j.splitter.values = ['arg 1', 'arg 2', 'arg 3']
+
+        # test all the assignments
+        self.assertTrue( isType(j, Job) )
+        self.assertEqual( j.application.exe, "sleep" )
+        self.assertEqual( j.application.args, ["myarg"] )
+        self.assertTrue( isType(j.backend, ARC) )
+        self.assertEqual( j.backend.CE, "my.ce" )
+        self.assertTrue( isType(j.inputdata, GangaDataset) )
+        self.assertEqual( len(j.inputdata.files), 1 )
+        self.assertTrue( isType(j.inputdata.files[0], LocalFile) )
+        self.assertEqual( j.inputdata.files[0].namePattern, "*.txt" )
+        self.assertEqual( len(j.inputfiles), 1 )
+        self.assertTrue( isType(j.inputfiles[0], LocalFile) )
+        self.assertEqual( j.inputfiles[0].namePattern, "*.txt" )
+        self.assertEqual( j.name, "testname" )
+        self.assertEqual( len(j.outputfiles), 1 )
+        self.assertTrue( isType(j.outputfiles[0], LocalFile) )
+        self.assertEqual( j.outputfiles[0].namePattern, "*.txt" )
+        self.assertEqual( len(j.postprocessors), 1 )
+        self.assertTrue( isType(j.postprocessors[0], FileChecker) )
+        self.assertEqual( j.postprocessors[0].files, ["stdout"] )
+        self.assertEqual( j.postprocessors[0].searchStrings, ["my search"] )
+        self.assertTrue( isType(j.splitter, GenericSplitter) )
+        self.assertEqual( j.splitter.attribute, "application.args" )
+        self.assertEqual( j.splitter.values, ['arg 1', 'arg 2', 'arg 3'])
+
+    def testJobCopy(self):
+        """Test that a job copy copies everything properly"""
+        from Ganga.GPI import Job, ARC, GenericSplitter, GangaDataset, LocalFile, FileChecker
+        from Ganga.GPIDev.Base.Proxy import isType
+
+        j = Job()
+        j.application.exe = "sleep"
+        j.application.args = ['myarg']
+        j.backend = ARC()
+        j.backend.CE = "my.ce"
+        j.inputdata = GangaDataset()
+        j.inputdata.files = [ LocalFile("*.txt") ]
+        j.inputfiles = [ LocalFile("*.txt") ]
+        j.name = "testname"
+        j.outputfiles = [ LocalFile("*.txt") ]
+        j.postprocessors = FileChecker(files=['stdout'], searchStrings = ['my search'])
+        j.splitter = GenericSplitter()
+        j.splitter.attribute = "application.args"
+        j.splitter.values = ['arg 1', 'arg 2', 'arg 3']
+        j2 = j.copy()
+
+        # test the copy has worked
+        self.assertTrue( isType(j2, Job) )
+        self.assertEqual( j2.application.exe, "sleep" )
+        self.assertEqual( j2.application.args, ["myarg"] )
+        self.assertTrue( isType(j2.backend, ARC) )
+        self.assertEqual( j2.backend.CE, "my.ce" )
+        self.assertTrue( isType(j2.inputdata, GangaDataset) )
+        self.assertEqual( len(j2.inputdata.files), 1 )
+        self.assertTrue( isType(j2.inputdata.files[0], LocalFile) )
+        self.assertEqual( j2.inputdata.files[0].namePattern, "*.txt" )
+        self.assertEqual( len(j2.inputfiles), 1 )
+        self.assertTrue( isType(j2.inputfiles[0], LocalFile) )
+        self.assertEqual( j2.inputfiles[0].namePattern, "*.txt" )
+        self.assertEqual( j2.name, "testname" )
+        self.assertEqual( len(j2.outputfiles), 1 )
+        self.assertTrue( isType(j2.outputfiles[0], LocalFile) )
+        self.assertEqual( j2.outputfiles[0].namePattern, "*.txt" )
+        self.assertEqual( len(j2.postprocessors), 1 )
+        self.assertTrue( isType(j2.postprocessors[0], FileChecker) )
+        self.assertEqual( j2.postprocessors[0].files, ["stdout"] )
+        self.assertEqual( j2.postprocessors[0].searchStrings, ["my search"] )
+        self.assertTrue( isType(j2.splitter, GenericSplitter) )
+        self.assertEqual( j2.splitter.attribute, "application.args" )
+        self.assertEqual( j2.splitter.values, ['arg 1', 'arg 2', 'arg 3'])


### PR DESCRIPTION
Cleans up the `__copy__` methods and uses a `deepcopy` for j.inputdata. Also added a test for job assignment and copy that fails on develop and passes here. Fixes #216.