### PR TITLE
Bugfix/stop shutdown insanity

### DIFF
--- a/python/Ganga/Core/GangaRepository/Registry.py
+++ b/python/Ganga/Core/GangaRepository/Registry.py
@@ -682,6 +682,8 @@ class Registry(object):
             #NO NO NO NO NO NO NO FOR THE SAKE OF MY SANITY NO, NEVER, EVER, EVER ITERATE OVER ALL OBJECTS BLINDLY FOR A FLUSH!!!
             #self._flush(self.values())
             self._flush()
+        if self.metadata and self.metadata.hasStarted():
+            self.metadata._flush()
 
     def _read_access(self, _obj, sub_obj=None):
         """Obtain read access on a given object.


### PR DESCRIPTION
This addresses #257 and at some level #256.

This PR restores the old default behaviour that calling flush with no arguments flushes all dirty objects.

We now explicitly ignore non loaded and non dirty jobs when flushing.
If you want to flush an object mark it as dirty.
If you don't mark it as dirty and want it written you should.

Unless we explicitly tie dirty into ```_getWriteAccess``` I don't expect this policy on what is dirty and what should be flushed to change.

Repository unlock is not yet used consistently and I've some concerns over the safety of releasing locks on every flush against erroneous ganga use.
I'm not objecting to Ganga releasing an object but releasing an object we have in memory (and therefore will __NOT__ re-load from disk) is asking for very serious problems.