### PR TITLE
Making warning of dead monitoring more verbose

### DIFF
--- a/python/Ganga/Core/MonitoringComponent/Local_GangaMC_Service.py
+++ b/python/Ganga/Core/MonitoringComponent/Local_GangaMC_Service.py
@@ -794,7 +794,7 @@ class JobRegistry_Monitor(GangaThread):
         _purge_actions_queue()
         stop_and_free_thread_pool(fail_cb, max_retries)
 
-        global_count = 0
+        cls.global_count = 0
         return True
 
     def stop(self, fail_cb=None, max_retries=5):
@@ -844,7 +844,7 @@ class JobRegistry_Monitor(GangaThread):
         #while self._runningNow is True:
         #    time.sleep(0.5)
 
-        global_count = 0
+        cls.global_count = 0
         return True
 
     def __cleanUp(self):

--- a/python/Ganga/Core/MonitoringComponent/Local_GangaMC_Service.py
+++ b/python/Ganga/Core/MonitoringComponent/Local_GangaMC_Service.py
@@ -33,6 +33,7 @@ ThreadPool = []
 
 heartbeat_times = None
 global_start_time = None
+global_count = 0
 
 # The JobAction class encapsulates a function, its arguments and its post result action
 # based on what is defined as a successful run of the function.
@@ -70,8 +71,12 @@ def checkHeartBeat():
         last_time = heartbeat_times[thread_name]
 
         dead_time = config['HeartBeatTimeOut']
+        max_warnings = 5
 
-        if (latest_timeNow - last_time) > dead_time and this_thread.isAlive() and this_thread._currently_running_command is True:
+        global global_count
+        if (latest_timeNow - last_time) > dead_time and this_thread.isAlive()\
+                and this_thread._currently_running_command is True\
+                and global_count < max_warnings:
 
             log.warning("Thread: %s Has not updated the heartbeat in %ss!! It's possibly dead" %(thread_name, str(dead_time)))
             log.warning("Thread is attempting to execute: %s" % this_thread._running_cmd)
@@ -80,6 +85,7 @@ def checkHeartBeat():
             ## Add at least 5sec here to avoid spamming the user non-stop that a monitoring thread has locked up almost entirely
             ## You'll get a message at most once per 5sec or less if the Monitoring is busy/asleep
             heartbeat_times[thread_name] += 5.
+            global_count+=1
 
 class MonitoringWorkerThread(GangaThread):
 

--- a/python/Ganga/Core/MonitoringComponent/Local_GangaMC_Service.py
+++ b/python/Ganga/Core/MonitoringComponent/Local_GangaMC_Service.py
@@ -534,7 +534,7 @@ class JobRegistry_Monitor(GangaThread):
         log.debug("Starting run method")
 
         while self.alive:
-            checkHeartBeat(cls.global_count)
+            checkHeartBeat(JobRegistry_Monitor.global_count)
             log.debug("Monitoring Loop is alive")
             # synchronize the main loop since we can get disable requests
             with self.__mainLoopCond:
@@ -794,7 +794,7 @@ class JobRegistry_Monitor(GangaThread):
         _purge_actions_queue()
         stop_and_free_thread_pool(fail_cb, max_retries)
 
-        cls.global_count = 0
+        JobRegistry_Monitor.global_count = 0
         return True
 
     def stop(self, fail_cb=None, max_retries=5):
@@ -844,7 +844,7 @@ class JobRegistry_Monitor(GangaThread):
         #while self._runningNow is True:
         #    time.sleep(0.5)
 
-        cls.global_count = 0
+        JobRegistry_Monitor.global_count = 0
         return True
 
     def __cleanUp(self):

--- a/python/Ganga/Core/MonitoringComponent/Local_GangaMC_Service.py
+++ b/python/Ganga/Core/MonitoringComponent/Local_GangaMC_Service.py
@@ -33,7 +33,6 @@ ThreadPool = []
 
 heartbeat_times = None
 global_start_time = None
-global_count = 0
 
 # The JobAction class encapsulates a function, its arguments and its post result action
 # based on what is defined as a successful run of the function.
@@ -61,7 +60,7 @@ def getNumAliveThreads():
             num_currently_running_command += 1
     return num_currently_running_command
 
-def checkHeartBeat():
+def checkHeartBeat(global_count):
 
     latest_timeNow = time.time()
 
@@ -73,7 +72,6 @@ def checkHeartBeat():
         dead_time = config['HeartBeatTimeOut']
         max_warnings = 5
 
-        global global_count
         if (latest_timeNow - last_time) > dead_time and this_thread.isAlive()\
                 and this_thread._currently_running_command is True\
                 and global_count < max_warnings:
@@ -468,8 +466,9 @@ def get_jobs_in_bunches(jobList_fromset, blocks_of_size=5, stripProxies=True):
 class JobRegistry_Monitor(GangaThread):
 
     """Job monitoring service thread."""
-    uPollRate = 0.5
-    minPollRate = 1.0
+    uPollRate = 1.
+    minPollRate = 1.
+    global_count = 0
 
     def __init__(self, registry):
         GangaThread.__init__(self, name="JobRegistry_Monitor")
@@ -535,7 +534,7 @@ class JobRegistry_Monitor(GangaThread):
         log.debug("Starting run method")
 
         while self.alive:
-            checkHeartBeat()
+            checkHeartBeat(cls.global_count)
             log.debug("Monitoring Loop is alive")
             # synchronize the main loop since we can get disable requests
             with self.__mainLoopCond:


### PR DESCRIPTION
Adding some more debug code to help with debugging any 'frozen' monitoring threads.