### PR TITLE
Close file handles in SessionLock

### DIFF
--- a/python/Ganga/Core/GangaRepository/SessionLock.py
+++ b/python/Ganga/Core/GangaRepository/SessionLock.py
@@ -453,6 +453,7 @@ class SessionLockManager(object):
                 if session_lock_refresher.numberRepos() <= 1:
                     session_lock_refresher = None
             #logger.debug("Session file '%s' deleted " % (self.fn))
+            os.close(self.lockfd)
             os.unlink(self.fn)
             # os.unlink(self.gfn)
         except OSError as x:

--- a/python/Ganga/Core/GangaRepository/SessionLock.py
+++ b/python/Ganga/Core/GangaRepository/SessionLock.py
@@ -484,17 +484,17 @@ class SessionLockManager(object):
                 if not os.path.exists(lock_path):
                     os.makedirs(lock_path)
                 if not os.path.isfile(lock_file):
-                    lock_file_hand = open(lock_file, "w")
-                    lock_file_hand.close()
+                    with open(lock_file, "w"):
+                        pass
             except Exception as err:
                 logger.debug("Global Lock Setup Error: %s" % str(err))
         else:
             try:
                 self.lockfn = os.path.join(self.sdir, "global_lock")
                 if not os.path.isfile(self.lockfn):
-                    lock = open(self.lockfn, "w")
-                    # create file (does not interfere with existing sessions)
-                    lock.close()
+                    with open(self.lockfn, "w"):
+                        # create file (does not interfere with existing sessions)
+                        pass
                 self.lockfd = self.delayopen_global(self.lockfn)
                 registerGlobalSessionFile(self.lockfn)
                 registerGlobalSessionFileHandler(self.lockfd)
@@ -548,8 +548,8 @@ class SessionLockManager(object):
                 os.system("fs setacl %s %s rliwka" % (lock_path, getpass.getuser()))
 
                 while not os.path.isfile(lock_file):
-                    lock_file_hand = open(lock_file, "w")
-                    lock_file_hand.close()
+                    with open(lock_file, "w"):
+                        pass
                     time.sleep(0.01)
 
             else:
@@ -855,9 +855,8 @@ class SessionLockManager(object):
     def check(self):
         self.global_lock_acquire()
         try:
-            f = open(self.cntfn)
-            newcount = int(f.readline())
-            f.close()
+            with open(self.cntfn) as f:
+                newcount = int(f.readline())
             assert newcount >= self.count
             sessions = os.listdir(self.sdir)
             prevnames = set()
@@ -870,9 +869,8 @@ class SessionLockManager(object):
                     if not self.afs:
                         fd = os.open(sf, os.O_RDONLY)
                         fcntl.lockf(fd, fcntl.LOCK_SH)  # ONLY NFS
-                    sf_file = open(sf)
-                    names = pickle.load(sf_file)
-                    sf_file.close()
+                    with open(sf) as sf_file:
+                        names = pickle.load(sf_file)
                     if not self.afs and fd > 0:
                         fcntl.lockf(fd, fcntl.LOCK_UN)  # ONLY NFS
                         os.close(fd)
@@ -907,9 +905,8 @@ class SessionLockManager(object):
                     if not self.afs:
                         fd = os.open(sf, os.O_RDONLY)
                         fcntl.lockf(fd, fcntl.LOCK_SH)  # ONLY NFS
-                    sf_file = open(sf)
-                    names = pickle.load(sf_file)
-                    sf_file.close()
+                    with open(sf) as sf_file:
+                        names = pickle.load(sf_file)
                     if not self.afs and fd > 0:
                         fcntl.lockf(fd, fcntl.LOCK_UN)  # ONLY NFS
                         os.close(fd)


### PR DESCRIPTION
I've been working on my new laptop today and when running the test suite I was finding that it was failing towards the end with a `Too many open files` error. Looking into the number of open file handles Ganga had, I was finding that it was increasing steadily with time. Looking in `/proc/<PID>/fd/` I saw lots and lots of `/home/matt/gangadir_testing/TestJob/repository/testframework/LocalXML/6.0/sessions/global_lock (deleted)`.

This PR makes sure firstly that all the calls to `close()` are either guarded by a context manager or by a `finally`. Secondly, it actually closes the `global_lock` file when the session closes down.