### PR TITLE
Setup the config properly for the ARC backend

### DIFF
--- a/python/Ganga/Lib/LCG/ARC.py
+++ b/python/Ganga/Lib/LCG/ARC.py
@@ -24,6 +24,8 @@ from Ganga.Lib.LCG.GridftpSandboxCache import GridftpSandboxCache
 
 from Ganga.GPIDev.Base.Proxy import getName
 
+config = getConfig('LCG')
+
 class ARC(IBackend):
 
     '''ARC backend - direct job submission to an ARC CE'''


### PR DESCRIPTION
Replacing the `getConfig` line that shouldn't have been removed.