### PR TITLE
GangaUnitTest teardown simplification

### DIFF
--- a/python/Ganga/new_tests/GPI/GangaUnitTest.py
+++ b/python/Ganga/new_tests/GPI/GangaUnitTest.py
@@ -1,4 +1,8 @@
 from __future__ import print_function
+
+import sys
+import shutil
+import os.path
 try:
     import unittest2 as unittest
 except ImportError:
@@ -6,11 +10,6 @@ except ImportError:
 
 
 def start_ganga(gangadir_for_test='$HOME/gangadir_testing', extra_opts=[]):
-
-    import sys
-    import os.path
-
-
     file_path = os.path.dirname(os.path.realpath(__file__))
     ganga_python_dir = os.path.join(file_path, '..', '..', '..')
     ganga_python_dir = os.path.realpath(ganga_python_dir)
@@ -213,7 +212,6 @@ class GangaUnitTest(unittest.TestCase):
         # Start ganga and internal services
         # This is called before each unittest
         if gangadir is None:
-            import os
             gangadir = os.path.join('$HOME/gangadir_testing', self.__class__.__name__)
             gangadir = os.path.expanduser(os.path.expandvars(gangadir))
             if not os.path.isdir(gangadir):
@@ -231,12 +229,10 @@ class GangaUnitTest(unittest.TestCase):
         unittest.TestCase.tearDown(self)
         # Stop ganga and mimick an exit to shutdown all internal processes
         stop_ganga()
-        import sys
         sys.stdout.flush()
 
     @classmethod
     def tearDownClass(cls):
         if cls.wipe_repo:
-            import shutil
             shutil.rmtree(cls.gangadir, ignore_errors=True)
 

--- a/python/Ganga/new_tests/GPI/GangaUnitTest.py
+++ b/python/Ganga/new_tests/GPI/GangaUnitTest.py
@@ -9,7 +9,7 @@ except ImportError:
     import unittest
 
 
-def start_ganga(gangadir_for_test='$HOME/gangadir_testing', extra_opts=[]):
+def start_ganga(gangadir_for_test, extra_opts=[]):
     file_path = os.path.dirname(os.path.realpath(__file__))
     ganga_python_dir = os.path.join(file_path, '..', '..', '..')
     ganga_python_dir = os.path.realpath(ganga_python_dir)
@@ -203,25 +203,21 @@ def stop_ganga():
 
 class GangaUnitTest(unittest.TestCase):
 
-    wipe_repo = None
-    gangadir = None
+    @classmethod
+    def gangadir(cls):
+        """
+        Return the directory that this test should store its registry and repository in
+        """
+        return os.path.join(os.path.expanduser('~'), 'gangadir_testing', cls.__name__)
 
-    def setUp(self, gangadir=None, wipe_repo=None, extra_opts=[]):
+    def setUp(self, extra_opts=[]):
         unittest.TestCase.setUp(self)
         # Start ganga and internal services
         # This is called before each unittest
-        if gangadir is None:
-            gangadir = os.path.join('$HOME/gangadir_testing', self.__class__.__name__)
-            gangadir = os.path.expanduser(os.path.expandvars(gangadir))
-            if not os.path.isdir(gangadir):
-                os.makedirs(gangadir)
-        if wipe_repo is None:
-            self.wipe_repo=True
-        else:
-            self.wipe_repo=wipe_repo
-        self.gangadir = gangadir
-        self.__class__.gangadir = self.gangadir
-        self.__class__.wipe_repo = self.wipe_repo
+
+        gangadir = self.gangadir()
+        if not os.path.isdir(gangadir):
+            os.makedirs(gangadir)
         start_ganga(gangadir_for_test=gangadir, extra_opts=extra_opts)
 
     def tearDown(self):
@@ -232,6 +228,5 @@ class GangaUnitTest(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        if cls.wipe_repo:
-            shutil.rmtree(cls.gangadir, ignore_errors=True)
+        shutil.rmtree(cls.gangadir(), ignore_errors=True)
 

--- a/python/Ganga/new_tests/GPI/GangaUnitTest.py
+++ b/python/Ganga/new_tests/GPI/GangaUnitTest.py
@@ -32,7 +32,6 @@ def start_ganga(gangadir_for_test='$HOME/gangadir_testing', extra_opts=[]):
     logger.info("Starting ganga")
 
     logger.info("Parsing Command Line options")
-    import Ganga.Runtime
     this_argv = [
         'ganga',  # `argv[0]` is usually the name of the program so fake that here
     ]


### PR DESCRIPTION
This change enforces that all `GangaUnitTest` tests run in a separate gangadir and that the gangadir is always wiped after the whole test class has finished. Until we have a situation where we want to preserve the gangadir after the test run or run in a specific gangadir, I'd like to keep this code as simple and short as possible.

014e0ea07d9eb356027c9796f551eaf621dd626e is the important change, the other two commits are just minor cleanup.