### PR TITLE
Disabling HeartBeat checking in Monitoring system by default

### DIFF
--- a/python/Ganga/__init__.py
+++ b/python/Ganga/__init__.py
@@ -245,7 +245,8 @@ poll_config.addOption('forced_shutdown_prompt_time', 10,
 poll_config.addOption('forced_shutdown_first_prompt_time', 5,
                  "User will get the FIRST prompt after N seconds, as specified by this parameter. This parameter also defines the time that Ganga will wait before shutting down, if there are only non-critical threads alive, in both interactive and batch mode.")
 
-poll_config.addOption('HeartBeatTimeOut', 300, 'Time before the user gets the warning that a thread has locked up due to failing to update the heartbeat attribute')
+import sys
+poll_config.addOption('HeartBeatTimeOut', sys.maxint, 'Time before the user gets the warning that a thread has locked up due to failing to update the heartbeat attribute')
 
 # ------------------------------------------------
 # Feedback


### PR DESCRIPTION
Disabling heartbeat by increasing default timeout to an obscene number.

I want to keep these as warnings so that we can much more easily debug what's going on but for users who think they're experiencing lockups can change this to be something more sensible like 300.