### PR TITLE
Don't re-exec Ganga when running tests

### DIFF
--- a/python/Ganga/new_tests/GPI/GangaUnitTest.py
+++ b/python/Ganga/new_tests/GPI/GangaUnitTest.py
@@ -34,6 +34,7 @@ def start_ganga(gangadir_for_test, extra_opts=[]):
     logger.info("Parsing Command Line options")
     this_argv = [
         'ganga',  # `argv[0]` is usually the name of the program so fake that here
+        '--no-rexec',  # Don't re-exec Ganga when running tests
     ]
 
     # These are the default options for all test instances


### PR DESCRIPTION
Re-execing is now not needed for most of Ganga and this was breaking the logging while running tests.

This change allows all logging messages to be correctly captured by the test framework.

@rob-c I believe this addresses the complaint you had last week about logging within tests.