### PR TITLE
Improve stacktracer

### DIFF
--- a/python/Ganga/Core/InternalServices/ShutdownManager.py
+++ b/python/Ganga/Core/InternalServices/ShutdownManager.py
@@ -40,6 +40,8 @@ Extend the behaviour of the default *atexit* module to support:
 
 import atexit
 
+from Ganga.Utility import stacktracer
+
 
 def _ganga_run_exitfuncs():
     """run any registered exit functions
@@ -159,6 +161,9 @@ def _ganga_run_exitfuncs():
     from Ganga.Core.GangaRepository.SessionLock import removeGlobalSessionFiles, removeGlobalSessionFileHandlers
     removeGlobalSessionFileHandlers()
     removeGlobalSessionFiles()
+
+    if stacktracer._tracer:
+        stacktracer.trace_stop()
 
     from Ganga.Utility.logging import requires_shutdown, final_shutdown
     if requires_shutdown is True:

--- a/python/Ganga/Runtime/bootstrap.py
+++ b/python/Ganga/Runtime/bootstrap.py
@@ -928,7 +928,6 @@ under certain conditions; type license() for details.
 
         # Start tracking all the threads and saving the information to a file
         stacktracer.trace_start()
-        atexit.register((100, stacktracer.trace_stop))
 
         from Ganga.Utility.logging import getLogger
         logger = getLogger()

--- a/python/Ganga/Utility/stacktracer.py
+++ b/python/Ganga/Utility/stacktracer.py
@@ -102,11 +102,11 @@ class TraceDumper(threading.Thread):
             pass
 
     def stacktraces(self):
-        with open(self.path, 'wb+') as fout:
-            try:
+        try:
+            with open(self.path, 'wb+') as fout:
                 fout.write(stacktraces())
-            except IOError:
-                pass  # Don't warn if the file faile to write
+        except IOError:
+            pass  # Don't warn if the file faile to write
 
 
 _tracer = None

--- a/python/Ganga/Utility/stacktracer.py
+++ b/python/Ganga/Utility/stacktracer.py
@@ -95,7 +95,7 @@ class TraceDumper(threading.Thread):
 
     def stop(self):
         self.stop_requested.set()
-        self.join()
+        self.join(timeout=0)
         try:
             os.unlink(self.path)
         except OSError:


### PR DESCRIPTION
Due to an oversight on my part, every single test was waiting up to 5 seconds for the stacktracer to finish its loop before exiting. It's a daemon thread and we're about to delete its file anyway so there's no point in waiting.

This error was causing the integration tests to take 17 minutes on my local machine. With this PR, they now only take 7 and a bit.