### PR TITLE
Move GangaUnitTest to a lib directory

### DIFF
--- a/python/Ganga/new_tests/GPI/Bugs/TestJIRA1961.py
+++ b/python/Ganga/new_tests/GPI/Bugs/TestJIRA1961.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from ..GangaUnitTest import GangaUnitTest
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
 
 
 class TestJIRA1961(GangaUnitTest):

--- a/python/Ganga/new_tests/GPI/Bugs/TestSavannah10064.py
+++ b/python/Ganga/new_tests/GPI/Bugs/TestSavannah10064.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from ..GangaUnitTest import GangaUnitTest
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
 
 
 class TestSavannah10064(GangaUnitTest):

--- a/python/Ganga/new_tests/GPI/Bugs/TestSavannah13404.py
+++ b/python/Ganga/new_tests/GPI/Bugs/TestSavannah13404.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import
 
-from ..GangaUnitTest import GangaUnitTest
-
 import os
+
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
 
 
 class TestSavannah13404(GangaUnitTest):

--- a/python/Ganga/new_tests/GPI/Bugs/TestSavannah13406.py
+++ b/python/Ganga/new_tests/GPI/Bugs/TestSavannah13406.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from ..GangaUnitTest import GangaUnitTest
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
 
 
 class TestSavannah13406(GangaUnitTest):

--- a/python/Ganga/new_tests/GPI/Bugs/TestSavannah13459.py
+++ b/python/Ganga/new_tests/GPI/Bugs/TestSavannah13459.py
@@ -1,11 +1,10 @@
 from __future__ import absolute_import
 
-from ..GangaUnitTest import GangaUnitTest
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
 
 class TestSavannah13459(GangaUnitTest):
 
     def test_Savannah13459(self):
-        from Ganga.GPI import Job, config
         from Ganga.GPI import Job, Executable
         j = Job()
         j.application = Executable()

--- a/python/Ganga/new_tests/GPI/Bugs/TestSavannah13685.py
+++ b/python/Ganga/new_tests/GPI/Bugs/TestSavannah13685.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from ..GangaUnitTest import GangaUnitTest
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
 
 
 class TestSavannah13685(GangaUnitTest):

--- a/python/Ganga/new_tests/GPI/Bugs/TestSavannah13979.py
+++ b/python/Ganga/new_tests/GPI/Bugs/TestSavannah13979.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from ..GangaUnitTest import GangaUnitTest
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
 
 
 class TestSavannah13979(GangaUnitTest):

--- a/python/Ganga/new_tests/GPI/Bugs/TestSavannah14799.py
+++ b/python/Ganga/new_tests/GPI/Bugs/TestSavannah14799.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from ..GangaUnitTest import GangaUnitTest
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
 
 
 class TestSavannah14799(GangaUnitTest):

--- a/python/Ganga/new_tests/GPI/Bugs/TestSavannah15630.py
+++ b/python/Ganga/new_tests/GPI/Bugs/TestSavannah15630.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from ..GangaUnitTest import GangaUnitTest
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
 
 
 class TestSavannah15630(GangaUnitTest):

--- a/python/Ganga/new_tests/GPI/Bugs/TestSavannah18215.py
+++ b/python/Ganga/new_tests/GPI/Bugs/TestSavannah18215.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from ..GangaUnitTest import GangaUnitTest
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
 
 
 def goto_state(j, destination):

--- a/python/Ganga/new_tests/GPI/Bugs/TestSavannah18272.py
+++ b/python/Ganga/new_tests/GPI/Bugs/TestSavannah18272.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from ..GangaUnitTest import GangaUnitTest
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
 
 
 class TestSavannah18272(GangaUnitTest):

--- a/python/Ganga/new_tests/GPI/Bugs/TestSavannah18729.py
+++ b/python/Ganga/new_tests/GPI/Bugs/TestSavannah18729.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from ..GangaUnitTest import GangaUnitTest
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
 
 
 class TestSavannah18729(GangaUnitTest):

--- a/python/Ganga/new_tests/GPI/Bugs/TestSavannah19059.py
+++ b/python/Ganga/new_tests/GPI/Bugs/TestSavannah19059.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from ..GangaUnitTest import GangaUnitTest
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
 
 
 class TestSavannah19059(GangaUnitTest):

--- a/python/Ganga/new_tests/GPI/Bugs/TestSavannah19123.py
+++ b/python/Ganga/new_tests/GPI/Bugs/TestSavannah19123.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import
 
-from ..GangaUnitTest import GangaUnitTest
-
 import os
+
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
 
 
 class TestSavannah19123(GangaUnitTest):

--- a/python/Ganga/new_tests/GPI/Bugs/TestSavannah28511.py
+++ b/python/Ganga/new_tests/GPI/Bugs/TestSavannah28511.py
@@ -1,11 +1,11 @@
 from __future__ import absolute_import
 
-from ..GangaUnitTest import GangaUnitTest
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
 
 
 class TestSavannah28511(GangaUnitTest):
     def test_Savannah28511(self):
-        from Ganga.GPI import Job, TestSubmitter
+        from Ganga.GPI import Job
 
         from GangaTest.Framework.utils import sleep_until_completed, sleep_until_state
 

--- a/python/Ganga/new_tests/GPI/Bugs/TestSavannah31691.py
+++ b/python/Ganga/new_tests/GPI/Bugs/TestSavannah31691.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import
 
-from ..GangaUnitTest import GangaUnitTest
-
 import os
+
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
 
 
 class TestSavannah31691(GangaUnitTest):

--- a/python/Ganga/new_tests/GPI/Bugs/TestSavannah33303.py
+++ b/python/Ganga/new_tests/GPI/Bugs/TestSavannah33303.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from ..GangaUnitTest import GangaUnitTest
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
 
 
 class TestSavannah33303(GangaUnitTest):

--- a/python/Ganga/new_tests/GPI/Bugs/TestSavannah40220.py
+++ b/python/Ganga/new_tests/GPI/Bugs/TestSavannah40220.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from ..GangaUnitTest import GangaUnitTest
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
 
 
 class TestSavannah40220(GangaUnitTest):

--- a/python/Ganga/new_tests/GPI/Bugs/TestSavannah43249.py
+++ b/python/Ganga/new_tests/GPI/Bugs/TestSavannah43249.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from ..GangaUnitTest import GangaUnitTest
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
 
 
 class TestSavannah43249(GangaUnitTest):

--- a/python/Ganga/new_tests/GPI/Bugs/TestSavannah44116.py
+++ b/python/Ganga/new_tests/GPI/Bugs/TestSavannah44116.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from ..GangaUnitTest import GangaUnitTest
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
 
 
 class TestSavannah44116(GangaUnitTest):

--- a/python/Ganga/new_tests/GPI/Bugs/TestSavannah47814.py
+++ b/python/Ganga/new_tests/GPI/Bugs/TestSavannah47814.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from ..GangaUnitTest import GangaUnitTest
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
 
 
 class TestSavannah47814(GangaUnitTest):

--- a/python/Ganga/new_tests/GPI/Bugs/TestSavannah74531.py
+++ b/python/Ganga/new_tests/GPI/Bugs/TestSavannah74531.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from ..GangaUnitTest import GangaUnitTest
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
 
 
 class TestSavannah74531(GangaUnitTest):

--- a/python/Ganga/new_tests/GPI/Bugs/TestSavannah76973.py
+++ b/python/Ganga/new_tests/GPI/Bugs/TestSavannah76973.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from ..GangaUnitTest import GangaUnitTest
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
 
 
 class TestSavannah76973(GangaUnitTest):

--- a/python/Ganga/new_tests/GPI/Bugs/TestSavannah77962.py
+++ b/python/Ganga/new_tests/GPI/Bugs/TestSavannah77962.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from ..GangaUnitTest import GangaUnitTest
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
 
 
 class TestSavannah77962(GangaUnitTest):

--- a/python/Ganga/new_tests/GPI/Bugs/TestSavannah8009.py
+++ b/python/Ganga/new_tests/GPI/Bugs/TestSavannah8009.py
@@ -1,12 +1,12 @@
 from __future__ import absolute_import
 
-from ..GangaUnitTest import GangaUnitTest
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
 
 
 class TestSavannah8009(GangaUnitTest):
 
     def test_Savannah8009(self):
-        from Ganga.GPI import Executable, Job, jobs, templates
+        from Ganga.GPI import Job, jobs, templates
 
         from GangaTest.Framework.utils import sleep_until_completed
 

--- a/python/Ganga/new_tests/GPI/Bugs/TestSavannah8111.py
+++ b/python/Ganga/new_tests/GPI/Bugs/TestSavannah8111.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from ..GangaUnitTest import GangaUnitTest
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
 
 
 class TestSavannah8111(GangaUnitTest):

--- a/python/Ganga/new_tests/GPI/Bugs/TestSavannah8529.py
+++ b/python/Ganga/new_tests/GPI/Bugs/TestSavannah8529.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from ..GangaUnitTest import GangaUnitTest
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
 
 
 class TestSavannah8529(GangaUnitTest):

--- a/python/Ganga/new_tests/GPI/Bugs/TestSavannah8534.py
+++ b/python/Ganga/new_tests/GPI/Bugs/TestSavannah8534.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from ..GangaUnitTest import GangaUnitTest
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
 
 
 class TestSavannah8534(GangaUnitTest):

--- a/python/Ganga/new_tests/GPI/Bugs/TestSavannah87262.py
+++ b/python/Ganga/new_tests/GPI/Bugs/TestSavannah87262.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, print_function
 
-from ..GangaUnitTest import GangaUnitTest
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
 
 
 class TestSavannah87262(GangaUnitTest):

--- a/python/Ganga/new_tests/GPI/Bugs/TestSavannah88651.py
+++ b/python/Ganga/new_tests/GPI/Bugs/TestSavannah88651.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from ..GangaUnitTest import GangaUnitTest
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
 
 
 class TestSavannah88651(GangaUnitTest):

--- a/python/Ganga/new_tests/GPI/Bugs/TestSavannah9007.py
+++ b/python/Ganga/new_tests/GPI/Bugs/TestSavannah9007.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from ..GangaUnitTest import GangaUnitTest
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
 
 
 class TestSavannah9007(GangaUnitTest):

--- a/python/Ganga/new_tests/GPI/Bugs/TestSavannah9008.py
+++ b/python/Ganga/new_tests/GPI/Bugs/TestSavannah9008.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from ..GangaUnitTest import GangaUnitTest
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
 
 
 class TestSavannah9008(GangaUnitTest):

--- a/python/Ganga/new_tests/GPI/Bugs/TestSavannah9120.py
+++ b/python/Ganga/new_tests/GPI/Bugs/TestSavannah9120.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from ..GangaUnitTest import GangaUnitTest
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
 
 
 class TestSavannah9120(GangaUnitTest):

--- a/python/Ganga/new_tests/GPI/Bugs/TestSavannah9289.py
+++ b/python/Ganga/new_tests/GPI/Bugs/TestSavannah9289.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from ..GangaUnitTest import GangaUnitTest
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
 
 
 class TestSavannah9289(GangaUnitTest):

--- a/python/Ganga/new_tests/GPI/Bugs/TestSavannah96158.py
+++ b/python/Ganga/new_tests/GPI/Bugs/TestSavannah96158.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from ..GangaUnitTest import GangaUnitTest
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
 
 
 class TestSavannah96158(GangaUnitTest):

--- a/python/Ganga/new_tests/GPI/Bugs/TestSavannah9638.py
+++ b/python/Ganga/new_tests/GPI/Bugs/TestSavannah9638.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from ..GangaUnitTest import GangaUnitTest
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
 
 
 def wipe_temp_dir():

--- a/python/Ganga/new_tests/GPI/Checkers/TestCustomChecker.py
+++ b/python/Ganga/new_tests/GPI/Checkers/TestCustomChecker.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import os
 import tempfile
 
-from ..GangaUnitTest import GangaUnitTest
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
 
 
 class TestCustomChecker(GangaUnitTest):

--- a/python/Ganga/new_tests/GPI/Checkers/TestFileChecker.py
+++ b/python/Ganga/new_tests/GPI/Checkers/TestFileChecker.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from ..GangaUnitTest import GangaUnitTest
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
 
 
 class TestFileChecker(GangaUnitTest):

--- a/python/Ganga/new_tests/GPI/Internals/TestRegistry.py
+++ b/python/Ganga/new_tests/GPI/Internals/TestRegistry.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import random
 import threading
 
-from ..GangaUnitTest import GangaUnitTest
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
 
 
 class HammerThread(threading.Thread):

--- a/python/Ganga/new_tests/GPI/Internals/TestRepo.py
+++ b/python/Ganga/new_tests/GPI/Internals/TestRepo.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import random
 import threading
 
-from ..GangaUnitTest import GangaUnitTest
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
 
 
 class FakeRegistry(object):

--- a/python/Ganga/new_tests/GPI/Loading/TestLazyLoading.py
+++ b/python/Ganga/new_tests/GPI/Loading/TestLazyLoading.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from ..GangaUnitTest import GangaUnitTest
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
 
 class TestLazyLoading(GangaUnitTest):
 

--- a/python/Ganga/new_tests/GPI/Loading/TestLazyLoadingSubjobs.py
+++ b/python/Ganga/new_tests/GPI/Loading/TestLazyLoadingSubjobs.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from ..GangaUnitTest import GangaUnitTest
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
 
 global_subjob_num = 5
 default_CleanUp = None

--- a/python/Ganga/new_tests/GPI/Mergers/TestCustomMerger.py
+++ b/python/Ganga/new_tests/GPI/Mergers/TestCustomMerger.py
@@ -5,11 +5,10 @@ import tempfile
 
 import pytest
 
-from GangaTest.Framework.utils import sleep_until_completed, write_file
-from Ganga.GPIDev.Base.Proxy import getProxyClass
 from Ganga.GPIDev.Adapters.IPostProcessor import PostProcessException
-
-from ..GangaUnitTest import GangaUnitTest
+from Ganga.GPIDev.Base.Proxy import getProxyClass
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
+from GangaTest.Framework.utils import sleep_until_completed, write_file
 from .CopySplitter import CopySplitter
 
 CopySplitter = getProxyClass(CopySplitter)

--- a/python/Ganga/new_tests/GPI/Mergers/TestMergeFailures.py
+++ b/python/Ganga/new_tests/GPI/Mergers/TestMergeFailures.py
@@ -4,12 +4,11 @@ import os
 
 import pytest
 
-from GangaTest.Framework.utils import sleep_until_completed, sleep_until_state
 from Ganga.GPIDev.Base.Proxy import getProxyClass
-
-from ..GangaUnitTest import GangaUnitTest
-from .MergerTester import MergerTester
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
+from GangaTest.Framework.utils import sleep_until_completed, sleep_until_state
 from .CopySplitter import CopySplitter
+from .MergerTester import MergerTester
 
 CopySplitter = getProxyClass(CopySplitter)
 MergerTester = getProxyClass(MergerTester)

--- a/python/Ganga/new_tests/GPI/Mergers/TestSmartMerger.py
+++ b/python/Ganga/new_tests/GPI/Mergers/TestSmartMerger.py
@@ -3,10 +3,9 @@ from __future__ import absolute_import
 import os
 import tempfile
 
-from GangaTest.Framework.utils import sleep_until_completed, file_contains, write_file
 from Ganga.Lib.Mergers.Merger import findFilesToMerge
-
-from ..GangaUnitTest import GangaUnitTest
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
+from GangaTest.Framework.utils import sleep_until_completed, file_contains, write_file
 
 
 class TestSmartMerger(GangaUnitTest):

--- a/python/Ganga/new_tests/GPI/Mergers/TestStdOut.py
+++ b/python/Ganga/new_tests/GPI/Mergers/TestStdOut.py
@@ -3,7 +3,7 @@ from __future__ import division, absolute_import
 import os
 import tempfile
 
-from ..GangaUnitTest import GangaUnitTest
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
 
 
 class TestStdOut(GangaUnitTest):

--- a/python/Ganga/new_tests/GPI/Mergers/TestStructure.py
+++ b/python/Ganga/new_tests/GPI/Mergers/TestStructure.py
@@ -5,8 +5,8 @@ import tempfile
 
 import pytest
 
-from ..GangaUnitTest import GangaUnitTest
 from Ganga.GPIDev.Adapters.IPostProcessor import PostProcessException
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
 
 
 class TestStructure(GangaUnitTest):

--- a/python/Ganga/new_tests/GPI/Monitoring/TestMonitoring.py
+++ b/python/Ganga/new_tests/GPI/Monitoring/TestMonitoring.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import time
 
-from ..GangaUnitTest import GangaUnitTest
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
 
 master_timeout = 300.
 
@@ -22,13 +22,12 @@ class TestMonitoring(GangaUnitTest):
         super(TestMonitoring, self).setUp(extra_opts=extra_opts)
 
     def tearDown(self):
-        from Ganga.Utility.Config import getConfig
         #getConfig('PollThread').getOption('autostart').revertToDefault()
         #getConfig('PollThread').getOption('base_poll_rate').revertToDefault()
         super(TestMonitoring, self).tearDown()
 
     def test_a_JobConstruction(self):
-        from Ganga.GPI import Job, jobs, disableMonitoring
+        from Ganga.GPI import Job, jobs
 
         j=Job()
 
@@ -59,7 +58,7 @@ class TestMonitoring(GangaUnitTest):
 
     def test_d_anotherNewJob(self):
 
-        from Ganga.GPI import Job, jobs
+        from Ganga.GPI import Job
 
         j=Job()
 
@@ -68,7 +67,7 @@ class TestMonitoring(GangaUnitTest):
 
     def test_e_reEnableMon(self):
 
-        from Ganga.GPI import disableMonitoring, enableMonitoring, Job, jobs
+        from Ganga.GPI import disableMonitoring, enableMonitoring, Job
 
         disableMonitoring()
         enableMonitoring()

--- a/python/Ganga/new_tests/GPI/Parallel/TestQueuedSubmit.py
+++ b/python/Ganga/new_tests/GPI/Parallel/TestQueuedSubmit.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import, print_function
 
-from ..GangaUnitTest import GangaUnitTest
-
 import time
+
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
 
 global_num_threads = 20
 global_num_jobs = global_num_threads*5
@@ -23,7 +23,7 @@ class TestQueuedSubmit(GangaUnitTest):
         assert num_threads == global_num_threads
 
     def test_b_SetupJobs(self):
-        from Ganga.GPI import Job, jobs, Executable
+        from Ganga.GPI import Job, jobs
 
         # Just in-case, I know this shouldn't be here, but if the repo gets polluted this is a sane fix
         for j in jobs:
@@ -60,7 +60,7 @@ class TestQueuedSubmit(GangaUnitTest):
             assert j.status != 'new'
 
     def test_d_Finished(self):
-        from Ganga.GPI import jobs, queues
+        from Ganga.GPI import jobs
         from GangaTest.Framework.utils import sleep_until_completed
 
         print('waiting on job', end=' ')

--- a/python/Ganga/new_tests/GPI/Parser/TestParser.py
+++ b/python/Ganga/new_tests/GPI/Parser/TestParser.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from ..GangaUnitTest import GangaUnitTest
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
 
 class TestParser(GangaUnitTest):
 

--- a/python/Ganga/new_tests/GPI/Parser/TestSelect.py
+++ b/python/Ganga/new_tests/GPI/Parser/TestSelect.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from ..GangaUnitTest import GangaUnitTest
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
 
 class TestSelect(GangaUnitTest):
 
@@ -26,7 +26,7 @@ class TestSelect(GangaUnitTest):
 
     def test_SelectSubJob(self):
 
-        from Ganga.GPI import Job, jobs, ArgSplitter
+        from Ganga.GPI import Job, ArgSplitter
         j=Job(splitter=ArgSplitter(args=[[1],[2],[3]]))
 
         assert len(j.subjobs) == 0

--- a/python/Ganga/new_tests/GPI/TestArgSplitter.py
+++ b/python/Ganga/new_tests/GPI/TestArgSplitter.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from .GangaUnitTest import GangaUnitTest
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
 
 
 class TestArgSplitter(GangaUnitTest):

--- a/python/Ganga/new_tests/GPI/TestJob.py
+++ b/python/Ganga/new_tests/GPI/TestJob.py
@@ -1,4 +1,4 @@
-from GangaUnitTest import GangaUnitTest
+from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest
 
 class TestJob(GangaUnitTest):
 

--- a/python/Ganga/new_tests/lib/GangaUnitTest.py
+++ b/python/Ganga/new_tests/lib/GangaUnitTest.py
@@ -92,6 +92,10 @@ def start_ganga(gangadir_for_test, extra_opts=[]):
         else:
             logger.info("InternalServices still running")
 
+    # Set the extra options again here in case they were overridden by initEnvironment() above
+    for opt in extra_opts:
+        setConfigOption(*opt)
+
     logger.info("Bootstrapping")
     Ganga.Runtime._prog.bootstrap(interactive=False)
 

--- a/python/Ganga/new_tests/lib/__init__.py
+++ b/python/Ganga/new_tests/lib/__init__.py
@@ -1,0 +1,3 @@
+"""
+Collection of modules to provide helpers for the test suite
+"""


### PR DESCRIPTION
I'm working on a `Dirac` backend test and this is prerequisite for that so that tests in other plugins can access `GangaUnitTest` via `from Ganga.new_tests.lib.GangaUnitTest import GangaUnitTest`.

This only affects the tests and I believe I've (well, PyCharm) caught all the places where the import path needs to change