### PR TITLE
Dropping use of global_ns

### DIFF
--- a/python/Ganga/Runtime/bootstrap.py
+++ b/python/Ganga/Runtime/bootstrap.py
@@ -1279,7 +1279,7 @@ under certain conditions; type license() for details.
         ipshell.confirm_exit = config['confirm_exit']
 
         # Launch embedded shell
-        ipshell(local_ns=local_ns, global_ns=local_ns)
+        ipshell(local_ns=local_ns)
 
     @staticmethod
     def ganga_prompt(dummy=None):


### PR DESCRIPTION
Should do a minor part of #379 as it removes the only (bad) reference to the ```global_ns``` which was left in due to the transition from IPython 0.6 to 1.x