### PR TITLE
Add and remove proxies on all proxy method args

### DIFF
--- a/python/Ganga/GPIDev/Base/Proxy.py
+++ b/python/Ganga/GPIDev/Base/Proxy.py
@@ -13,6 +13,7 @@ from Ganga.GPIDev.Schema import ComponentItem
 from Ganga.GPIDev.Base.Objects import Node, GangaObject, ObjectMetaclass, _getName
 from Ganga.Core import GangaAttributeError, ProtectedAttributeError, ReadOnlyObjectError, TypeMismatchError
 
+import functools
 import os
 
 from inspect import isclass
@@ -626,6 +627,24 @@ class ProxyDataDescriptor(object):
         GangaObject.__setattr__(raw_obj, attr_name, final_val)
 
 
+def proxy_wrap(f):
+    # type: (Callable) -> Callable
+    """
+    A decorator to strip the proxy from all incoming arguments
+    (including ``self`` if it's a method) and add one to the return
+    value.
+    """
+
+    @functools.wraps(f)
+    def proxy_wrapped(*args, **kwargs):
+        s_args = [stripProxy(a) for a in args]
+        s_kwargs = dict((name, stripProxy(a)) for name, a in kwargs.items())
+        r = f(*s_args, **s_kwargs)
+        return addProxy(r)
+
+    return proxy_wrapped
+
+
 class ProxyMethodDescriptor(object):
 
     def __init__(self, name, internal_name):
@@ -634,8 +653,10 @@ class ProxyMethodDescriptor(object):
 
     def __get__(self, obj, cls):
         if obj is None:
-            return getattr(stripProxy(cls), self._internal_name)
-        return getattr(stripProxy(obj), self._internal_name)
+            method = getattr(stripProxy(cls), self._internal_name)
+        else:
+            method = getattr(stripProxy(obj), self._internal_name)
+        return proxy_wrap(method)
 
 ##########################################################################
 

--- a/python/Ganga/test/Unit/TestProxy.py
+++ b/python/Ganga/test/Unit/TestProxy.py
@@ -14,10 +14,16 @@ class SampleGangaObject(GangaObject):
     _category = 'TestGangaObject'
     _name = 'TestGangaObject'
 
-    _exportmethods = ['example']
+    _exportmethods = ['example', 'check_not_proxy']
 
     def example(self):
         return 'example_string'
+
+    def check_not_proxy(self, obj):
+        assert not Ganga.GPIDev.Base.Proxy.isProxy(obj), 'incoming argument should be proxy-stripped'
+        ret = SampleGangaObject()
+        assert not Ganga.GPIDev.Base.Proxy.isProxy(ret), 'new object should not be proxy-wrapped'
+        return ret
 
     def not_proxied(self):
         return 'example_string'
@@ -141,6 +147,12 @@ class TestProxy(unittest.TestCase):
 
     def test_call_proxy_method(self):
         self.assertEqual(self.p.example(), 'example_string')
+
+    def test_proxy_layer_function(self):
+        """Ensure that proxies are removed from any arguments to a method"""
+        p2 = Ganga.GPIDev.Base.Proxy.addProxy(SampleGangaObject())
+        ret = self.p.check_not_proxy(p2)
+        assert Ganga.GPIDev.Base.Proxy.isProxy(ret), 'returned object should be proxy-wrapped'
 
     def test_call_nonproxied_method(self):
         def _call():


### PR DESCRIPTION
Until now it seems that while schema attributes were being correctly stripped and wrapped as they were passed through the proxy-interface, the same was not being done for arguments and return values of exported methods. 

All proxy-exported methods are accessed via `ProxyMethodDescriptor` which now correctly removes the proxies from all incoming arguments and adds them to any return value.

This depends on #392 to make one of the `GangaList` tests pass so I will rebase this on develop once that is merged.