### PR TITLE
Making Registry and __set__ excluively lock and __set__ and __get__ lock but not registry and __get__

### DIFF
--- a/python/Ganga/Core/GangaRepository/Registry.py
+++ b/python/Ganga/Core/GangaRepository/Registry.py
@@ -694,7 +694,7 @@ class Registry(object):
             if not obj._dirty:
                 continue
 
-            with obj.lock:
+            with obj.reg_lock:
                 # flush the object. Need to call _getWriteAccess for consistency reasons
                 # TODO: getWriteAccess should only 'get write access', as that's not needed should it be called here?
                 obj._getWriteAccess()
@@ -724,7 +724,7 @@ class Registry(object):
         if obj_id in self._inprogressDict.keys():
             return
 
-        with _obj.lock:
+        with _obj.reg_lock:
             self.__safe_read_access(_obj, sub_obj)
 
     @synchronised
@@ -803,7 +803,7 @@ class Registry(object):
         if obj_id in self._inprogressDict.keys():
             return
 
-        with obj.lock:
+        with obj.reg_lock:
             self.__write_access(obj)
 
     def __write_access(self, _obj):

--- a/python/Ganga/Core/GangaRepository/Registry.py
+++ b/python/Ganga/Core/GangaRepository/Registry.py
@@ -694,7 +694,7 @@ class Registry(object):
             if not obj._dirty:
                 continue
 
-            with obj.reg_lock:
+            with obj.const_lock:
                 # flush the object. Need to call _getWriteAccess for consistency reasons
                 # TODO: getWriteAccess should only 'get write access', as that's not needed should it be called here?
                 obj._getWriteAccess()
@@ -724,7 +724,7 @@ class Registry(object):
         if obj_id in self._inprogressDict.keys():
             return
 
-        with _obj.reg_lock:
+        with _obj.const_lock:
             self.__safe_read_access(_obj, sub_obj)
 
     @synchronised
@@ -803,7 +803,7 @@ class Registry(object):
         if obj_id in self._inprogressDict.keys():
             return
 
-        with obj.reg_lock:
+        with obj.const_lock:
             self.__write_access(obj)
 
     def __write_access(self, _obj):

--- a/python/Ganga/Core/GangaRepository/SubJobXMLList.py
+++ b/python/Ganga/Core/GangaRepository/SubJobXMLList.py
@@ -363,12 +363,14 @@ class SubJobXMLList(GangaObject):
                 try:
                     subjob_data = self.__get_dataFile(str(index), True)
                     self._cachedJobs[index] = from_file(sj_file)[0]
+                    if self._definedParent is not None:
+                        self._cachedJobs[index]._setParent( self._definedParent )
                 except Exception as err:
                     logger.debug("Failed to Load XML for job: %s using: %s" % (str(index), str(subjob_data)))
                     logger.debug("Err:\n%s" % str(err))
                     raise err
 
-        if self._definedParent is not None:
+        if self._definedParent is not None and self._cachedJobs[index]._getParent() is not self._definedParent:
             self._cachedJobs[index]._setParent( self._definedParent )
         return self._cachedJobs[index]
 
@@ -385,12 +387,14 @@ class SubJobXMLList(GangaObject):
 
         super(SubJobXMLList, self)._setParent( parentObj )
 
-        self._definedParent = parentObj
+        if self._definedParent is not parentObj:
+            self._definedParent = parentObj
 
         if not hasattr(self, '_cachedJobs'):
             return
         for k in self._cachedJobs.keys():
-            self._cachedJobs[k]._setParent( parentObj )
+            if self._cachedJobs[k]._getParent() is not self._definedParent:
+                self._cachedJobs[k]._setParent( parentObj )
 
     def getCachedData(self, index):
         """Get the cached data from the index for one of the subjobs"""

--- a/python/Ganga/GPIDev/Base/Objects.py
+++ b/python/Ganga/GPIDev/Base/Objects.py
@@ -58,7 +58,7 @@ def synchronised(f):
     """
     @functools.wraps(f)
     def decorated(self, *args, **kwargs):
-        with self._internal_lock:
+        with self.const_lock:
             return f(self, *args, **kwargs)
     return decorated
 
@@ -134,8 +134,7 @@ class Node(object):
         if parent is None:
             setattr(self, '_parent', parent)
         else:
-            with parent.const_lock:
-                with parent._internal_lock:  # This will lock the _new_ root object
+            with parent.const_lock: # This will lock the _new_ root object
                     setattr(self, '_parent', parent)
             # Finally the new and then old root objects will be unlocked
 

--- a/python/Ganga/GPIDev/Base/Objects.py
+++ b/python/Ganga/GPIDev/Base/Objects.py
@@ -158,6 +158,10 @@ class Node(object):
         """
         This is a context manager which acquires the const write lock on the
         object's root object.
+
+        This lock acquires exclusive access over an object tree to prevent it
+        changing. Reading schema attributes on the object is still allowed
+        but changing them is not. Only one thread can hold this lock at once.
         """
         root = self._getRoot()
         root._write_lock.acquire()

--- a/python/Ganga/GPIDev/Base/Objects.py
+++ b/python/Ganga/GPIDev/Base/Objects.py
@@ -135,7 +135,7 @@ class Node(object):
             setattr(self, '_parent', parent)
         else:
             with parent.const_lock: # This will lock the _new_ root object
-                    setattr(self, '_parent', parent)
+                setattr(self, '_parent', parent)
             # Finally the new and then old root objects will be unlocked
 
     @property

--- a/python/Ganga/GPIDev/Base/Objects.py
+++ b/python/Ganga/GPIDev/Base/Objects.py
@@ -41,7 +41,7 @@ logger = Ganga.Utility.logging.getLogger(modulename=1)
 
 _imported_GangaList = None
 
-do_not_copy = ['_index_cache', '_parent', '_registry', '_data', '_lock', '_proxyObject']
+do_not_copy = ['_index_cache', '_parent', '_registry', '_data', '_lock', '_reg_lock', '_proxyObject']
 
 def _getGangaList():
     global _imported_GangaList

--- a/python/Ganga/new_tests/Unit/TestGangaObject.py
+++ b/python/Ganga/new_tests/Unit/TestGangaObject.py
@@ -263,7 +263,7 @@ class TestThreadSafeGangaObject(MultiThreadedTestCase):
             rand = random.Random()
             rand.seed(time.clock() + thread_number)
             for _ in range(100):
-                with o.lock:
+                with o.const_lock:
                     num = rand.randint(0, 1000)
                     o.a = num
                     time.sleep(rand.uniform(0, 1E-6))
@@ -290,7 +290,7 @@ class TestThreadSafeGangaObject(MultiThreadedTestCase):
             rand = random.Random()
             rand.seed(time.clock() + thread_number)
             for _ in range(100):
-                with child.lock:
+                with child.const_lock:
                     num = rand.randint(0, 1000)
                     o.a = num
                     child_num = rand.randint(0, 1000)
@@ -320,13 +320,13 @@ class TestThreadSafeGangaObject(MultiThreadedTestCase):
             rand = random.Random()
             rand.seed(time.clock() + thread_number)
             for _ in range(10):  # Run this thread many times to keep it running for long enough to see problems.
-                with o.lock:
+                with o.const_lock:
                     num = rand.randint(0, 1000)
                     o.a = num
                     time.sleep(rand.uniform(0, 1E-6))
                     assert o.a == num
 
-                with o.lock:
+                with o.const_lock:
                     o.b = rand.choice([ThreadedTestGangaObject, SimpleGangaObject])()
                     child_num = rand.randint(0, 1000)
                     o.b.a = child_num
@@ -340,7 +340,7 @@ class TestThreadSafeGangaObject(MultiThreadedTestCase):
                         time.sleep(rand.uniform(0, 1E-6))
                         assert o.b.b.a == num
 
-                with o.lock:
+                with o.const_lock:
                     num = rand.randint(0, 1000)
                     o.b.a = num
                     time.sleep(rand.uniform(0, 1E-6))

--- a/python/Ganga/new_tests/Unit/TestGangaObject.py
+++ b/python/Ganga/new_tests/Unit/TestGangaObject.py
@@ -254,7 +254,13 @@ class TestThreadSafeGangaObject(MultiThreadedTestCase):
 
     def test_read_write(self):
         """
-        This tests whether claiming a lock on the object stops other threads overwriting our value
+        This tests whether claiming a lock on the object stops other threads
+        overwriting our value. It starts two types of thread:
+
+        1. one which acquires a lock for its duraction, sets values and then
+        makes sure they are unchanged
+        2. one which sets the value being checked in thread-type 1 to random
+        values.
         """
         o = ThreadedTestGangaObject()
         random.seed(time.gmtime())
@@ -279,7 +285,11 @@ class TestThreadSafeGangaObject(MultiThreadedTestCase):
         """
         Are parent locks held correctly?
 
-        We make a parent and a child and then check whether claiming an explicit lock on the child will stop changes to the parent.
+        We make a parent and a child and then check whether claiming an
+        explicit lock on the child will stop changes to the parent.
+
+        This is similar to ``test_read_write`` except it is working on a child
+        object and making sure the lock holds.
         """
         o = ThreadedTestGangaObject()
         o.b = SimpleGangaObject()
@@ -311,8 +321,10 @@ class TestThreadSafeGangaObject(MultiThreadedTestCase):
         """
         Make sure that the coarse locks work
 
-        In each thread we grab sole access of the object via its ``lock`` property and do things to it.
-        This is required for the cases where you need to do multiple things to an object before allowing anyone else to.
+        In each thread we grab sole access of the object via its ``const_lock``
+        property and do things to it.
+        This is required for the cases where you need to do multiple things to
+        an object before allowing anyone else to.
         """
         o = ThreadedTestGangaObject()
 

--- a/python/Ganga/new_tests/Unit/TestGangaObject.py
+++ b/python/Ganga/new_tests/Unit/TestGangaObject.py
@@ -189,7 +189,7 @@ class MultiThreadedTestCase(unittest.TestCase):
     and any exception raised by the thread will be correctly propagated to the main thread with correct traceback for test failure reporting.
     """
 
-    def run_threads(self, functions=None, num_threads=50, timeout=30):
+    def run_threads(self, functions=None, num_threads=50, timeout=60):
         """
         Args:
             functions: a list of functions which will be randomly chosen to run in threads. They will take one argument which is an integer thread id
@@ -346,4 +346,4 @@ class TestThreadSafeGangaObject(MultiThreadedTestCase):
                     time.sleep(rand.uniform(0, 1E-6))
                     assert o.b.a == num
 
-        self.run_threads([change], num_threads=50)
+        self.run_threads([change])


### PR DESCRIPTION
This PR makes the Descriptor  ```__set__``` and registry access exclusively lock to the same thread and have the ```__get__``` and ```__set__``` of the Root of an object exclusively lock on a thread without requiring that the Registry and Descriptor ```__get__``` methods exclusively lock access.

This appears to alleviate the problems experienced when submitting man LHCbDirac subjobs that causes Ganga to lockup after a few minutes of use.

I'm keen to see how this performs on the Jenkins system but this alleviates problems on lxplus for LHCb.

I can't motivate a strong reason why the Registry and Descriptor ```__get__``` methods should mutually lock the root of an object.

If there are strong objections then another solution to #293 is going to have to be found ahead of 6.1.17