### PR TITLE
Some fixes which stop error messages from being thrown on shutdown du…

### DIFF
--- a/python/Ganga/Core/GangaThread/GangaThreadPool.py
+++ b/python/Ganga/Core/GangaThread/GangaThreadPool.py
@@ -191,6 +191,8 @@ class GangaThreadPool(object):
         # have disappeared
         for t in reversed(critThreads):
             logger.debug('shutting down Thread: %s' % t.getName())
+            if hasattr(t, 'setDeamon'):
+                t.setDeamon(False)
             t.stop()
             logger.debug('shutdown Thread: %s' % t.getName())
             # t.unregister()

--- a/python/Ganga/Core/GangaThread/GangaThreadPool.py
+++ b/python/Ganga/Core/GangaThread/GangaThreadPool.py
@@ -191,9 +191,9 @@ class GangaThreadPool(object):
         # have disappeared
         for t in reversed(critThreads):
             logger.debug('shutting down Thread: %s' % t.getName())
-            if hasattr(t, 'setDeamon'):
-                t.setDeamon(False)
             t.stop()
+            if hasattr(t, 'setDaemon') and not t.isAlive():
+                t.setDaemon(False)
             logger.debug('shutdown Thread: %s' % t.getName())
             # t.unregister()
 

--- a/python/Ganga/Core/GangaThread/GangaThreadPool.py
+++ b/python/Ganga/Core/GangaThread/GangaThreadPool.py
@@ -193,7 +193,7 @@ class GangaThreadPool(object):
             logger.debug('shutting down Thread: %s' % t.getName())
             t.stop()
             if hasattr(t, 'setDaemon') and not t.isAlive():
-                t.setDaemon(False)
+                t.daemon = False
             logger.debug('shutdown Thread: %s' % t.getName())
             # t.unregister()
 

--- a/python/Ganga/Core/GangaThread/GangaThreadPool.py
+++ b/python/Ganga/Core/GangaThread/GangaThreadPool.py
@@ -192,8 +192,6 @@ class GangaThreadPool(object):
         for t in reversed(critThreads):
             logger.debug('shutting down Thread: %s' % t.getName())
             t.stop()
-            if hasattr(t, 'setDaemon') and not t.isAlive():
-                t.daemon = False
             logger.debug('shutdown Thread: %s' % t.getName())
             # t.unregister()
 

--- a/python/Ganga/Core/GangaThread/WorkerThreads/WorkerThreadPool.py
+++ b/python/Ganga/Core/GangaThread/WorkerThreads/WorkerThreadPool.py
@@ -227,7 +227,7 @@ class WorkerThreadPool(object):
         for w in self.__worker_threads:
             w.stop()
             w.join()
-            w.setDaemon(False)
+            w.daemon = False
             # FIXME NEED TO CALL AN OPTIONAL CLEANUP FUCNTION HERE IF THREAD IS STOPPED
             # w.unregister()
             #del w

--- a/python/Ganga/Core/GangaThread/WorkerThreads/WorkerThreadPool.py
+++ b/python/Ganga/Core/GangaThread/WorkerThreads/WorkerThreadPool.py
@@ -227,7 +227,6 @@ class WorkerThreadPool(object):
         for w in self.__worker_threads:
             w.stop()
             w.join()
-            w.daemon = False
             # FIXME NEED TO CALL AN OPTIONAL CLEANUP FUCNTION HERE IF THREAD IS STOPPED
             # w.unregister()
             #del w

--- a/python/Ganga/Core/GangaThread/WorkerThreads/WorkerThreadPool.py
+++ b/python/Ganga/Core/GangaThread/WorkerThreads/WorkerThreadPool.py
@@ -230,7 +230,6 @@ class WorkerThreadPool(object):
             # FIXME NEED TO CALL AN OPTIONAL CLEANUP FUCNTION HERE IF THREAD IS STOPPED
             # w.unregister()
             #del w
-        del self.__worker_threads[:]
         self.__worker_threads = []
         return
 

--- a/python/Ganga/Core/GangaThread/WorkerThreads/WorkerThreadPool.py
+++ b/python/Ganga/Core/GangaThread/WorkerThreads/WorkerThreadPool.py
@@ -225,9 +225,9 @@ class WorkerThreadPool(object):
     def _stop_worker_threads(self, shutdown=False):
         self._shutdown = shutdown
         for w in self.__worker_threads:
-            w.setDaemon(False)
             w.stop()
             w.join()
+            w.setDaemon(False)
             # FIXME NEED TO CALL AN OPTIONAL CLEANUP FUCNTION HERE IF THREAD IS STOPPED
             # w.unregister()
             #del w

--- a/python/Ganga/Core/GangaThread/WorkerThreads/WorkerThreadPool.py
+++ b/python/Ganga/Core/GangaThread/WorkerThreads/WorkerThreadPool.py
@@ -225,11 +225,13 @@ class WorkerThreadPool(object):
     def _stop_worker_threads(self, shutdown=False):
         self._shutdown = shutdown
         for w in self.__worker_threads:
+            w.setDaemon(False)
             w.stop()
+            w.join()
             # FIXME NEED TO CALL AN OPTIONAL CLEANUP FUCNTION HERE IF THREAD IS STOPPED
             # w.unregister()
             #del w
-        #del self.__worker_threads[:]
+        del self.__worker_threads[:]
         self.__worker_threads = []
         return
 

--- a/python/Ganga/Core/GangaThread/WorkerThreads/__init__.py
+++ b/python/Ganga/Core/GangaThread/WorkerThreads/__init__.py
@@ -32,6 +32,5 @@ def shutDownQueues():
     del _global_queues
     _global_queues = None
     import Ganga.GPI
-    setattr(Ganga.GPI, 'queues', None)
     delattr(Ganga.GPI, 'queues')
 

--- a/python/Ganga/Core/GangaThread/WorkerThreads/__init__.py
+++ b/python/Ganga/Core/GangaThread/WorkerThreads/__init__.py
@@ -24,11 +24,14 @@ def shutDownQueues():
     logger = getLogger()
     logger.debug("Shutting Down Queues system")
     global _global_queues
-    _global_queues.lock()
-    _global_queues._purge_all()
+    try:
+        _global_queues.lock()
+        _global_queues._purge_all()
+    except:
+        logger.warning("Error in shutting down queues thread. Likely harmless")
     del _global_queues
     _global_queues = None
     import Ganga.GPI
+    setattr(Ganga.GPI, 'queues', None)
     delattr(Ganga.GPI, 'queues')
-
 


### PR DESCRIPTION
…e to daemon threads running whilst being destroyed by Python

I'd like to quickly push this into 6.1.17.

As part of fixing the flushing to disk at shutdown I discovered several other nasty errors which needed to be addressed to do with shutting down of threads.

If there is any long discussion we can hold off but this allows daemon-ed threads to shutdown more safely and gets rid of weird intermittent shutdown errors.

Any objections to merging as long as the tests are unaffected?