### PR TITLE
Fix 2.6 compatibility in logging module

### DIFF
--- a/python/Ganga/Utility/logging/__init__.py
+++ b/python/Ganga/Utility/logging/__init__.py
@@ -343,7 +343,7 @@ class FlushedMemoryHandler(_MemHandler):
         The exception to this is when the MemHandler says we flush as we want to always flush then.
         """
         return (threading.currentThread().getName() == "MainThread") or \
-                super(FlushedMemoryHandler, self).shouldFlush(record)
+                _MemHandler.shouldFlush(self, record)
 
 
 def enableCaching():


### PR DESCRIPTION
The `MemoryHandler` is an old style `classobj` not a `type` and so the `super` call breaks in python 2.6. This PR fixes that.