### PR TITLE
Feature/improve condor options

### DIFF
--- a/python/Ganga/Lib/Condor/Condor.py
+++ b/python/Ganga/Lib/Condor/Condor.py
@@ -113,7 +113,8 @@ class Condor(IBackend):
         "globusscheduler": SimpleItem(defvalue="", doc="Globus scheduler to be used (required for Condor-G submission)"),
         "globus_rsl": SimpleItem(defvalue="",
                                  doc="Globus RSL settings (for Condor-G submission)"),
-
+        "accounting_group": SimpleItem(defvalue='', doc="Provide an accounting group for this job."),
+        "cdf_options": SimpleItem(defvalue={}, doc="Additional options to set in the CDF file given by a dictionary")
     })
 
     _category = "backends"
@@ -365,6 +366,13 @@ class Condor(IBackend):
                 'stream_error': 'false',
                 'getenv': self.getenv
             }
+
+        # extend with additional cdf options
+        cdfDict.update(self.cdf_options)
+
+        # accounting group
+        if self.accounting_group:
+            cdfDict['accounting_group'] = self.accounting_group
 
         envList = []
         if self.env:

--- a/python/Ganga/Lib/Condor/CondorRequirements.py
+++ b/python/Ganga/Lib/Condor/CondorRequirements.py
@@ -55,8 +55,8 @@ Excluded execution hosts, given as a string of space-separated names:
 'machine1 machine2 machine3'; or as a list of names:
 [ 'machine1', 'machine2', 'machine3' ]
 """ ),
-        "opsys": SimpleItem(defvalue="LINUX", doc="Operating system"),
-        "arch": SimpleItem(defvalue="INTEL", doc="System architecture"),
+        "opsys": SimpleItem(defvalue="", doc="Operating system"),
+        "arch": SimpleItem(defvalue="", doc="System architecture"),
         "memory": SimpleItem(defvalue=400, doc="Mininum physical memory"),
         "virtual_memory": SimpleItem(defvalue=400,
                                      doc="Minimum virtual memory"),

--- a/python/Ganga/Lib/Condor/CondorRequirements.py
+++ b/python/Ganga/Lib/Condor/CondorRequirements.py
@@ -57,8 +57,8 @@ Excluded execution hosts, given as a string of space-separated names:
 """ ),
         "opsys": SimpleItem(defvalue="", doc="Operating system"),
         "arch": SimpleItem(defvalue="", doc="System architecture"),
-        "memory": SimpleItem(defvalue=400, doc="Mininum physical memory"),
-        "virtual_memory": SimpleItem(defvalue=400,
+        "memory": SimpleItem(defvalue=0, doc="Mininum physical memory"),
+        "virtual_memory": SimpleItem(defvalue=0,
                                      doc="Minimum virtual memory"),
         "other": SimpleItem(defvalue=[], typelist=["str"], sequence=1,
                             doc="""


### PR DESCRIPTION
This adds some more options to Condor:

j.backend.cdf_options = {"test2": 0}  # add this to the CDF file
j.backend.accounting_group = "mygroup"  # add an accounting group to the CDF file

This also zeroes the requirements so by default, submission should be trivial.

