### PR TITLE
Fixing use of flush commands...

### DIFF
--- a/python/Ganga/Core/GangaRepository/Registry.py
+++ b/python/Ganga/Core/GangaRepository/Registry.py
@@ -712,7 +712,7 @@ class Registry(object):
             self._flush(self.values())
 
         if self.metadata and self.metadata.hasStarted():
-            self.metadata._flush()
+            self.metadata.flush_all()
 
     def _read_access(self, _obj, sub_obj=None):
         """Obtain read access on a given object.


### PR DESCRIPTION
I'm assuming we want to standardize on flush_all in this case, but either way this line is broken