### PR TITLE
Add auto-flusher to registries

### DIFF
--- a/python/Ganga/Core/GangaRepository/Registry.py
+++ b/python/Ganga/Core/GangaRepository/Registry.py
@@ -183,18 +183,24 @@ class RegistryFlusher(threading.Thread):
     def stop(self):
         self._stop.set()
 
+    @property
     def stopped(self):
         return self._stop.isSet()
 
     def run(self):
+        """
+        This will run an indefinite loop which periodically checks
+        whether it should stop. In between calls to ``flush_all`` it
+        will wait for a fixed period of time.
+        """
         sleep_period = 30
         sleeps_per_second = 10  # This changes the granularity of the sleep.
-        while not self.stopped():
+        while not self.stopped:
             for i in range(sleep_period*sleeps_per_second):
                 time.sleep(1/sleeps_per_second)
-                if self.stopped():
+                if self.stopped:
                     return
-            print 'auto-flushing', self.registry.name
+            logger.debug('auto-flushing', self.registry.name)
             self.registry.flush_all()
 
 

--- a/python/Ganga/Core/GangaRepository/Registry.py
+++ b/python/Ganga/Core/GangaRepository/Registry.py
@@ -932,8 +932,6 @@ class Registry(object):
             self.repository.startup()
             # All Ids could have changed
             self.changed_ids = {}
-            self.flush_thread = RegistryFlusher(self)
-            self.flush_thread.start()
             t1 = time.time()
             logger.debug("Registry '%s' [%s] startup time: %s sec" % (self.name, self.type, t1 - t0))
         except Exception as err:
@@ -951,7 +949,6 @@ class Registry(object):
         logger.debug("Shutting Down Registry")
         logger.debug("shutdown")
         try:
-            self.flush_thread.join()
             self._hasStarted = True
             try:
                 if not self.metadata is None:

--- a/python/Ganga/Core/GangaRepository/Registry.py
+++ b/python/Ganga/Core/GangaRepository/Registry.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 import functools
 from Ganga.Utility.logging import getLogger
 
@@ -185,9 +187,11 @@ class RegistryFlusher(threading.Thread):
         return self._stop.isSet()
 
     def run(self):
+        sleep_period = 30
+        sleeps_per_second = 10  # This changes the granularity of the sleep.
         while not self.stopped():
-            for i in range(30):
-                time.sleep(1)
+            for i in range(sleep_period*sleeps_per_second):
+                time.sleep(1/sleeps_per_second)
                 if self.stopped():
                     return
             print 'auto-flushing', self.registry.name

--- a/python/Ganga/Core/GangaRepository/Registry.py
+++ b/python/Ganga/Core/GangaRepository/Registry.py
@@ -181,11 +181,19 @@ class RegistryFlusher(threading.Thread):
         self._stop = threading.Event()
 
     def stop(self):
+        """
+        Ask the thread to stop what it is doing and it will finish
+        the next chance it gets.
+        """
         self._stop.set()
 
     @property
     def stopped(self):
         return self._stop.isSet()
+
+    def join(self, *args, **kwargs):
+        self.stop()
+        super(RegistryFlusher, self).join(*args, **kwargs)
 
     def run(self):
         """
@@ -942,7 +950,6 @@ class Registry(object):
         logger.debug("Shutting Down Registry")
         logger.debug("shutdown")
         try:
-            self.flush_thread.stop()
             self.flush_thread.join()
             self._hasStarted = True
             try:

--- a/python/Ganga/Core/GangaRepository/Registry.py
+++ b/python/Ganga/Core/GangaRepository/Registry.py
@@ -13,6 +13,7 @@ from Ganga.GPIDev.Lib.GangaList.GangaList import GangaList
 from Ganga.GPIDev.Base.Objects import GangaObject
 from Ganga.GPIDev.Schema import Schema, Version
 from Ganga.GPIDev.Base.Proxy import stripProxy, isType, getName
+from Ganga.Utility.Config import getConfig
 
 logger = getLogger()
 
@@ -201,7 +202,7 @@ class RegistryFlusher(threading.Thread):
         whether it should stop. In between calls to ``flush_all`` it
         will wait for a fixed period of time.
         """
-        sleep_period = 30
+        sleep_period = getConfig('Registry')['AutoFlusherWaitTime']
         sleeps_per_second = 10  # This changes the granularity of the sleep.
         while not self.stopped:
             for i in range(sleep_period*sleeps_per_second):

--- a/python/Ganga/GPIDev/Lib/Registry/JobRegistry.py
+++ b/python/Ganga/GPIDev/Lib/Registry/JobRegistry.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import
 from Ganga.Utility.external.OrderedDict import OrderedDict as oDict
 
 from Ganga.Core.exceptions import GangaException
-from Ganga.Core.GangaRepository.Registry import Registry, RegistryKeyError, RegistryAccessError
+from Ganga.Core.GangaRepository.Registry import Registry, RegistryKeyError, RegistryAccessError, RegistryFlusher
 
 from Ganga.GPIDev.Base.Proxy import stripProxy, isType, addProxy
 
@@ -82,6 +82,12 @@ class JobRegistry(Registry):
             stripProxy(jt)._setRegistry(self.metadata)
             self.metadata._add(jt)
         self.jobtree = self.metadata[self.metadata.ids()[-1]]
+        self.flush_thread = RegistryFlusher(self)
+        self.flush_thread.start()
+
+    def shutdown(self):
+        self.flush_thread.join()
+        super(JobRegistry, self).shutdown()
 
     def getJobTree(self):
         return self.jobtree

--- a/python/Ganga/GPIDev/Lib/Registry/PrepRegistry.py
+++ b/python/Ganga/GPIDev/Lib/Registry/PrepRegistry.py
@@ -39,7 +39,6 @@ class PrepRegistry(Registry):
 
     def shutdown(self):
         """Flush and disconnect the repository. Called from Repository_runtime.py """
-        self.flush_thread.join()
         self._hasStarted = True
         from Ganga.Utility.logging import getLogger
         self.shouldRun = True

--- a/python/Ganga/GPIDev/Lib/Registry/PrepRegistry.py
+++ b/python/Ganga/GPIDev/Lib/Registry/PrepRegistry.py
@@ -39,6 +39,8 @@ class PrepRegistry(Registry):
 
     def shutdown(self):
         """Flush and disconnect the repository. Called from Repository_runtime.py """
+        self.flush_thread.stop()
+        self.flush_thread.join()
         self._hasStarted = True
         from Ganga.Utility.logging import getLogger
         self.shouldRun = True

--- a/python/Ganga/GPIDev/Lib/Registry/PrepRegistry.py
+++ b/python/Ganga/GPIDev/Lib/Registry/PrepRegistry.py
@@ -39,7 +39,6 @@ class PrepRegistry(Registry):
 
     def shutdown(self):
         """Flush and disconnect the repository. Called from Repository_runtime.py """
-        self.flush_thread.stop()
         self.flush_thread.join()
         self._hasStarted = True
         from Ganga.Utility.logging import getLogger

--- a/python/Ganga/__init__.py
+++ b/python/Ganga/__init__.py
@@ -836,3 +836,7 @@ Executable/* = Ganga.Lib.MonitoringServices.DummyMS.DummyMS
 
 """, is_open=True)
 
+# ------------------------------------------------
+# MonitoringServices
+reg_config = makeConfig('Registry','')
+reg_config.addOption('AutoFlusherWaitTime', 30, 'Time to wait between auto-flusher runs')


### PR DESCRIPTION
This adds an auto-flushing background thread to all registries which flushes all dirty objects with a 30 second gap in between.