### PR TITLE
Use the GangaObject setter to mark as flushed

### DIFF
--- a/python/Ganga/Core/GangaRepository/Registry.py
+++ b/python/Ganga/Core/GangaRepository/Registry.py
@@ -640,7 +640,7 @@ class Registry(object):
                 if not obj._dirty:
                     continue
                 self.repository.flush([obj_id])
-                obj._dirty = False
+                obj._setFlushed()
                 self.repository.unlock([obj_id])
 
     @synchronised


### PR DESCRIPTION
As @rob-c pointed out, there is a setter function to mark an object as non-dirty.