### PR TITLE
Make GangaObjects only lock their root object

### DIFF
--- a/python/Ganga/GPIDev/Base/Objects.py
+++ b/python/Ganga/GPIDev/Base/Objects.py
@@ -141,8 +141,8 @@ class Node(object):
     @contextmanager
     def lock(self):
         """
-        This is a context manager which acquires the lock on the object and all it's ancestors.
-        When the context manager exits, all the locks are released in the reverse order to that which they were acquired.
+        This is a context manager which acquires the lock on the
+        object's root object.
         """
         root = self._getRoot()
         root._lock.acquire()

--- a/python/Ganga/GPIDev/Base/Objects.py
+++ b/python/Ganga/GPIDev/Base/Objects.py
@@ -125,13 +125,17 @@ class Node(object):
         setattr(obj, '_registry', self._registry)
         return obj
 
-    @synchronised
     def _getParent(self):
         return self._parent
 
-    @synchronised
+    @synchronised  # This will lock the _current_ (soon to be _old_) root object
     def _setParent(self, parent):
-        setattr(self, '_parent', parent)
+        if parent is None:
+            setattr(self, '_parent', parent)
+        else:
+            with parent.lock:  # This will lock the _new_ root object
+                setattr(self, '_parent', parent)
+            # Finally the new and then old root objects will be unlocked
 
     @property
     @contextmanager
@@ -140,19 +144,12 @@ class Node(object):
         This is a context manager which acquires the lock on the object and all it's ancestors.
         When the context manager exits, all the locks are released in the reverse order to that which they were acquired.
         """
-        self._lock.acquire()
-        ancestors = []
-        p = self._parent
-        while p is not None:
-            p._lock.acquire()
-            ancestors.append(p)
-            p = p._parent
+        root = self._getRoot()
+        root._lock.acquire()
         try:
             yield
         finally:
-            for p in reversed(ancestors):
-                p._lock.release()
-            self._lock.release()
+            root._lock.release()
 
     # get the root of the object tree
     # if parent does not exist then the root is the 'self' object


### PR DESCRIPTION
Rather than having a lock on every single GangaObject which then propagates up the parent chain, instead just acquire the lock in the object's root object. This is sensitive to altering the parent of an object so extra logic is need in _setParent to lock both the old and new root.

This is a requirement for getting #267 working properly.