### PR TITLE
Bugfix/tests fix for exportToGPI

### DIFF
--- a/python/Ganga/Core/GangaThread/GangaThreadPool.py
+++ b/python/Ganga/Core/GangaThread/GangaThreadPool.py
@@ -81,9 +81,6 @@ class GangaThreadPool(object):
 
     def _really_shutdown(self, should_wait_cb=None):
 
-        #from Ganga.GPI import queues
-        #queues._stop_all_threads(shutdown=True)
-
         from Ganga.Utility.logging import getLogger
         logger = getLogger('GangaThread')
 
@@ -156,18 +153,16 @@ class GangaThreadPool(object):
         from Ganga.Utility.logging import getLogger
         logger = getLogger('GangaThread')
 
-        from Ganga.GPI import queues
+        try:
+            from Ganga.GPI import queues
+        except ImportError:
+            from Ganga.Core.GangaThread.WorkerThreads import _global_queues as queues
 
-        queues._purge_all()
-        queues._stop_all_threads(shutdown=True)
+        if queues is not None:
+            queues._purge_all()
+            queues._stop_all_threads(shutdown=True)
 
-        # while queues.totalNumAllThreads() != 0:
-        #    queues._stop_all_threads()
-        #    logger.warning( "Tasks still running: %s" % queues.threadStatus() )
-        #    import time
-        #    time.sleep( 0.1 )
-
-        logger.debug("ExternalTasks still running: %s" % queues.threadStatus())
+            logger.debug("ExternalQueues still running: %s" % queues.threadStatus())
 
         logger.debug('Service threads to shutdown: %s' % ([i for i in reversed(list(_all_threads))]))
 

--- a/python/Ganga/Core/GangaThread/WorkerThreads/__init__.py
+++ b/python/Ganga/Core/GangaThread/WorkerThreads/__init__.py
@@ -28,5 +28,7 @@ def shutDownQueues():
     _global_queues._purge_all()
     del _global_queues
     _global_queues = None
+    import Ganga.GPI
+    delattr(Ganga.GPI, 'queues')
 
 

--- a/python/Ganga/Core/GangaThread/WorkerThreads/__init__.py
+++ b/python/Ganga/Core/GangaThread/WorkerThreads/__init__.py
@@ -14,7 +14,7 @@ def startUpQueues():
         exportToGPI('queues', _global_queues, 'Objects')
 
         import atexit
-        atexit.register((-10., shutDownQueues))
+        atexit.register((100, shutDownQueues))
 
     else:
         logger.error("Cannot Start queues if they've already started")

--- a/python/Ganga/Core/__init__.py
+++ b/python/Ganga/Core/__init__.py
@@ -71,8 +71,7 @@ def bootstrap(reg, interactive_session):
 
     # export to GPI
     from Ganga.Runtime.GPIexport import exportToGPI
-    exportToGPI(
-        'runMonitoring', monitoring_component.runMonitoring, 'Functions')
+    exportToGPI('runMonitoring', monitoring_component.runMonitoring, 'Functions')
 
     autostart_default = interactive_session
     config.overrideDefaultValue('autostart', bool(autostart_default))

--- a/python/Ganga/Runtime/Repository_runtime.py
+++ b/python/Ganga/Runtime/Repository_runtime.py
@@ -93,6 +93,21 @@ def checkDiskQuota():
 
     return
 
+def bootstrap_reg_names():
+    # ALEX added this as need to ensure that prep registry is started up BEFORE job or template
+    # or even named templated registries as the _auto__init from job will require the prep registry to
+    # already be ready. This showed up when adding the named templates.
+    def prep_filter(x, y):
+        if x.name == 'prep':
+            return -1
+        return 1
+
+    names = []
+    for registry in sorted(getRegistries(), prep_filter):
+        names.append(registry.name)
+
+    return names
+
 def bootstrap():
     retval = []
 

--- a/python/Ganga/new_tests/GPI/GangaUnitTest.py
+++ b/python/Ganga/new_tests/GPI/GangaUnitTest.py
@@ -76,6 +76,10 @@ def start_ganga(gangadir_for_test='$HOME/gangadir_testing', extra_opts=[]):
         logger.info("Initializing")
         Ganga.Runtime._prog.initEnvironment(opt_rexec=False)
     else:
+        # The queues are shut down by the atexit handlers so we need to start them here
+        from Ganga.Core.GangaThread.WorkerThreads import startUpQueues
+        startUpQueues()
+
         # We need to test if the internal services need to be reinitialized
         from Ganga.Core.InternalServices import Coordinator
         if not Coordinator.servicesEnabled:
@@ -86,10 +90,6 @@ def start_ganga(gangadir_for_test='$HOME/gangadir_testing', extra_opts=[]):
             reactivate()
         else:
             logger.info("InternalServices still running")
-
-        # The queues are shut down by the atexit handlers so we need to start them here
-        from Ganga.Core.GangaThread.WorkerThreads import startUpQueues
-        startUpQueues()
 
     logger.info("Bootstrapping")
     Ganga.Runtime._prog.bootstrap(interactive=False)


### PR DESCRIPTION
This addresses #223 

Aside from a few lines of change in the shutdown of the threadpool and queues shutdown methods and the addition of an extra function into the Repository_runtime this PR is mainly focused on fixing a bug in ```GangaUnitTest``` where objects were referencing a ```queues``` and ```repository``` objects which should have been destroyed and recreated between tests.

It is explicitly assumed that the credentials objects are safe to exist across multiple tests, however should this not be the case the reference to them should probably be removed from the GPI at the end of the shutdown and the objects correctly recreated upon the startup of GangaUnitTest.

This is a relatively trivial fix with regards to changes in Core but effects the test system in quite a strong way so I'm keen to see if the tests pass correctly with this PR.