### PR TITLE
Set the dirty flag to False after a flush

### DIFF
--- a/python/Ganga/Core/GangaRepository/Registry.py
+++ b/python/Ganga/Core/GangaRepository/Registry.py
@@ -640,6 +640,7 @@ class Registry(object):
                 if not obj._dirty:
                     continue
                 self.repository.flush([obj_id])
+                obj._dirty = False
                 self.repository.unlock([obj_id])
 
     @synchronised


### PR DESCRIPTION
As noticed by @rob-c, the dirty status of an object was not being reset after a successful flush. This does this so we should see far few flushes needed.

This may also help with the extraneous flushes on shutdown.