### PR TITLE
Moving startup/cleanup of Registries to a sane place

### DIFF
--- a/python/Ganga/Runtime/Repository_runtime.py
+++ b/python/Ganga/Runtime/Repository_runtime.py
@@ -15,16 +15,19 @@ logger = getLogger()
 
 
 def requiresAfsToken():
+    # Were we executed from within an AFS folder
     return fullpath(getLocalRoot(), True).find('/afs') == 0
 
 
 def getLocalRoot():
+    # Get the local top level directory for the Repo
     if config['repositorytype'] in ['LocalXML', 'LocalAMGA', 'LocalPickle', 'SQLite']:
         return os.path.join(expandfilename(config['gangadir'], True), 'repository', config['user'], config['repositorytype'])
     else:
         return ''
 
 def getLocalWorkspace():
+    # Get the local top level dirtectory for the Workspace
     if config['repositorytype'] in ['LocalXML', 'LocalAMGA', 'LocalPickle', 'SQLite']:
         return os.path.join(expandfilename(config['gangadir'], True), 'workspace', config['user'], config['repositorytype'])
     else:
@@ -37,7 +40,7 @@ partition_warning = 95
 partition_critical = 99
 
 def checkDiskQuota():
-
+    # Throw an error atthe user if their AFS area is (extremely close to) full to avoid repo corruption
     import subprocess
 
     repo_partition = getLocalRoot()
@@ -90,6 +93,8 @@ def checkDiskQuota():
     return
 
 def bootstrap_getreg():
+    # Get the list of registries sorted in the bootstrap way
+    
     # ALEX added this as need to ensure that prep registry is started up BEFORE job or template
     # or even named templated registries as the _auto__init from job will require the prep registry to
     # already be ready. This showed up when adding the named templates.
@@ -101,10 +106,12 @@ def bootstrap_getreg():
     return [registry for registry in sorted(getRegistries(), prep_filter)]
 
 def bootstrap_reg_names():
+    # Get the list of registry names
     all_reg = bootstrap_getreg()
     return [reg.name for reg in all_reg]
 
 def bootstrap():
+    # Bootstrap for startup and setting of parameters for the Registries
     retval = []
 
     try:
@@ -137,6 +144,7 @@ def bootstrap():
 
 
 def updateLocksNow():
+    # Update all of the file locks for the registries
 
     logger.debug("Updating timestamp of Lock files")
     for registry in getRegistries():
@@ -145,6 +153,7 @@ def updateLocksNow():
 
 
 def shutdown():
+    # Shutdown method for all repgistries in order
     from Ganga.Utility.logging import getLogger
     logger = getLogger()
     logger.info('Registry Shutdown')
@@ -201,6 +210,7 @@ def shutdown():
     removeRegistries()
 
 def flush_all():
+    # Flush all registries in their current state with all dirty knowledge going to disk
     from Ganga.Utility.logging import getLogger
     logger = getLogger()
     logger.debug("Flushing All repositories")
@@ -217,6 +227,7 @@ def flush_all():
 
 
 def startUpRegistries():
+    # Startup the registries and export them to the GPI, also add jobtree and shareref
     from Ganga.Runtime.GPIexport import exportToGPI
     # import default runtime modules
 
@@ -241,7 +252,7 @@ def startUpRegistries():
     exportToGPI('shareref', shareref, 'Objects', 'Mechanism for tracking use of shared directory resources')
 
 def removeRegistries():
-    ## Remove lingering Objects from the GPI
+    ## Remove lingering Objects from the GPI and fully cleanup after the startup
 
     ## First start with repositories
 

--- a/python/Ganga/Runtime/bootstrap.py
+++ b/python/Ganga/Runtime/bootstrap.py
@@ -1049,31 +1049,9 @@ under certain conditions; type license() for details.
         exportToGPI('convert_merger_to_postprocessor',
                     convert_merger_to_postprocessor, 'Functions')
 
-        # import default runtime modules
-        from Ganga.Runtime import Repository_runtime
         import Ganga.Core
-
-        # bootstrap user-defined runtime modules and enable transient named
-        # template registries
-
-        # bootstrap runtime modules
-        from Ganga.GPIDev.Lib.JobTree import TreeError
-
-        # boostrap the repositories and connect to them
-        for n, k, d in Repository_runtime.bootstrap():
-            # make all repository proxies visible in GPI
-            exportToGPI(n, k, 'Objects', d)
-
-        # JobTree
-        from Ganga.Core.GangaRepository import getRegistry
-        jobtree = GPIProxyObjectFactory(getRegistry("jobs").getJobTree())
-        exportToGPI('jobtree', jobtree, 'Objects', 'Logical tree view of the jobs')
-        exportToGPI('TreeError', TreeError, 'Exceptions')
-
-        # ShareRef
-        shareref = GPIProxyObjectFactory(getRegistry("prep").getShareRef())
-        exportToGPI('shareref', shareref, 'Objects',
-                    'Mechanism for tracking use of shared directory resources')
+        from Ganga.Runtime.Repository_runtime import startUpRegistries
+        startUpRegistries()
 
         # export full_print
         from Ganga.GPIDev.Base.VPrinter import full_print

--- a/python/Ganga/new_tests/GPI/GangaUnitTest.py
+++ b/python/Ganga/new_tests/GPI/GangaUnitTest.py
@@ -108,6 +108,9 @@ def start_ganga(gangadir_for_test, extra_opts=[]):
     logger.info("Passing to Unittest")
 
 def emptyReposiories():
+    
+    from Ganga.Utility.logging import getLogger
+    logger = getLogger()
     # empty repository so we start again at job 0 when we restart
     logger.info("Clearing the Job and Template repositories")
 

--- a/python/Ganga/new_tests/GPI/GangaUnitTest.py
+++ b/python/Ganga/new_tests/GPI/GangaUnitTest.py
@@ -76,22 +76,8 @@ def start_ganga(gangadir_for_test='$HOME/gangadir_testing', extra_opts=[]):
         logger.info("Initializing")
         Ganga.Runtime._prog.initEnvironment(opt_rexec=False)
     else:
-        from Ganga.Runtime.GPIexport import exportToGPI
-
-        from Ganga.Runtime import Repository_runtime
-        # boostrap the repositories and connect to them
-        for n, k, d in Repository_runtime.bootstrap():
-            # make all repository proxies visible in GPI
-            exportToGPI(n, k, 'Objects', d)
-
-        # JobTree
-        from Ganga.Core.GangaRepository import getRegistry
-        jobtree = getRegistry("jobs").getJobTree()
-        exportToGPI('jobtree', jobtree, 'Objects', 'Logical tree view of the jobs')
-
-        # ShareRef
-        shareref = getRegistry("prep").getShareRef()
-        exportToGPI('shareref', shareref, 'Objects', 'Mechanism for tracking use of shared directory resources')
+        from Ganga.Runtime.Repository_runtime import startUpRegistries
+        startUpRegistries()
 
         # The queues are shut down by the atexit handlers so we need to start them here
         from Ganga.Core.GangaThread.WorkerThreads import startUpQueues
@@ -184,24 +170,6 @@ def stop_ganga():
     # Finished
     logger.info("Test Finished")
 
-    ## Remove lingering Objects from the GPI
-
-    ## First start with repositories
-
-    import Ganga.GPI
-
-    from Ganga.Runtime import Repository_runtime
-
-    for name in Repository_runtime.bootstrap_reg_names():
-        delattr(Ganga.GPI, name)
-
-    ## Now remove the JobTree
-    delattr(Ganga.GPI, 'jobtree')
-    ## Now remove the sharedir
-    delattr(Ganga.GPI, 'shareref')
-
-
-    ## gridProxy and afsToken are assumed to be safe to persist beteen instances
 
 class GangaUnitTest(unittest.TestCase):
 

--- a/python/Ganga/new_tests/GPI/GangaUnitTest.py
+++ b/python/Ganga/new_tests/GPI/GangaUnitTest.py
@@ -107,7 +107,7 @@ def start_ganga(gangadir_for_test, extra_opts=[]):
 
     logger.info("Passing to Unittest")
 
-def emptyReposiories():
+def emptyRepositories():
     
     from Ganga.Utility.logging import getLogger
     logger = getLogger()

--- a/python/Ganga/new_tests/GPI/GangaUnitTest.py
+++ b/python/Ganga/new_tests/GPI/GangaUnitTest.py
@@ -107,6 +107,32 @@ def start_ganga(gangadir_for_test, extra_opts=[]):
 
     logger.info("Passing to Unittest")
 
+def emptyReposiories():
+    # empty repository so we start again at job 0 when we restart
+    logger.info("Clearing the Job and Template repositories")
+
+    from Ganga.GPI import jobs, templates, tasks
+    for j in jobs:
+        try:
+            j.remove()
+        except:
+            pass
+    for t in templates:
+        try:
+            t.remove()
+        except:
+            pass
+    for t in tasks:
+        try:
+            t.remove(remove_jobs=True)
+        except:
+            pass
+    if hasattr(jobs, 'clean'):
+        jobs.clean(confirm=True, force=True)
+    if hasattr(templates, 'clean'):
+        templates.clean(confirm=True, force=True)
+    if hasattr(tasks, 'clean'):
+        tasks.clean(confirm=True, force=True)
 
 def stop_ganga():
 
@@ -121,28 +147,10 @@ def stop_ganga():
         whole_cleanup = getConfig('TestingFramework')['AutoCleanup']
     else:
         whole_cleanup = True
-
     logger.info("AutoCleanup: %s" % whole_cleanup)
 
     if whole_cleanup is True:
-        # empty repository so we start again at job 0 when we restart
-        logger.info("Clearing the Job and Template repositories")
-
-        from Ganga.GPI import jobs, templates
-        for j in jobs:
-            try:
-                j.remove()
-            except:
-                pass
-        for t in templates:
-            try:
-                t.remove()
-            except:
-                pass
-        if hasattr(jobs, 'clean'):
-            jobs.clean(confirm=True, force=True)
-        if hasattr(templates, 'clean'):
-            templates.clean(confirm=True, force=True)
+        emptyRepositories()
 
     logger.info("Shutting Down Internal Services")
 
@@ -167,7 +175,6 @@ def stop_ganga():
 
     # Finished
     logger.info("Test Finished")
-
 
 class GangaUnitTest(unittest.TestCase):
 
@@ -197,4 +204,3 @@ class GangaUnitTest(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         shutil.rmtree(cls.gangadir(), ignore_errors=True)
-


### PR DESCRIPTION
This PR cleans up the GangaUnitTest as well as making it clearer where the repositories are loaded from.

This also moves the removal of the registries to be managed by the registry shutdown which is more sensible.