### PR TITLE
Making import GangaList work from within Proxy layer

### DIFF
--- a/python/Ganga/GPIDev/Base/Proxy.py
+++ b/python/Ganga/GPIDev/Base/Proxy.py
@@ -13,6 +13,8 @@ from Ganga.GPIDev.Schema import ComponentItem
 from Ganga.GPIDev.Base.Objects import Node, GangaObject, ObjectMetaclass, _getName
 from Ganga.Core import GangaAttributeError, ProtectedAttributeError, ReadOnlyObjectError, TypeMismatchError
 
+from Ganga.GPIDev.Lib.GangaList.GangaList import GangaList
+
 import os
 
 from inspect import isclass
@@ -142,14 +144,7 @@ def raw_eval(val):
     return new_val
 
 def getKnownLists():
-    global _knownLists
-    if _knownLists is None:
-        try:
-            from Ganga.GPIDev.Lib.GangaList.GangaList import GangaList
-        except ImportError:
-            _knownLists = None
-            return (tuple, list)
-        _knownLists = (tuple, list, GangaList)
+    _knownLists = (tuple, list, GangaList)
     return _knownLists
 
 def isProxy(obj):
@@ -436,6 +431,7 @@ class ProxyDataDescriptor(object):
         else:
             # val is not iterable
             if item['strict_sequence']:
+                logger.error("Didn't expect to get: %s" % str(val))
                 raise GangaAttributeError('cannot assign a simple value %s to a strict sequence attribute %s.%s (a list is expected instead)' % (repr(val), getName(obj), name))
             if stripper is not None:
                 new_v = makeGangaList(stripper(val))

--- a/python/Ganga/GPIDev/Schema/Schema.py
+++ b/python/Ganga/GPIDev/Schema/Schema.py
@@ -400,16 +400,7 @@ class Item(object):
     # compare the kind of item:
     # all calls are equivalent:
     # item.isA(SimpleItem)
-    def isA(self, _what):
-
-        try:
-            from Ganga.GPIDev.Base.Proxy import stripProxy
-        except ImportError:
-            def dummyfunc(arg):
-                return arg
-            stripProxy = dummyfunc
-
-        what = stripProxy(_what)
+    def isA(self, what):
 
         if isinstance(what, types.InstanceType):
             what = what.__class__

--- a/python/Ganga/GPIDev/Schema/Schema.py
+++ b/python/Ganga/GPIDev/Schema/Schema.py
@@ -111,8 +111,8 @@ class Schema(object):
 
     @property
     def name(self):
-        from Ganga.GPIDev.Base.Proxy import getName
-        return getName(self._pluginclass)
+        from Ganga.GPIDev.Base.Objects import _getName
+        return _getName(self._pluginclass)
 
     def allItems(self):
         if self.datadict is None: return zip()
@@ -402,7 +402,12 @@ class Item(object):
     # item.isA(SimpleItem)
     def isA(self, _what):
 
-        from Ganga.GPIDev.Base.Proxy import stripProxy
+        try:
+            from Ganga.GPIDev.Base.Proxy import stripProxy
+        except ImportError:
+            def dummyfunc(arg):
+                return arg
+            stripProxy = dummyfunc
 
         what = stripProxy(_what)
 

--- a/python/Ganga/GPIDev/TypeCheck.py
+++ b/python/Ganga/GPIDev/TypeCheck.py
@@ -101,7 +101,7 @@ def _valueTypeAllowed(val, valTypeList, logger=None):
         try:
             from Ganga.GPIDev.Base import GangaObject
         except:
-            GangaObject = None
+            GangaObject = type(None)
 
         raw_type = stripProxy(_type)
         raw_val = stripProxy(val)

--- a/python/Ganga/Runtime/bootstrap.py
+++ b/python/Ganga/Runtime/bootstrap.py
@@ -869,6 +869,9 @@ under certain conditions; type license() for details.
 
         from Ganga.Runtime.GPIexport import exportToGPI
 
+        from Ganga.GPIDev.Lib.GangaList.GangaList import GangaList
+        exportToGPI('GangaList', GangaList, 'Classes')
+
         from Ganga.Utility.Plugin import allPlugins
         # make all plugins visible in GPI
         for k in allPlugins.allCategories():


### PR DESCRIPTION
This change is to primarily allow for ```from Ganga.GPIDev.Lib.GangaList.GangaList import GangaList``` to work at the top of ```Proxy.py```

This moves around a load of imports but not much else. I find this nicer than the previous solution where it wasn't clear from reading the code if it has always been loaded or not.