### PR TITLE
Changing RegistrySlice to have ids better determined

### DIFF
--- a/python/Ganga/GPIDev/Lib/Registry/RegistrySlice.py
+++ b/python/Ganga/GPIDev/Lib/Registry/RegistrySlice.py
@@ -41,7 +41,7 @@ class RegistrySlice(object):
         self._proxyClass = None
 
     def _getObjKeys(self):
-        return deepcopy(self.objects.keys() if not isType(self.objects, SubJobXMLList) else [_id for _id in range(len(self.objects))])
+        return deepcopy(self.objects.keys())
 
     def _getColour(self, obj):
         """ Override this function in derived slices to colorize your job/task/... list"""

--- a/python/Ganga/GPIDev/Lib/Registry/RegistrySlice.py
+++ b/python/Ganga/GPIDev/Lib/Registry/RegistrySlice.py
@@ -40,9 +40,6 @@ class RegistrySlice(object):
         self._colour_normal = Effects().normal
         self._proxyClass = None
 
-    def _getObjKeys(self):
-        return deepcopy(self.objects.keys())
-
     def _getColour(self, obj):
         """ Override this function in derived slices to colorize your job/task/... list"""
         return self._colour_normal
@@ -54,7 +51,7 @@ class RegistrySlice(object):
             raise GangaException("The variable 'keep_going' must be a boolean. Probably you wanted to do %s(%s).%s()" % (
                 self.name, keep_going, method))
         result = []
-        id_list = self._getObjKeys()
+        id_list = self.objects.keys()
         for _id in id_list:
             obj = self.objects[_id]
             try:
@@ -82,7 +79,8 @@ class RegistrySlice(object):
             maxid = sys.maxsize
         if minid is None:
             minid = 0
-        return [k for k in self._getObjKeys() if minid <= k <= maxid]
+        allObjK = self.objects.keys()
+        return [k for k in allObjK if minid <= k <= maxid]
 
     def clean(self, confirm=False, force=False):
         """Cleans the repository only if this slice represents the repository
@@ -202,7 +200,7 @@ class RegistrySlice(object):
                 maxid = sys.maxsize
             select = select_by_range
 
-        id_list = self._getObjKeys()
+        id_list = self.objects.keys()
 
         for this_id in id_list:
             obj = self.objects[this_id]
@@ -284,7 +282,7 @@ class RegistrySlice(object):
 
     def copy(self, keep_going):
         this_slice = self.__class__("copy of %s" % self.name)
-        id_list = self._getObjKeys()
+        id_list = self.objects.keys()
         for _id in id_list:
             obj = self.objects[_id]
             #obj = _unwrap(obj)
@@ -303,7 +301,8 @@ class RegistrySlice(object):
         return this_slice
 
     def __contains__(self, j):
-        return j.id in self._getObjKeys()
+        allObjK = self.objects.keys()
+        return j.id in allObjK
 
     def __call__(self, this_id):
         """ Retrieve an object by id.
@@ -362,7 +361,8 @@ class RegistrySlice(object):
 
         if isinstance(x, str):
             ids = []
-            for i in self._getObjKeys():
+            allObjK = self.objects.keys()
+            for i in allObjK:
                 j = self.objects[i]
                 if j.name == x:
                     ids.append(j.id)
@@ -448,7 +448,8 @@ class RegistrySlice(object):
             ds += "-" * len(this_format % tuple([""] * len(self._display_columns))) + "\n"
 
 
-        for obj_i in self._getObjKeys():
+        allObjK = self.objects.keys()
+        for obj_i in allObjK:
 
             cached_data = None
 

--- a/python/Ganga/GPIDev/Lib/Registry/RegistrySlice.py
+++ b/python/Ganga/GPIDev/Lib/Registry/RegistrySlice.py
@@ -5,7 +5,6 @@ from Ganga.Core.GangaRepository.Registry import RegistryKeyError, RegistryIndexE
 from Ganga.Core.GangaRepository.SubJobXMLList import SubJobXMLList
 import fnmatch
 import collections
-from copy import deepcopy
 
 from Ganga.GPIDev.Schema import ComponentItem
 from Ganga.Utility.external.OrderedDict import OrderedDict as oDict
@@ -51,8 +50,7 @@ class RegistrySlice(object):
             raise GangaException("The variable 'keep_going' must be a boolean. Probably you wanted to do %s(%s).%s()" % (
                 self.name, keep_going, method))
         result = []
-        id_list = self.objects.keys()
-        for _id in id_list:
+        for _id in self.objects.keys():
             obj = self.objects[_id]
             try:
                 if isinstance(method, str):
@@ -79,8 +77,7 @@ class RegistrySlice(object):
             maxid = sys.maxsize
         if minid is None:
             minid = 0
-        allObjK = self.objects.keys()
-        return [k for k in allObjK if minid <= k <= maxid]
+        return [k for k in self.objects.keys() if minid <= k <= maxid]
 
     def clean(self, confirm=False, force=False):
         """Cleans the repository only if this slice represents the repository
@@ -200,9 +197,7 @@ class RegistrySlice(object):
                 maxid = sys.maxsize
             select = select_by_range
 
-        id_list = self.objects.keys()
-
-        for this_id in id_list:
+        for this_id in self.objects.keys():
             obj = self.objects[this_id]
             logger.debug("id, obj: %s, %s" % (str(this_id), str(obj)))
             if select(int(this_id)):
@@ -282,8 +277,7 @@ class RegistrySlice(object):
 
     def copy(self, keep_going):
         this_slice = self.__class__("copy of %s" % self.name)
-        id_list = self.objects.keys()
-        for _id in id_list:
+        for _id in self.objects.keys():
             obj = self.objects[_id]
             #obj = _unwrap(obj)
             copy = obj.clone()
@@ -301,8 +295,7 @@ class RegistrySlice(object):
         return this_slice
 
     def __contains__(self, j):
-        allObjK = self.objects.keys()
-        return j.id in allObjK
+        return j.id in self.objects.keys()
 
     def __call__(self, this_id):
         """ Retrieve an object by id.
@@ -361,8 +354,7 @@ class RegistrySlice(object):
 
         if isinstance(x, str):
             ids = []
-            allObjK = self.objects.keys()
-            for i in allObjK:
+            for i in self.objects.keys():
                 j = self.objects[i]
                 if j.name == x:
                     ids.append(j.id)
@@ -448,8 +440,7 @@ class RegistrySlice(object):
             ds += "-" * len(this_format % tuple([""] * len(self._display_columns))) + "\n"
 
 
-        allObjK = self.objects.keys()
-        for obj_i in allObjK:
+        for obj_i in self.objects.keys():
 
             cached_data = None
 

--- a/python/Ganga/GPIDev/Lib/Registry/RegistrySlice.py
+++ b/python/Ganga/GPIDev/Lib/Registry/RegistrySlice.py
@@ -5,6 +5,7 @@ from Ganga.Core.GangaRepository.Registry import RegistryKeyError, RegistryIndexE
 from Ganga.Core.GangaRepository.SubJobXMLList import SubJobXMLList
 import fnmatch
 import collections
+from copy import deepcopy
 
 from Ganga.GPIDev.Schema import ComponentItem
 from Ganga.Utility.external.OrderedDict import OrderedDict as oDict
@@ -39,6 +40,9 @@ class RegistrySlice(object):
         self._colour_normal = Effects().normal
         self._proxyClass = None
 
+    def _getObjKeys(self):
+        return deepcopy(self.objects.keys() if not isType(self.objects, SubJobXMLList) else [_id for _id in range(len(self.objects))])
+
     def _getColour(self, obj):
         """ Override this function in derived slices to colorize your job/task/... list"""
         return self._colour_normal
@@ -50,7 +54,7 @@ class RegistrySlice(object):
             raise GangaException("The variable 'keep_going' must be a boolean. Probably you wanted to do %s(%s).%s()" % (
                 self.name, keep_going, method))
         result = []
-        id_list = self.objects.keys() if not isType(self.objects, SubJobXMLList) else [_id for _id in range(len(self.objects))]
+        id_list = self._getObjKeys()
         for _id in id_list:
             obj = self.objects[_id]
             try:
@@ -78,12 +82,7 @@ class RegistrySlice(object):
             maxid = sys.maxsize
         if minid is None:
             minid = 0
-        return [k for k in self.objects.keys() if minid <= k <= maxid]
-        #ids = []
-        # def callback(j):
-        #    ids.append(j.id)
-        # self.do_select(callback,minid,maxid)
-        # return ids
+        return [k for k in self._getObjKeys() if minid <= k <= maxid]
 
     def clean(self, confirm=False, force=False):
         """Cleans the repository only if this slice represents the repository
@@ -203,7 +202,7 @@ class RegistrySlice(object):
                 maxid = sys.maxsize
             select = select_by_range
 
-        id_list = self.objects.keys() if not isType(self.objects, SubJobXMLList) else [_id for _id in range(len(self.objects))]
+        id_list = self._getObjKeys()
 
         for this_id in id_list:
             obj = self.objects[this_id]
@@ -285,7 +284,7 @@ class RegistrySlice(object):
 
     def copy(self, keep_going):
         this_slice = self.__class__("copy of %s" % self.name)
-        id_list = self.objects.keys() if not isType(self.objects, SubJobXMLList) else [_id for _id in range(len(self.objects))]
+        id_list = self._getObjKeys()
         for _id in id_list:
             obj = self.objects[_id]
             #obj = _unwrap(obj)
@@ -304,7 +303,7 @@ class RegistrySlice(object):
         return this_slice
 
     def __contains__(self, j):
-        return j.id in self.objects.keys()
+        return j.id in self._getObjKeys()
 
     def __call__(self, this_id):
         """ Retrieve an object by id.
@@ -363,7 +362,7 @@ class RegistrySlice(object):
 
         if isinstance(x, str):
             ids = []
-            for i in self.objects.keys():
+            for i in self._getObjKeys():
                 j = self.objects[i]
                 if j.name == x:
                     ids.append(j.id)
@@ -449,7 +448,7 @@ class RegistrySlice(object):
             ds += "-" * len(this_format % tuple([""] * len(self._display_columns))) + "\n"
 
 
-        for obj_i in self.objects.keys():
+        for obj_i in self._getObjKeys():
 
             cached_data = None
 


### PR DESCRIPTION
Small cleanup of the use of keys within ```RegistrySlice``` This was 'fixed' as part of making sure ```SubjobXMLList``` worked with subjobs  properly from a user perspective but I've realised it should be used everywhere in the class as it's more correct.

I've checked ```SubjobXMLList``` and it now correctly supports the keys method in a way which doesn't cause problems.

I've tried to make sure that the ```keys()``` method isn't called in lists etc as this is a locked list which if it's called many times behind the scenes due to some poor code there will at least be a performance cost due to the number of calls to the function with the constant (un)locking.