### PR TITLE
Correctly propagate exception tracebacks

### DIFF
--- a/python/Ganga/Core/GangaRepository/Registry.py
+++ b/python/Ganga/Core/GangaRepository/Registry.py
@@ -590,7 +590,7 @@ class Registry(object):
             returnable_id = self.__safe_add(obj, force_index)
             ## Add to list of loaded jobs in memory
             self._loaded_ids.append(returnable_id)
-        except (RepositoryError) as err:
+        except RepositoryError as err:
             raise
         except Exception as err:
             logger.debug("Unknown Add Error: %s" % str(err))

--- a/python/Ganga/GPIDev/Lib/Job/Job.py
+++ b/python/Ganga/GPIDev/Lib/Job/Job.py
@@ -628,7 +628,7 @@ class Job(GangaObject):
         except Exception as x:
             self.status = saved_status
             log_user_exception()
-            raise JobStatusError(x)
+            raise JobStatusError(x), None, sys.exc_info()[2]
         # useful for debugging
         #finally:
         #    pass
@@ -1652,7 +1652,7 @@ class Job(GangaObject):
                 # revert to the new status
                 logger.error('%s ... reverting job %s to the new status', str(err), self.getFQID('.'))
                 self.updateStatus('new')
-                raise JobError("Error: %s" % str(err))
+                raise JobError("Error: %s" % str(err)), None, sys.exc_info()[2]
 
         # This appears to be done by the backend now in a way that handles sub-jobs,
         # in the case of a master job however we need to still perform this

--- a/python/Ganga/GPIDev/Lib/Job/Job.py
+++ b/python/Ganga/GPIDev/Lib/Job/Job.py
@@ -8,6 +8,7 @@ import os
 import re
 import time
 import uuid
+import sys
 
 import Ganga.Core.FileWorkspace
 import Ganga.GPIDev.MonitoringServices

--- a/python/Ganga/Runtime/bootstrap.py
+++ b/python/Ganga/Runtime/bootstrap.py
@@ -849,7 +849,7 @@ under certain conditions; type license() for details.
         except Exception as x:
             logger.critical('Ganga system plugins could not be loaded due to the following reason: %s', str(x))
             logger.exception(x)
-            raise GangaException(x)
+            raise GangaException(x), None, sys.exc_info()[2]
 
         # initialize runtime packages, they are registered in allRuntimes
         # dictionary automatically


### PR DESCRIPTION
Make sure that when an exception is reraised or wrapped in another exception type that the traceback points back to the original errors.

Currently in the test suite, if a test fails during a test submit then the traceback captured by pytest points at line 1659 of Job.py and the traceback looks like:
```python
self = <GPI.Bugs.TestSavannah8534.TestSavannah8534 testMethod=test_Savannah8534>

    def test_Savannah8534(self):
        from Ganga.GPI import Job, TestApplication, TestSubmitter
    
        app = TestApplication()
    
        j = Job(backend=TestSubmitter(time=30), application=app)
>       j.submit()

python/Ganga/new_tests/GPI/Bugs/TestSavannah8534.py:13: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <Ganga.GPIDev.Lib.Job.Job.Job object at 0x3fa6bd0>, keep_going = False, keep_on_fail = False, prepare = False

    def submit(self, keep_going=None, keep_on_fail=None, prepare=False):
            <...snip...>
            else:
                # revert to the new status
                logger.error('%s ... reverting job %s to the new status', str(err), self.getFQID('.'))
                self.updateStatus('new')
>               raise JobError("Error: %s" % str(err))
E               JobError: JobError: Error: list index out of range

python/Ganga/GPIDev/Lib/Job/Job.py:1659: JobError
```

While the true traceback will be present in the logging output (by virtue of `log_user_exception()`), it makes the process much harder to follow. With the changes in this PR, when the exceptions are raised, they are done so using the traceback to the original error so you get something like:
```python
self = <GPI.Bugs.TestSavannah8534.TestSavannah8534 testMethod=test_Savannah8534>

    def test_Savannah8534(self):
        from Ganga.GPI import Job, TestApplication, TestSubmitter
    
        app = TestApplication()
    
        j = Job(backend=TestSubmitter(time=30), application=app)
>       j.submit()

python/Ganga/new_tests/GPI/Bugs/TestSavannah8534.py:13: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <Ganga.GPIDev.Lib.Job.Job.Job object at 0x3fa6bd0>, keep_going = False, keep_on_fail = False, prepare = False

            <...snip...>
            a = []
>           a[3]
E           JobError: JobError: Error: list index out of range

python/Ganga/GPIDev/Lib/Job/Job.py:1659: JobError
```

Which actually points to the source of the error.

This has been discussed in a few blogs such as [Re-raising Exceptions](http://www.ianbicking.org/blog/2007/09/re-raising-exceptions.html) and [Re-throwing exceptions in Python](http://nedbatchelder.com/blog/200711/rethrowing_exceptions_in_python.html).

In Python 3 this is all much nicer as described at [The most underrated feature in Python 3](https://blog.ionelmc.ro/2014/08/03/the-most-underrated-feature-in-python-3/).