### PR TITLE
Fix object equality

### DIFF
--- a/python/Ganga/GPIDev/Base/Objects.py
+++ b/python/Ganga/GPIDev/Base/Objects.py
@@ -325,10 +325,7 @@ class Node(object):
         from Ganga.GPIDev.Base.VPrinter import VSummaryPrinter
         self.accept(VSummaryPrinter(level, verbosity_level, whitespace_marker, out, selection, interactive))
 
-    def __eq__(self, _node):
-
-        node = _node
-
+    def __eq__(self, node):
         if self is node:
             return 1
 

--- a/python/Ganga/GPIDev/Base/Objects.py
+++ b/python/Ganga/GPIDev/Base/Objects.py
@@ -327,18 +327,18 @@ class Node(object):
 
     def __eq__(self, node):
         if self is node:
-            return 1
+            return True
 
         if not isinstance(node, type(self)):
-            return 0
+            return False
 
         # Compare the schemas against each other
         if (hasattr(self, '_schema') and self._schema is None) and (hasattr(node, '_schema') and node._schema is None):
-            return 1  # If they're both `None`
+            return True  # If they're both `None`
         elif (hasattr(self, '_schema') and self._schema is None) or (hasattr(node, '_schema') and node._schema is None):
-            return 0  # If just one of them is `None`
+            return False  # If just one of them is `None`
         elif not self._schema.isEqual(node._schema):
-            return 0  # Both have _schema but do not match
+            return False  # Both have _schema but do not match
 
         # Check each schema item in turn and check for equality
         for (name, item) in self._schema.allItems():
@@ -346,9 +346,9 @@ class Node(object):
                 #logger.info("testing: %s::%s" % (str(_getName(self)), str(name)))
                 if getattr(self, name) != getattr(node, name):
                     #logger.info( "diff: %s::%s" % (str(_getName(self)), str(name)))
-                    return 0
+                    return False
 
-        return 1
+        return True
 
     def __ne__(self, node):
         return not self.__eq__(node)

--- a/python/Ganga/GPIDev/Base/Objects.py
+++ b/python/Ganga/GPIDev/Base/Objects.py
@@ -331,8 +331,6 @@ class Node(object):
 
         if self is node:
             return 1
-        if not node:  # or not self._schema.isEqual(node._schema):
-            return 0
 
         if not isinstance(node, type(self)):
             return 0

--- a/python/Ganga/new_tests/GPI/TestJob.py
+++ b/python/Ganga/new_tests/GPI/TestJob.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+from Ganga.GPIDev.Base.Proxy import stripProxy
+
 from .GangaUnitTest import GangaUnitTest
 
 
@@ -106,9 +108,12 @@ class TestJob(GangaUnitTest):
         self.assertEqual( j2.splitter.values, ['arg 1', 'arg 2', 'arg 3'])
 
     def test_job_equality(self):
+        """Check that copies of Jobs are equal to each other"""
         from Ganga.GPI import Job
         j = Job()
         j2 = j.copy()
         j3 = Job(j)
         assert j == j2
         assert j2 == j3
+        assert stripProxy(j) == stripProxy(j2)
+        assert stripProxy(j2) == stripProxy(j3)

--- a/python/Ganga/new_tests/GPI/TestJob.py
+++ b/python/Ganga/new_tests/GPI/TestJob.py
@@ -1,4 +1,7 @@
-from GangaUnitTest import GangaUnitTest
+from __future__ import absolute_import
+
+from .GangaUnitTest import GangaUnitTest
+
 
 class TestJob(GangaUnitTest):
 
@@ -101,3 +104,11 @@ class TestJob(GangaUnitTest):
         self.assertTrue( isType(j2.splitter, GenericSplitter) )
         self.assertEqual( j2.splitter.attribute, "application.args" )
         self.assertEqual( j2.splitter.values, ['arg 1', 'arg 2', 'arg 3'])
+
+    def test_job_equality(self):
+        from Ganga.GPI import Job
+        j = Job()
+        j2 = j.copy()
+        j3 = Job(j)
+        assert j == j2
+        assert j2 == j3

--- a/python/Ganga/test/GPI/JobCopyConstructor.gpi
+++ b/python/Ganga/test/GPI/JobCopyConstructor.gpi
@@ -1,8 +1,0 @@
-j = Job()
-j2 = j.copy()
-j3 = Job(j)
-
-assert(j == j2)
-assert(j2 == j3)
-
-


### PR DESCRIPTION
This fixes #229 by slightly altering the definition of equality of `GangaObject`s. Previously when doing
```python
a == b
```
they would always be unequal if `b` was 'falsy' (i.e. things like `[]`, `0` and, in our case, an empty `MultiPostProcessor`).

This removes that check completely and (along with some slight tidying to `__eq__`) migrates over another (previously-failing) test.