### PR TITLE
Add a thread stacktracer

### DIFF
--- a/python/Ganga/Runtime/bootstrap.py
+++ b/python/Ganga/Runtime/bootstrap.py
@@ -26,9 +26,11 @@ import string
 import sys
 import time
 import re
+import atexit
 
 from Ganga import _gangaVersion, _gangaPythonPath
 from Ganga.Utility.Config.Config import getConfig
+from Ganga.Utility import stacktracer
 import Ganga.Runtime
 
 def new_version_format_to_old(version):
@@ -845,6 +847,10 @@ under certain conditions; type license() for details.
         from Ganga.Utility.Runtime import allRuntimes
         from Ganga.Utility.logging import getLogger
         logger = getLogger()
+
+        # Start tracking all the threads and saving the information to a file
+        stacktracer.trace_start()
+        atexit.register((100, stacktracer.trace_stop))
 
         for n, r in zip(allRuntimes.keys(), allRuntimes.values()):
             try:

--- a/python/Ganga/Utility/feedback_report.py
+++ b/python/Ganga/Utility/feedback_report.py
@@ -186,6 +186,7 @@ def report(job=None):
         gangaLogFileName = "gangalog.txt"
         jobsListFileName = "jobslist.txt"
         tasksListFileName = "taskslist.txt"
+        thread_trace_file_name = 'thread_trace.html'
         from Ganga.Utility import Config
         uploadFileServer = Config.getConfig('Feedback')['uploadServer']
         #uploadFileServer= "http://gangamon.cern.ch/django/errorreports/"
@@ -651,6 +652,15 @@ def report(job=None):
             except Exception as err:
                 logger.debug("Err %s" % str(err))
                 writeErrorLog(str(sys.exc_info()[1]))
+
+        # Copy thread stack trace file
+        try:
+            thread_trace_source_path = os.path.join(getConfig('Configuration')['gangadir'], thread_trace_file_name)
+            thread_trace_target_path = os.path.join(fullLogDirName, thread_trace_file_name)
+            shutil.copyfile(thread_trace_source_path, thread_trace_target_path)
+        except (OSError, IOError) as err:
+            logger.debug('Err %s', err)
+            writeErrorLog(str(sys.exc_info()[1]))
 
         resultArchive = '%s.tar.gz' % folderToArchive
 

--- a/python/Ganga/Utility/stacktracer.py
+++ b/python/Ganga/Utility/stacktracer.py
@@ -99,7 +99,10 @@ class TraceDumper(threading.Thread):
 
     def stacktraces(self):
         with open(self.path, 'wb+') as fout:
-            fout.write(stacktraces())
+            try:
+                fout.write(stacktraces())
+            except IOError:
+                pass  # Don't warn if the file faile to write
 
 
 _tracer = None

--- a/python/Ganga/Utility/stacktracer.py
+++ b/python/Ganga/Utility/stacktracer.py
@@ -14,6 +14,7 @@ import sys
 import threading
 import time
 import traceback
+from datetime import datetime
 
 try:
     from pygments import highlight
@@ -54,6 +55,7 @@ def stacktraces():
         trace = traceback.format_stack(stack)
         html.append(highlight_trace(''.join(trace)))
 
+    html.append('<small>' + datetime.utcnow().isoformat() + '</small>')
     html.append('</body>')
     html.append('</html>')
 

--- a/python/Ganga/Utility/stacktracer.py
+++ b/python/Ganga/Utility/stacktracer.py
@@ -1,0 +1,135 @@
+"""
+Stack tracer for multi-threaded applications.
+
+Usage:
+
+from Ganga.Utility import stacktracer
+stacktracer.trace_start('trace.html')
+....
+stacktracer.trace_stop()
+"""
+
+import os
+import sys
+import threading
+import time
+import traceback
+
+try:
+    from pygments import highlight
+    from pygments.formatters.html import HtmlFormatter
+    from pygments.lexers.python import Python3TracebackLexer
+    def highlight_trace(string):
+        return highlight(string, Python3TracebackLexer(), HtmlFormatter(noclasses=True))
+except ImportError:
+    def highlight_trace(string):
+        return '<pre>' + string + '</pre>'
+
+
+def stacktraces():
+    # type: () -> str
+    """
+    Based on http://bzimmer.ziclix.com/2008/12/17/python-thread-dumps/
+
+    Returns:
+        str: HTML code to be saved to a file
+    """
+    html = [
+        '<!doctype html>',
+        '<html lang="en">',
+        '<head>',
+        '<meta charset=utf-8>',
+        '<title>Current Ganga Threads</title>',
+        '</head>'
+        '<body>'
+        '<h1>Current Ganga Threads</h1>',
+    ]
+    for thread_id, stack in sys._current_frames().items():
+        name = dict((t.ident, t.name) for t in threading.enumerate())
+        title = '<h2>{0}</h2>'.format(name.get(thread_id, None))
+        html.append(title)
+
+        trace = traceback.format_stack(stack)
+        html.append(highlight_trace(''.join(trace)))
+
+    html.append('</body>')
+    html.append('</html>')
+
+    return '\n'.join(html)
+
+
+class TraceDumper(threading.Thread):
+    """
+    Dump stack traces into a given file periodically.
+
+    This part was heavily based on code by
+    `nagylzs <http://code.activestate.com/recipes/577334-how-to-debug-deadlocked-multi-threaded-programs/>`_
+    """
+    def __init__(self, path, interval, auto):
+        # type: (str, int, bool) -> None
+        """
+        Args:
+            path: File path to output HTML (stack trace file)
+            interval: In seconds: how often to update the trace file.
+            auto: Set flag (True) to update trace continuously.
+                Clear flag (False) to update only if file not exists.
+                (Then delete the file to force update.)
+        """
+        assert interval > 0.1, 'Stacktracer interval must be greater than 0.1 seconds'
+        threading.Thread.__init__(self)
+        self.auto = auto
+        self.interval = interval
+        self.path = os.path.abspath(path)
+        self.stop_requested = threading.Event()
+        self.daemon = True
+
+    def run(self):
+        while not self.stop_requested.isSet():
+            time.sleep(self.interval)
+            if self.auto or not os.path.isfile(self.path):
+                self.stacktraces()
+
+    def stop(self):
+        self.stop_requested.set()
+        self.join()
+        try:
+            os.unlink(self.path)
+        except OSError:
+            pass
+
+    def stacktraces(self):
+        with open(self.path, 'wb+') as fout:
+            fout.write(stacktraces())
+
+
+_tracer = None
+
+
+def trace_start(path, interval=5, auto=True):
+    # type: (str, int, bool) -> None
+    """
+    Start tracing into the given file.
+
+    Args:
+        path: File path to output HTML (stack trace file)
+        interval: In seconds: how often to update the trace file.
+        auto: Set flag (True) to update trace continuously.
+            Clear flag (False) to update only if file not exists.
+            (Then delete the file to force update.)
+    """
+    global _tracer
+    if _tracer is None:
+        _tracer = TraceDumper(path, interval, auto)
+        _tracer.start()
+    else:
+        raise Exception('Already tracing to {0}'.format(_tracer.path))
+
+
+def trace_stop():
+    """Stop tracing."""
+    global _tracer
+    if _tracer is None:
+        raise Exception('Not tracing, cannot stop.')
+    else:
+        _tracer.stop()
+        _tracer = None

--- a/python/Ganga/Utility/stacktracer.py
+++ b/python/Ganga/Utility/stacktracer.py
@@ -25,6 +25,8 @@ except ImportError:
     def highlight_trace(string):
         return '<pre>' + string + '</pre>'
 
+from Ganga.Utility.Config import getConfig
+
 
 def stacktraces():
     # type: () -> str
@@ -108,7 +110,7 @@ class TraceDumper(threading.Thread):
 _tracer = None
 
 
-def trace_start(path, interval=5, auto=True):
+def trace_start(filename='thread_trace.html', interval=5, auto=True):
     # type: (str, int, bool) -> None
     """
     Start tracing into the given file.
@@ -120,6 +122,7 @@ def trace_start(path, interval=5, auto=True):
             Clear flag (False) to update only if file not exists.
             (Then delete the file to force update.)
     """
+    path = os.path.join(getConfig('Configuration')['gangadir'], filename)
     global _tracer
     if _tracer is None:
         _tracer = TraceDumper(path, interval, auto)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pytest
 pytest-cov
 unittest2
 coverage
+pygments


### PR DESCRIPTION
This adds a module to `Ganga.Utility` to provide the dumping of thread stacktraces to a file. It can be used with:
```python
from Ganga.Utility import stacktracer
stacktracer.trace_start('trace.html')
```
That code that can, for example, be added to a user's `~/.ganga.py` or just run live.

It may be useful in the future to incorporate this with `report()` or maybe the monitoring thread heartbeat monitor. I think we should also think about running this alongside the test suite so that locked-up tests can be debugged even on Jenkins.