### PR TITLE
Bugfix/stop loading on exit

### DIFF
--- a/python/Ganga/Core/GangaRepository/Registry.py
+++ b/python/Ganga/Core/GangaRepository/Registry.py
@@ -645,7 +645,6 @@ class Registry(object):
                 obj_id = getattr(obj, _reg_id_str)
                 self.repository.flush([obj_id])
                 obj._setFlushed()
-                self.repository.unlock([obj_id])
 
     @synchronised
     def flush_all(self):

--- a/python/Ganga/Core/GangaRepository/Registry.py
+++ b/python/Ganga/Core/GangaRepository/Registry.py
@@ -636,12 +636,11 @@ class Registry(object):
         for obj in objs:
             with obj.lock:
                 # check if the object is dirty, if not do nothing
-                print obj._dirty
                 if not obj._dirty:
                     continue
 
                 # flush the object. Need to call _getWriteAccess for consistency reasons
-                # TODO: getWriteAccess should only 'get write access' and as that's not needed shouldn't be called here?
+                # TODO: getWriteAccess should only 'get write access', as that's not needed should it be called here?
                 obj._getWriteAccess()
                 obj_id = getattr(obj, _reg_id_str)
                 self.repository.flush([obj_id])

--- a/python/Ganga/Core/GangaRepository/Registry.py
+++ b/python/Ganga/Core/GangaRepository/Registry.py
@@ -635,10 +635,15 @@ class Registry(object):
 
         for obj in objs:
             with obj.lock:
-                obj._getWriteAccess()
-                obj_id = getattr(obj, _reg_id_str)
+                # check if the object is dirty, if not do nothing
+                print obj._dirty
                 if not obj._dirty:
                     continue
+
+                # flush the object. Need to call _getWriteAccess for consistency reasons
+                # TODO: getWriteAccess should only 'get write access' and as that's not needed shouldn't be called here?
+                obj._getWriteAccess()
+                obj_id = getattr(obj, _reg_id_str)
                 self.repository.flush([obj_id])
                 obj._dirty = False
                 self.repository.unlock([obj_id])

--- a/python/Ganga/Core/GangaRepository/Registry.py
+++ b/python/Ganga/Core/GangaRepository/Registry.py
@@ -656,6 +656,9 @@ class Registry(object):
         if self.hasStarted():
             self._flush(self.values())
 
+        if self.metadata and self.metadata.hasStarted():
+            self.metadata._flush()
+
     def _read_access(self, _obj, sub_obj=None):
         """Obtain read access on a given object.
         sub-obj is the object the read access is actually desired (ignored at the moment)

--- a/python/Ganga/Core/GangaRepository/Registry.py
+++ b/python/Ganga/Core/GangaRepository/Registry.py
@@ -634,11 +634,11 @@ class Registry(object):
             raise RegistryAccessError("Cannot flush to a disconnected repository!")
 
         for obj in objs:
-            with obj.lock:
-                # check if the object is dirty, if not do nothing
-                if not obj._dirty:
-                    continue
+            # check if the object is dirty, if not do nothing
+            if not obj._dirty:
+                continue
 
+            with obj.lock:
                 # flush the object. Need to call _getWriteAccess for consistency reasons
                 # TODO: getWriteAccess should only 'get write access', as that's not needed should it be called here?
                 obj._getWriteAccess()

--- a/python/Ganga/new_tests/GPI/Bugs/TestSavannah19123.py
+++ b/python/Ganga/new_tests/GPI/Bugs/TestSavannah19123.py
@@ -24,14 +24,24 @@ class TestSavannah19123(GangaUnitTest):
 
         j = Job()
         j.application.exe = 'bash'
-        j.application.args = ['-c', 'for i in `seq 1 30`; do echo $i; sleep 1; done']
+        j.application.args = ['-c', 'for i in `seq 1 2`; do echo $i; sleep 1; done']
         j.backend = Local()
 
         j.submit()
 
         check(False)
 
-        sleep_until_state(j, 5, 'running')
+        if not sleep_until_state(j, 5, 'running'):
+            # problem with the test - print out stdout/stderr and assert
+            for fn in ['stdout','stderr']:
+                fn = os.path.join(j.outputdir,fn)
+                print " ----  Contents of " + fn
+                if os.path.exists(fn):
+                    print open(fn).read()
+                else:
+                    print "NO FILE AVAILABLE"
+
+            self.assertEqual(j.status, 'running')
 
         j.kill()
 

--- a/python/Ganga/new_tests/GPI/Bugs/TestSavannah19123.py
+++ b/python/Ganga/new_tests/GPI/Bugs/TestSavannah19123.py
@@ -24,7 +24,7 @@ class TestSavannah19123(GangaUnitTest):
 
         j = Job()
         j.application.exe = 'bash'
-        j.application.args = ['-c', 'for i in `seq 1 2`; do echo $i; sleep 1; done']
+        j.application.args = ['-c', 'for i in `seq 1 30`; do echo $i; sleep 1; done']
         j.backend = Local()
 
         j.submit()


### PR DESCRIPTION
This should fix #257 and is alternative to PR #264. Basically, it just reorders the `obj._getWriteAccess` function to after the check on the `_dirty` flag as within the write access call (shouldn't this be read access?) the job is loaded which makes sense if you're requesting write access.