### PR TITLE
Reorder terms in conditional

### DIFF
--- a/python/Ganga/GPIDev/Base/Objects.py
+++ b/python/Ganga/GPIDev/Base/Objects.py
@@ -361,7 +361,7 @@ class Node(object):
 
     def getNodeIndexCache(self, force_cache=False):
         if not force_cache and self.fullyLoadedFromDisk():
-            if self._getRegistry():
+            if self._getRegistry() is not None:
                 ## Fully loaded so lets regenerate this on the fly to avoid losing data
                 return self._getRegistry().getIndexCache(self)
             else:
@@ -372,7 +372,7 @@ class Node(object):
                                                                  
     def fullyLoadedFromDisk(self):
         """This returns a boolean. and it's related to if self has_loaded in the Registry of this object"""
-        if self._getRegistry():
+        if self._getRegistry() is not None:
             return self._getRegistry().has_loaded(self)
         return True
 

--- a/python/Ganga/GPIDev/Base/Objects.py
+++ b/python/Ganga/GPIDev/Base/Objects.py
@@ -360,7 +360,7 @@ class Node(object):
         setattr(self, '_index_cache', new_index_cache)
 
     def getNodeIndexCache(self, force_cache=False):
-        if self.fullyLoadedFromDisk() and not force_cache:
+        if not force_cache and self.fullyLoadedFromDisk():
             if self._getRegistry():
                 ## Fully loaded so lets regenerate this on the fly to avoid losing data
                 return self._getRegistry().getIndexCache(self)


### PR DESCRIPTION
Put the simpler term first so that if `force_cache` is `True`, it doesn't need to check `fullyLoadedFromDisk()`.

This will hopefully help with some lockups we've been seeing on ganga-ci which are being caused by this section of code.