### PR TITLE
Fix typo

### DIFF
--- a/python/Ganga/Core/GangaRepository/Registry.py
+++ b/python/Ganga/Core/GangaRepository/Registry.py
@@ -262,7 +262,7 @@ class Registry(object):
         return this_id in self._objects
 
     def updateLocksNow(self):
-        loger.debug("updateLocksNow")
+        logger.debug("updateLocksNow")
         self.repository.updateLocksNow()
 
     def trackandRelease(self):


### PR DESCRIPTION
This prevents at least some jobs from being submitted, with error messages like:

```
Ganga.Core.GangaThread.WorkerThreads: ERROR    Exception raised executing 'getLFNReplicas' in Thread 'None':
Traceback (most recent call last):
  File "/afs/cern.ch/lhcb/software/DEV/GANGA/GANGA_v601r16/install/ganga/python/Ganga/Core/GangaThread/WorkerThreads/WorkerThreadPool.py", line 114, in __worker_thread
    result = item.command_input.function(*these_args, **item.command_input.kwargs)
  File "/afs/cern.ch/lhcb/software/DEV/GANGA/GANGA_v601r16/install/ganga/python/GangaDirac/Lib/Splitters/OfflineGangaDiracSplitter.py", line 80, in getLFNReplicas
    Ganga.Runtime.Repository_runtime.updateLocksNow()
  File "/afs/cern.ch/lhcb/software/DEV/GANGA/GANGA_v601r16/install/ganga/python/Ganga/Runtime/Repository_runtime.py", line 138, in updateLocksNow
    registry.updateLocksNow()
  File "/afs/cern.ch/lhcb/software/DEV/GANGA/GANGA_v601r16/install/ganga/python/Ganga/Core/GangaRepository/Registry.py", line 265, in updateLocksNow
    loger.debug("updateLocksNow")
NameError: global name 'loger' is not defined
```

I got this error when testing v601r16 on lxplus, running with:

```bash
$ lb-run --dev Ganga v601r16 ganga
```