### PR TITLE
Don't read GangaRoot dir as a config file

### DIFF
--- a/python/Ganga/Runtime/bootstrap.py
+++ b/python/Ganga/Runtime/bootstrap.py
@@ -585,7 +585,9 @@ under certain conditions; type license() for details.
         import Ganga.Utility.util
         import inspect
         GangaRootPath = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe()))), '../..'))
-        self.options.config_path = Ganga.Utility.files.expandfilename(os.path.join(GangaRootPath, self.options.config_path))
+
+        if self.options.config_path:
+            self.options.config_path = Ganga.Utility.files.expandfilename(os.path.join(GangaRootPath, self.options.config_path))
 
         # check if the specified config options are different from the defaults
         # and set session values appropriately


### PR DESCRIPTION
This PR stops Ganga trying to read the GangaRoot dir as a config file.

Given that ATLAS/LHCb people don't seem to see this error anyway, their self.options.config_path is slightly different at this point. I think it's because they have overridden what this removed line is doing. I think therefore that it is safe to remove this but would appreciate someone with ATLAS/LHCb environment testing this.