### PR TITLE
Always flush a job every time its status changes

### DIFF
--- a/python/Ganga/GPIDev/Lib/Job/Job.py
+++ b/python/Ganga/GPIDev/Lib/Job/Job.py
@@ -635,7 +635,7 @@ class Job(GangaObject):
         if self.status != saved_status and self.master is None:
             logger.info('job %s status changed to "%s"', self.getFQID('.'), self.status)
             self._setDirty()
-            # TODO try to force a flush here maybe?
+            self._getRegistry()._flush([self])
         if update_master and self.master is not None:
             self.master.updateMasterJobStatus()
 


### PR DESCRIPTION
In Ganga<6.1.16 the registry would, upon certain actions performed on it, do a flush to disk of all dirty jobs but only if it had been more than 30 seconds since the last flush. This wasn't a complete solution in that while there was a rate-limiter, there was no consistent prompt to flush. In 6.1.16 this logic was simplified with a look to adding a flushing thread in the near future which would attempt flush every 30 seconds ([see example](https://gist.github.com/milliams/2d95706c8f511f63d294)). This was deemed good enough since everything would be flushed on exit anyway.

This PR adds in an explicit flush each time a job's status changes. While this will slightly increase the total number of flushes it will ensure that important state changes like this are not lost.