### PR TITLE
Stop and join job monitoring thread

### DIFF
--- a/python/Ganga/Core/InternalServices/ShutdownManager.py
+++ b/python/Ganga/Core/InternalServices/ShutdownManager.py
@@ -74,6 +74,8 @@ def _ganga_run_exitfuncs():
         from Ganga.Core.MonitoringComponent.Local_GangaMC_Service import getStackTrace
         getStackTrace()
         monitoring_component.disableMonitoring()
+        monitoring_component.stop()
+        monitoring_component.join()
 
     ## Stop the tasks system from running it's GangaThread before we get to the GangaThread shutdown section!
     from Ganga.GPIDev.Lib.Tasks import stopTasks


### PR DESCRIPTION
Currently, we are not joining the thread which is maintaining the job monitoring. This results in more than a hundred open threads persisting through the tests which is potentially causing a problem in the Jenkins test system.

Even if it's not causing a problem, it will at least clean up the thread tracer output.