### PR TITLE
Allow assignment of lists to PostProcessors

### DIFF
--- a/python/Ganga/GPIDev/Adapters/IPostProcessor.py
+++ b/python/Ganga/GPIDev/Adapters/IPostProcessor.py
@@ -153,7 +153,10 @@ def postprocessor_filter(value, item):
 #    if item is Job._schema['postprocessors']:
     if item in valid_jobtypes:
         ds = MultiPostProcessor()
-        ds.__construct__([value])
+        if isinstance(value, list) or isType(value, GangaList):
+            ds.__construct__(value)
+        else:
+            ds.__construct__([value])
         return ds
     else:
         raise PostProcessException(


### PR DESCRIPTION
This allows the following to work:

```
        tm = TextMerger(files=['stdout'],compress = True)
        rm = RootMerger(files=['thesis_data.root'],args = '-f6')
        fc = FileChecker(files = ['stdout'],searchString = ['Segmentation'])
        cc = CustomChecker(module = '~/mychecker.py')
        n = Notifier(address = 'myadress.cern.ch')

        j.postprocessors = [tm,rm,fc,cc,n]
```

Fixes #385