### PR TITLE
Remove Reexec machinery

### DIFF
--- a/bin/ganga
+++ b/bin/ganga
@@ -61,7 +61,7 @@ try:
     Ganga.Runtime._prog = Ganga.Runtime.GangaProgram()
     Ganga.Runtime._prog.parseOptions()
     Ganga.Runtime._prog.configure()
-    Ganga.Runtime._prog.initEnvironment(Ganga.Runtime._prog.options.rexec)
+    Ganga.Runtime._prog.initEnvironment()
     Ganga.Runtime._prog.bootstrap(Ganga.Runtime._prog.interactive)
     Ganga.Runtime._prog.new_user_wizard()
     # Import GPI and run Ganga

--- a/python/Ganga/PACKAGE.py
+++ b/python/Ganga/PACKAGE.py
@@ -43,7 +43,7 @@ _defaultExternalHome = None
 _externalPackages = {
     'ipython': {'version': '1.2.1',
                 'noarch': True,
-                'PYTHONPATH': 'lib/python'},
+                'syspath': 'lib/python'},
 #    'paramiko': {'version': '1.7.3',
 #                 'noarch': True,
 #                 'syspath': 'lib/python2.3/site-packages'},

--- a/python/Ganga/Runtime/bootstrap.py
+++ b/python/Ganga/Runtime/bootstrap.py
@@ -276,7 +276,7 @@ under certain conditions; type license() for details.
                           help='never prompt interactively for anything except IPython (FIXME: this is not fully implemented)')
 
         parser.add_option("--no-rexec", dest="rexec", action="store_const", const=0,
-                          help='rely on existing environment and do not re-exec ganga process'
+                          help='[DEPRECATED] rely on existing environment and do not re-exec ganga process'
                                'to setup runtime plugin modules (affects LD_LIBRARY_PATH)')
 
         parser.add_option("--test", dest='TEST', action="store_true", default=False,
@@ -292,6 +292,11 @@ under certain conditions; type license() for details.
         parser.disable_interspersed_args()
 
         (self.options, self.args) = parser.parse_args(args=self.argv[1:])
+
+        # check for --no-rexec. It does nothing now!
+        if self.options.rexec == 0:
+            from Ganga.Utility.logging import getLogger
+            getLogger().warning("Ganga no longer re-execs. --no-rexec option will be ignored.")
 
         def file_opens(f, message):
             try:
@@ -820,11 +825,8 @@ under certain conditions; type license() for details.
             os.dup2(se.fileno(), sys.stderr.fileno())
 
     # initialize environment: find all user-defined runtime modules and set their environments
-    # if option rexec=1 then initEnvironment restarts the current ganga process (needed for LD_LIBRARY_PATH on linux)
-    # set rexec=0 if you prepare your environment outside of Ganga and you do
-    # not want to rexec process
     @staticmethod
-    def initEnvironment(opt_rexec):
+    def initEnvironment():
 
         from Ganga.Utility.logging import getLogger
         logger = getLogger()

--- a/python/Ganga/Utility/Runtime.py
+++ b/python/Ganga/Utility/Runtime.py
@@ -154,13 +154,13 @@ class RuntimePackage(object):
         except ImportError as x:
             logger.warning("cannot import runtime package %s: %s", self.name, str(x))
 
-    def getEnvironment(self):
-        # FIXME: pass the configuration object
-        g = importName(self.name, 'getEnvironment')
+    def standardSetup(self):
+        """Perform any standard setup for the package"""
+        g = importName(self.name, 'standardSetup')
         if g:
-            return g(self.config)
+            return g()
         else:
-            logger.debug("no environment defined for runtime package %s", self.name)
+            logger.debug("no standard setup defined for runtime package %s", self.name)
             return {}
 
     def loadPlugins(self):

--- a/python/Ganga/Utility/Setup.py
+++ b/python/Ganga/Utility/Setup.py
@@ -99,6 +99,7 @@ class PackageSetup(object):
             if not paths:
                 return True
 
+            # loop over the sys paths to be added
             for path in reversed(paths.split(':')):
                 if path not in sys.path:
 
@@ -107,7 +108,13 @@ class PackageSetup(object):
 
                 # add to PYTHONPATH?
                 if set_python_path:
-                    pp_toks = os.environ['PYTHONPATH'].split(':')
+                    if 'PYTHONPATH' in os.environ:
+                        pp_toks = os.environ['PYTHONPATH'].split(':')
+                    else:
+                        # PYTHONPATH is empty so add Ganga in first
+                        pp_toks = [sys.path[0]]
+
+                    # create a new PYTHONPATH
                     if path not in pp_toks:
                         pp_toks.insert(1, path)
 

--- a/python/Ganga/Utility/Setup.py
+++ b/python/Ganga/Utility/Setup.py
@@ -84,17 +84,34 @@ class PackageSetup(object):
                     pp = ''
                 os.environ[var] = path + pp
 
-    def setSysPath(self, name):
+    def setSysPath(self, name, set_python_path=True):
         """ Update the sys.path variable for a given package by adding a given package to the PYTHONPATH.
         It assumes that the first item in PYTHONPATH is Ganga, so the package path is added as a second item.
+        If set_python_path is True, it will update the PYTHONPATH as well
         """
         import sys
-        import os.path
+        import os
 
         if getExternalHome():
-            path = self.getPackagePath2(name, 'syspath')
-            if path:
-                sys.path.insert(1, path)
+
+            # get the path(s)
+            paths = self.getPackagePath2(name, 'syspath')
+            if not paths:
+                return True
+
+            for path in paths.split(':'):
+                if path not in sys.path:
+
+                    # add to sys path
+                    sys.path.insert(1, path)
+
+                # add to PYTHONPATH?
+                if set_python_path:
+                    pp_toks = os.environ['PYTHONPATH'].split(':')
+                    if path not in pp_toks:
+                        pp_toks.insert(1, path)
+
+                    os.environ['PYTHONPATH'] = ':'.join(pp_toks)
 
         return True
 

--- a/python/Ganga/Utility/Setup.py
+++ b/python/Ganga/Utility/Setup.py
@@ -99,7 +99,7 @@ class PackageSetup(object):
             if not paths:
                 return True
 
-            for path in paths.split(':'):
+            for path in reversed(paths.split(':')):
                 if path not in sys.path:
 
                     # add to sys path

--- a/python/Ganga/__init__.py
+++ b/python/Ganga/__init__.py
@@ -8,9 +8,6 @@ from Ganga.Utility.ColourText import ANSIMarkup, overview_colours
 
 
 # Global Functions
-def getEnvironment(config = None):
-    return {}
-
 def getLCGRootPath():
 
     lcg_release_areas = {'afs' : '/afs/cern.ch/sw/lcg/releases/LCG_79',

--- a/python/Ganga/testlib/GangaUnitTest.py
+++ b/python/Ganga/testlib/GangaUnitTest.py
@@ -41,7 +41,6 @@ def start_ganga(gangadir_for_test, extra_opts=[]):
     logger.info("Parsing Command Line options")
     this_argv = [
         'ganga',  # `argv[0]` is usually the name of the program so fake that here
-        '--no-rexec',  # Don't re-exec Ganga when running tests
     ]
 
     # These are the default options for all test instances

--- a/python/Ganga/testlib/GangaUnitTest.py
+++ b/python/Ganga/testlib/GangaUnitTest.py
@@ -81,7 +81,7 @@ def start_ganga(gangadir_for_test, extra_opts=[]):
         logger.info("Parsing Configuration Options")
         Ganga.Runtime._prog.configure()
         logger.info("Initializing")
-        Ganga.Runtime._prog.initEnvironment(opt_rexec=False)
+        Ganga.Runtime._prog.initEnvironment()
     else:
         from Ganga.Runtime.Repository_runtime import startUpRegistries
         from Ganga.Utility.Config import getConfig

--- a/python/GangaAtlas/PACKAGE.py
+++ b/python/GangaAtlas/PACKAGE.py
@@ -103,5 +103,3 @@ def standardSetup(setup=setup):
     for name in setup.packages:
         setup.setSysPath(name)
 
-    print sys.path
-    print os.environ['PYTHONPATH']

--- a/python/GangaAtlas/PACKAGE.py
+++ b/python/GangaAtlas/PACKAGE.py
@@ -16,7 +16,7 @@ _external_packages = {
     'DQ2Clients' : { 'version' : '2.6.1_rc15',
                      'DQ2_HOME' : 'opt/dq2',
                      'PATH' : ['opt/dq2/bin','nordugrid/bin'],
-                     'PYTHONPATH' : ['opt/dq2/lib/','external/mysqldb32/'],
+                     'syspath' : ['opt/dq2/lib/','external/mysqldb32/'],
                      'LD_LIBRARY_PATH' : ['external/mysql32/','external/mysqldb32/','external/nordugrid/lib/'],
                      'DQ2_ENDUSER_SETUP' : 'True',
                      'noarch':True ,
@@ -24,8 +24,7 @@ _external_packages = {
                      },
     'rucio-clients' : { 'version' : '1.0.1',
                      'PATH' : ['bin/'],
-                     'PYTHONPATH' : [ 'externals/kerberos/lib.slc6-x86_64-2.6', 'externals/kerberos/lib.slc6-i686-2.6', 'lib/python2.6/site-packages' ],
-                     #'PYTHONPATH' : [ 'externals/kerberos/lib.slc6-i686-2.6', 'externals/kerberos/lib.slc6-x86_64-2.6', 'lib/python2.6/site-packages' ],
+                     'syspath' : [ 'externals/kerberos/lib.slc6-x86_64-2.6', 'externals/kerberos/lib.slc6-i686-2.6', 'lib/python2.6/site-packages' ],
                      'RUCIO_HOME' : '/afs/cern.ch/sw/ganga/external/rucio-clients/0.2.13/noarch/', # done properly below
                      'RUCIO_AUTH_TYPE' : 'x509_proxy',
                      'RUCIO_ACCOUNT' : 'ganga',
@@ -34,13 +33,13 @@ _external_packages = {
                      },
 
     'panda-client' : { 'version' : '0.5.39', 
-                       'PYTHONPATH':['lib/python2.4/site-packages'],
+                       'syspath':['lib/python2.4/site-packages'],
                        'CONFIGEXTRACTOR_PATH':'etc/panda/share',
                        'PANDA_SYS':'.',
                        'noarch':True
                        },
     'zsi' : { 'version' : '2.1-a1',  # Needed for pyAMI
-                       'PYTHONPATH':['lib/python'],
+                       'syspath':['lib/python'],
                        'noarch':True
                        },
     '4Suite' : { 'version' : '1.0.2.1', 
@@ -48,7 +47,7 @@ _external_packages = {
                  'syspath':['lib/python2.4/site-packages']
                        },
     'pyAMI' : { 'version' : '3.1.2.1', 
-                       'PYTHONPATH':['.'],
+                       'syspath':['.'],
                        'noarch':True
                        }
 
@@ -81,14 +80,10 @@ def standardSetup(setup=setup):
                 # hack the 4Suite path for 2.5
                 setup.packages['4Suite']['PYTHONPATH']  =  [ package.replace('2.4','2.5') for package in setup.packages['4Suite']['PYTHONPATH'] ]
                 setup.packages['4Suite']['syspath']  =  [ package.replace('2.4','2.5') for package in setup.packages['4Suite']['syspath'] ]
-                setup.setSysPath(name)
             elif name == '4Suite' and sys.hexversion > 0x2060000:
                 # hack the 4Suite path for 2.6
                 setup.packages['4Suite']['PYTHONPATH']  =  [ package.replace('2.4','2.6') for package in setup.packages['4Suite']['PYTHONPATH'] ]
                 setup.packages['4Suite']['syspath']  =  [ package.replace('2.4','2.6') for package in setup.packages['4Suite']['syspath'] ]
-                setup.setSysPath(name)
-            else:
-               pass 
     else:
         sys.exit()
 
@@ -104,4 +99,9 @@ def standardSetup(setup=setup):
         if 'RUCIO_AUTH_TYPE' in setup.packages[p]:
             os.environ['RUCIO_AUTH_TYPE'] = setup.packages[p]['RUCIO_AUTH_TYPE']
 
-    
+    # update the syspath and PYTHONPATH for the packages
+    for name in setup.packages:
+        setup.setSysPath(name)
+
+    print sys.path
+    print os.environ['PYTHONPATH']

--- a/python/GangaAtlas/__init__.py
+++ b/python/GangaAtlas/__init__.py
@@ -103,6 +103,21 @@ if not _after_bootstrap:
     config.addOption('recon_files_per_job',10,'OBSOLETE', type=int)
 
 
+def standardSetup():
+
+    import PACKAGE
+    PACKAGE.standardSetup()
+
+    # set up X509_CERT_DIR for DQ2
+    from Ganga.Utility.GridShell import getShell
+    gshell = getShell()
+    if gshell:
+        try:
+            os.environ.update({'X509_CERT_DIR':gshell.env['X509_CERT_DIR'],
+                               'X509_USER_PROXY':gshell.env['X509_USER_PROXY']})
+        except KeyError:
+            os.environ.update({'X509_CERT_DIR':'/etc/grid-security/certificates'})
+
 
 def loadPlugins( config = {} ):
 
@@ -118,20 +133,6 @@ def loadPlugins( config = {} ):
    import Lib.AMIGA
    
    return None
-
-def getEnvironment(c):
-    import PACKAGE
-    PACKAGE.standardSetup()
-    
-    #   set up X509_CERT_DIR for DQ2
-    from Ganga.Utility.GridShell import getShell
-    gshell = getShell()
-    if gshell:
-       try:
-          return { 'X509_CERT_DIR' : gshell.env['X509_CERT_DIR'], 'X509_USER_PROXY' : gshell.env['X509_USER_PROXY']  }
-       except KeyError:
-          return { 'X509_CERT_DIR' : '/etc/grid-security/certificates' }
-
 
 # some checks to make sure that new Dashboard MSG service is enabled in the user's configuration
 

--- a/python/GangaAtlas/__init__.py
+++ b/python/GangaAtlas/__init__.py
@@ -1,106 +1,102 @@
 # File: GangaAtlas/__init__.py
 
 ## Config options
-from Ganga.Utility.Config import makeConfig, ConfigError, getConfig
+from Ganga.Utility.Config import makeConfig, getConfig
 import os
-
-from Ganga.Utility.Config.Config import _after_bootstrap
 from Ganga.Utility.logging import getLogger
 logger = getLogger()
 
-if not _after_bootstrap:
+# -------------------------------------------------
+# Athena Options
+config = makeConfig('Athena','Athena configuration parameters')
+config.addOption('LCGOutputLocation', 'srm://srm-atlas.cern.ch/castor/cern.ch/grid/atlas/scratch/%s/ganga' % os.environ['USER'], 'FIXME')
+config.addOption('LocalOutputLocation', '/castor/cern.ch/atlas/scratch/%s/ganga' % os.environ['USER'], 'FIXME')
+config.addOption('IndividualSubjobDirsForLocalOutput', False, 'When copying local output, should dir structure be jid.sid (False) or jid/sid (True)' )
+config.addOption('SingleDirForLocalOutput', False, 'When copying local output, only a single dirs used for output and output filenames are changed with jid.sid' )
+config.addOption('NoSubDirsAtAllForLocalOutput', False, 'When copying local output, all output is copied to the given output location with no subdirs created' )
+config.addOption('ATLAS_SOFTWARE', '/afs/cern.ch/project/gd/apps/atlas/slc3/software', 'FIXME')
+config.addOption('PRODUCTION_ARCHIVE_BASEURL', 'http://atlas-computing.web.cern.ch/atlas-computing/links/kitsDirectory/Production/kits/', 'FIXME')
+config.addOption('ExcludedSites', '' , 'FIXME')
+config.addOption('CMTHOME', os.path.join(os.environ['HOME'],'cmthome') , 'The path in which the cmtsetup magic function will look up the setup.sh for CMT environment setup')
+config.addOption('CMTCONFIG', 'i686-slc5-gcc43-opt', 'Default value to be used as CMTCONFIG environment setup value (LCG/Batch backend)')
+config.addOption('CMTCONFIG_LIST', [ 'i686-slc4-gcc34-opt', 'i686-slc5-gcc43-opt' ], 'Allowed values for CMTCONFIG environment setup value (LCG/Batch backend)')
+config.addOption('MaxJobsAthenaSplitterJobLCG', 1000 , 'Number of maximum jobs allowed for job splitting with the AthenaSplitterJob and the LCG backend')
+config.addOption('DCACHE_RA_BUFFER', 32768 , 'Size of the dCache read ahead buffer used for dcap input file reading')
+config.addOption('ENABLE_DQ2COPY', False , 'Enable DQ2_COPY input workflow on LCG backend')
+config.addOption('ENABLE_SGE_DQ2JOBSPLITTER', False , 'Enable DQ2JobSplitter for SGE backend')
+config.addOption('ENABLE_SGE_FILESTAGER', False , 'Enable FILE_STAGER input access mode for SGE backend')
+config.addOption('EXE_MAXFILESIZE', 1024*1024 , 'Athena.exetype=EXE jobs: Maximum size of files to be sent to WNs (default 1024*1024B)')
+config.addOption('dereferenceSymLinks', False , 'Set to True to dereference symlinks in the sources area. E.g. if src is a symlink, the target will be copied into the sources archive.')
+config.addOption('MaxJobsDQ2JobSplitter', 5000, 'Maximum number of allowed subjobs of DQ2JobSplitter')
+config.addOption('MaxFilesPandaDQ2JobSplitter', 5000, 'Maximum number of allowed subjobs of DQ2JobSplitter')
+config.addOption('MaxJobsDQ2JobSplitterLCGCompile', 500, 'Maximum number of allowed subjobs of DQ2JobSplitter on LCG/Cream with compile option switched on')
+config.addOption('MaxFileSizeNGDQ2JobSplitter', 14336, 'Maximum total sum of filesizes per subjob of DQ2JobSplitter at the NG backend (in MB)')
+config.addOption('MaxFileSizePandaDQ2JobSplitter', 13336, 'Maximum total sum of filesizes per subjob of DQ2JobSplitter at the Panda backend (in MB)')
+config.addOption('DefaultNumFilesPandaDirectDQ2JobSplitter', 50, 'Default number of input files per subjob used at a direct access site in Panda in DQ2JobSplitter')
+config.addOption('AllowedSitesNGDQ2JobSplitter', [ 'NDGF-T1_DATADISK', 'NDGF-T1_MCDISK', 'NDGF-T1_PRODDISK', 'NDGF-T1_SCRATCHDISK' ], 'Allowed space tokens/sites for DQ2JobSplitter on NG backend' )
+config.addOption('AnyCloudPreferenceList', [ ], 'List of clouds that should be preferentially submitted to when using the anyCloud option' )
+config.addOption('ATLASOutputDatasetLFC', 'prod-lfc-atlas-local.cern.ch', 'FIXME')
+config.addOption('PathToEOSBinary', '/afs/cern.ch/project/eos/installation/pro/bin/eos.select', 'Path to the EOS binary for output copying/checking')
+config.addOption('RemoveTempUserAreaAfterPrepare', True, 'If True, user areas created in /tmp are removed after prepare has been called (the version in the gangadir shared area will be used instead)')
 
-    # -------------------------------------------------
-    # Athena Options
-    config = makeConfig('Athena','Athena configuration parameters')
-    config.addOption('LCGOutputLocation', 'srm://srm-atlas.cern.ch/castor/cern.ch/grid/atlas/scratch/%s/ganga' % os.environ['USER'], 'FIXME')
-    config.addOption('LocalOutputLocation', '/castor/cern.ch/atlas/scratch/%s/ganga' % os.environ['USER'], 'FIXME')
-    config.addOption('IndividualSubjobDirsForLocalOutput', False, 'When copying local output, should dir structure be jid.sid (False) or jid/sid (True)' )
-    config.addOption('SingleDirForLocalOutput', False, 'When copying local output, only a single dirs used for output and output filenames are changed with jid.sid' )
-    config.addOption('NoSubDirsAtAllForLocalOutput', False, 'When copying local output, all output is copied to the given output location with no subdirs created' )
-    config.addOption('ATLAS_SOFTWARE', '/afs/cern.ch/project/gd/apps/atlas/slc3/software', 'FIXME')
-    config.addOption('PRODUCTION_ARCHIVE_BASEURL', 'http://atlas-computing.web.cern.ch/atlas-computing/links/kitsDirectory/Production/kits/', 'FIXME')
-    config.addOption('ExcludedSites', '' , 'FIXME')
-    config.addOption('CMTHOME', os.path.join(os.environ['HOME'],'cmthome') , 'The path in which the cmtsetup magic function will look up the setup.sh for CMT environment setup')
-    config.addOption('CMTCONFIG', 'i686-slc5-gcc43-opt', 'Default value to be used as CMTCONFIG environment setup value (LCG/Batch backend)')
-    config.addOption('CMTCONFIG_LIST', [ 'i686-slc4-gcc34-opt', 'i686-slc5-gcc43-opt' ], 'Allowed values for CMTCONFIG environment setup value (LCG/Batch backend)')
-    config.addOption('MaxJobsAthenaSplitterJobLCG', 1000 , 'Number of maximum jobs allowed for job splitting with the AthenaSplitterJob and the LCG backend')
-    config.addOption('DCACHE_RA_BUFFER', 32768 , 'Size of the dCache read ahead buffer used for dcap input file reading')
-    config.addOption('ENABLE_DQ2COPY', False , 'Enable DQ2_COPY input workflow on LCG backend')
-    config.addOption('ENABLE_SGE_DQ2JOBSPLITTER', False , 'Enable DQ2JobSplitter for SGE backend')
-    config.addOption('ENABLE_SGE_FILESTAGER', False , 'Enable FILE_STAGER input access mode for SGE backend')
-    config.addOption('EXE_MAXFILESIZE', 1024*1024 , 'Athena.exetype=EXE jobs: Maximum size of files to be sent to WNs (default 1024*1024B)')
-    config.addOption('dereferenceSymLinks', False , 'Set to True to dereference symlinks in the sources area. E.g. if src is a symlink, the target will be copied into the sources archive.')
-    config.addOption('MaxJobsDQ2JobSplitter', 5000, 'Maximum number of allowed subjobs of DQ2JobSplitter')
-    config.addOption('MaxFilesPandaDQ2JobSplitter', 5000, 'Maximum number of allowed subjobs of DQ2JobSplitter')
-    config.addOption('MaxJobsDQ2JobSplitterLCGCompile', 500, 'Maximum number of allowed subjobs of DQ2JobSplitter on LCG/Cream with compile option switched on')
-    config.addOption('MaxFileSizeNGDQ2JobSplitter', 14336, 'Maximum total sum of filesizes per subjob of DQ2JobSplitter at the NG backend (in MB)')
-    config.addOption('MaxFileSizePandaDQ2JobSplitter', 13336, 'Maximum total sum of filesizes per subjob of DQ2JobSplitter at the Panda backend (in MB)')
-    config.addOption('DefaultNumFilesPandaDirectDQ2JobSplitter', 50, 'Default number of input files per subjob used at a direct access site in Panda in DQ2JobSplitter')
-    config.addOption('AllowedSitesNGDQ2JobSplitter', [ 'NDGF-T1_DATADISK', 'NDGF-T1_MCDISK', 'NDGF-T1_PRODDISK', 'NDGF-T1_SCRATCHDISK' ], 'Allowed space tokens/sites for DQ2JobSplitter on NG backend' )
-    config.addOption('AnyCloudPreferenceList', [ ], 'List of clouds that should be preferentially submitted to when using the anyCloud option' )
-    config.addOption('ATLASOutputDatasetLFC', 'prod-lfc-atlas-local.cern.ch', 'FIXME')
-    config.addOption('PathToEOSBinary', '/afs/cern.ch/project/eos/installation/pro/bin/eos.select', 'Path to the EOS binary for output copying/checking')
-    config.addOption('RemoveTempUserAreaAfterPrepare', True, 'If True, user areas created in /tmp are removed after prepare has been called (the version in the gangadir shared area will be used instead)')
+# -------------------------------------------------
+# AthenaMC Options
+config = makeConfig('AthenaMC', 'AthenaMC configuration options')
 
-    # -------------------------------------------------
-    # AthenaMC Options
-    config = makeConfig('AthenaMC', 'AthenaMC configuration options')
+# -------------------------------------------------
+# DQ2 Options
+config = makeConfig('DQ2', 'DQ2 configuration options')
 
-    # -------------------------------------------------
-    # DQ2 Options
-    config = makeConfig('DQ2', 'DQ2 configuration options')
+try:
+    config.addOption('DQ2_URL_SERVER', os.environ['DQ2_URL_SERVER'], 'FIXME')
+except KeyError:
+    config.addOption('DQ2_URL_SERVER', 'http://atlddmcat.cern.ch/dq2/', 'FIXME')
+try:
+    config.addOption('DQ2_URL_SERVER_SSL', os.environ['DQ2_URL_SERVER_SSL'], 'FIXME')
+except KeyError:
+    config.addOption('DQ2_URL_SERVER_SSL', 'https://atlddmcat.cern.ch:443/dq2/', 'FIXME')
 
-    try:
-        config.addOption('DQ2_URL_SERVER', os.environ['DQ2_URL_SERVER'], 'FIXME')
-    except KeyError:
-        config.addOption('DQ2_URL_SERVER', 'http://atlddmcat.cern.ch/dq2/', 'FIXME')
-    try:
-        config.addOption('DQ2_URL_SERVER_SSL', os.environ['DQ2_URL_SERVER_SSL'], 'FIXME')
-    except KeyError:
-        config.addOption('DQ2_URL_SERVER_SSL', 'https://atlddmcat.cern.ch:443/dq2/', 'FIXME')
+try:
+    config.addOption('DQ2_LOCAL_SITE_ID', os.environ['DQ2_LOCAL_SITE_ID'], 'Sets the DQ2 local site id')
+except KeyError:
+    config.addOption('DQ2_LOCAL_SITE_ID', 'CERN-PROD_DATADISK', 'Sets the DQ2 local site id')
 
-    try:
-        config.addOption('DQ2_LOCAL_SITE_ID', os.environ['DQ2_LOCAL_SITE_ID'], 'Sets the DQ2 local site id')
-    except KeyError:
-        config.addOption('DQ2_LOCAL_SITE_ID', 'CERN-PROD_DATADISK', 'Sets the DQ2 local site id')
+config.addOption('DQ2_OUTPUT_SPACE_TOKENS', [ 'ATLASSCRATCHDISK', 'ATLASLOCALGROUPDISK', 'T2ATLASSCRATCHDISK', 'T2ATLASLOCALGROUPDISK' ] , 'Allowed space tokens names of DQ2OutputDataset output' )
 
-    config.addOption('DQ2_OUTPUT_SPACE_TOKENS', [ 'ATLASSCRATCHDISK', 'ATLASLOCALGROUPDISK', 'T2ATLASSCRATCHDISK', 'T2ATLASLOCALGROUPDISK' ] , 'Allowed space tokens names of DQ2OutputDataset output' )
+config.addOption('DQ2_BACKUP_OUTPUT_LOCATIONS', [ 'CERN-PROD_SCRATCHDISK', 'CERN-PROD_USERTAPE', 'FZK-LCG2_SCRATCHDISK', 'IN2P3-CC_SCRATCHDISK', 'TRIUMF-LCG2_SCRATCHDISK', 'IFAE_SCRATCHDISK', 'NIKHEF-ELPROD_SCRATCHDISK' ], 'Default backup locations of DQ2OutputDataset output' )
 
-    config.addOption('DQ2_BACKUP_OUTPUT_LOCATIONS', [ 'CERN-PROD_SCRATCHDISK', 'CERN-PROD_USERTAPE', 'FZK-LCG2_SCRATCHDISK', 'IN2P3-CC_SCRATCHDISK', 'TRIUMF-LCG2_SCRATCHDISK', 'IFAE_SCRATCHDISK', 'NIKHEF-ELPROD_SCRATCHDISK' ], 'Default backup locations of DQ2OutputDataset output' )
+config.addOption('USE_STAGEOUT_SUBSCRIPTION', False, 'Allow DQ2 subscription to aggregate DQ2OutputDataset output on a storage element instead of using remote lcg-cr' )
 
-    config.addOption('USE_STAGEOUT_SUBSCRIPTION', False, 'Allow DQ2 subscription to aggregate DQ2OutputDataset output on a storage element instead of using remote lcg-cr' )
+config.addOption('usertag','user','user tag for a given data taking period')
 
-    config.addOption('usertag','user','user tag for a given data taking period')
+config.addOption('USE_ACCESS_INFO', False, 'Use automatic best choice of input dataset access mode provided by AtlasLCGRequirements.')
 
-    config.addOption('USE_ACCESS_INFO', False, 'Use automatic best choice of input dataset access mode provided by AtlasLCGRequirements.')
+config.addOption('CHECK_OUTPUT_DUPLICATES', False, 'Check for duplicate files in DQ2OutputDataset in LCG backend - this could possibly happen by ShallowRetry of glite WMS. A duplicates dataset is created')
+config.addOption('DELETE_DUPLICATES_DATASET', False, 'If CHECK_OUTPUT_DUPLICATES=True is used, duplicates dataset can be automatically deleted by setting this flag to True.')
 
-    config.addOption('CHECK_OUTPUT_DUPLICATES', False, 'Check for duplicate files in DQ2OutputDataset in LCG backend - this could possibly happen by ShallowRetry of glite WMS. A duplicates dataset is created')
-    config.addOption('DELETE_DUPLICATES_DATASET', False, 'If CHECK_OUTPUT_DUPLICATES=True is used, duplicates dataset can be automatically deleted by setting this flag to True.')
+config.addOption('USE_NICKNAME_DQ2OUTPUTDATASET', True, 'Use voms nicknames for DQ2OutputDataset.')
+config.addOption('ALLOW_MISSING_NICKNAME_DQ2OUTPUTDATASET', False, 'Allow that voms nickname is empty for DQ2OutputDataset name creating.')
 
-    config.addOption('USE_NICKNAME_DQ2OUTPUTDATASET', True, 'Use voms nicknames for DQ2OutputDataset.')
-    config.addOption('ALLOW_MISSING_NICKNAME_DQ2OUTPUTDATASET', False, 'Allow that voms nickname is empty for DQ2OutputDataset name creating.')
+config.addOption('OUTPUTDATASET_LIFETIME', '', 'Maximum lifetime of a DQ2OutputDataset.')
+config.addOption('OUTPUTDATASET_NAMELENGTH', 131, 'Maximum characters of a DQ2OutputDataset.')
+config.addOption('OUTPUTFILE_NAMELENGTH', 150, 'Maximum characters of a filename in DQ2OutputDataset.')
+config.addOption('NumberOfDQ2DownloadThreads', 5, 'Number of simultaneous DQ2 downloads when calling "retrieve"')
 
-    config.addOption('OUTPUTDATASET_LIFETIME', '', 'Maximum lifetime of a DQ2OutputDataset.')
-    config.addOption('OUTPUTDATASET_NAMELENGTH', 131, 'Maximum characters of a DQ2OutputDataset.')
-    config.addOption('OUTPUTFILE_NAMELENGTH', 150, 'Maximum characters of a filename in DQ2OutputDataset.')
-    config.addOption('NumberOfDQ2DownloadThreads', 5, 'Number of simultaneous DQ2 downloads when calling "retrieve"')
+config.addOption('setupScript', '/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase/user/gangaDDMSetup.sh', 'Script to setup DQ2Clients software')
 
-    config.addOption('setupScript', '/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase/user/gangaDDMSetup.sh', 'Script to setup DQ2Clients software')
+# -------------------------------------------------
+# AMI Dataset Options
+config = makeConfig('AMIDataset','AMI dataset')
+config.addOption('MaxNumOfFiles', 3000, 'Maximum number of files in a given dataset patterns')
+config.addOption('MaxNumOfDatasets', 100, 'Maximum number of datasets in a given dataset patterns')
 
-    # -------------------------------------------------
-    # AMI Dataset Options
-    config = makeConfig('AMIDataset','AMI dataset')
-    config.addOption('MaxNumOfFiles', 3000, 'Maximum number of files in a given dataset patterns')
-    config.addOption('MaxNumOfDatasets', 100, 'Maximum number of datasets in a given dataset patterns')
-
-    # -------------------------------------------------
-    # Tasks Options
-    config = getConfig("Tasks")
-    config.addOption('cloudPreference',[],'list of preferred clouds to choose for AnaTask analysis')
-    config.addOption('backendPreference',["LCG","Panda","NG"],'order of preferred backends (LCG, Panda, NG) for AnaTask analysis')
-    config.addOption('merged_files_per_job',1,'OBSOLETE', type=int)
-    config.addOption('recon_files_per_job',10,'OBSOLETE', type=int)
+# -------------------------------------------------
+# Tasks Options
+config = getConfig("Tasks")
+config.addOption('cloudPreference',[],'list of preferred clouds to choose for AnaTask analysis')
+config.addOption('backendPreference',["LCG","Panda","NG"],'order of preferred backends (LCG, Panda, NG) for AnaTask analysis')
+config.addOption('merged_files_per_job',1,'OBSOLETE', type=int)
+config.addOption('recon_files_per_job',10,'OBSOLETE', type=int)
 
 
 def standardSetup():

--- a/python/GangaCMS/__init__.py
+++ b/python/GangaCMS/__init__.py
@@ -26,8 +26,9 @@ configMetrics.addOption('location','%s/GangaCMS/metrics.ini'%(ganga_pythonpath),
 dscrpt = 'The version CRAB used for job submission.'
 configCMSSW.addOption('CRAB_VERSION','CRAB_2_7_5',dscrpt)
 
-def getEnvironment( config = {} ):
-    import sys
+
+def standardSetup():
+
     import os.path
     import PACKAGE
 
@@ -59,8 +60,6 @@ def getEnvironment( config = {} ):
 #    shell = Shell(cmssw_setup_script)   
 
     logger.info('GangaCMS> [INFO] getEnvironment : done')
-#    return shell.env
-    return {}
 
 def loadPlugins( config = {} ):
     import Lib.CRABTools

--- a/python/GangaDirac/__init__.py
+++ b/python/GangaDirac/__init__.py
@@ -80,13 +80,11 @@ if not _after_bootstrap:
                                                  'Unknown: No status for Job': 'failed'},
                                                 "Mapping of Dirac to Ganga Job statuses used to construct a queue to finalize a given job, i.e. final statues in 'statusmapping'")
 
-def getEnvironment(config=None):
-    import sys
-    import os.path
-    import PACKAGE
+def standardSetup():
 
+    import PACKAGE
     PACKAGE.standardSetup()
-    return
+
 
 
 def loadPlugins(config=None):

--- a/python/GangaGaudi/__init__.py
+++ b/python/GangaGaudi/__init__.py
@@ -17,13 +17,11 @@ if not _after_bootstrap:
     dscrpt = 'Levels below InstallArea/[<platform>]/python to decend when looking for .py files to include'
     configGaudi.addOption('pyFileCollectionDepth', 2, dscrpt)
 
-def getEnvironment(config=None):
-    import sys
-    import os.path
-    import PACKAGE
 
+def standardSetup():
+
+    import PACKAGE
     PACKAGE.standardSetup()
-    return
 
 
 def loadPlugins(config=None):

--- a/python/GangaLHCb/__init__.py
+++ b/python/GangaLHCb/__init__.py
@@ -126,13 +126,10 @@ if not _after_bootstrap:
     _store_root_version()
 
 
-def getEnvironment(config=None):
-    import sys
-    import os.path
-    import PACKAGE
+def standardSetup():
 
+    import PACKAGE
     PACKAGE.standardSetup()
-    return {}
 
 
 def loadPlugins(config=None):

--- a/python/GangaNA62/__init__.py
+++ b/python/GangaNA62/__init__.py
@@ -2,13 +2,11 @@ import os
 import Ganga.Utility.logging
 import Ganga.Utility.Config
 
-def getEnvironment( config = {} ):
-   import sys
-   import os.path
-   import PACKAGE
+def standardSetup():
 
+   import PACKAGE
    PACKAGE.standardSetup()
-   return
+
 
 def loadPlugins( config = {} ):
    import Lib.Applications

--- a/python/GangaND280/PACKAGE.py
+++ b/python/GangaND280/PACKAGE.py
@@ -13,9 +13,3 @@ from Ganga.Utility.Setup import PackageSetup
 
 setup = PackageSetup(external_packages)
 
-def standardSetup(setup=setup):
-    for p in setup.packages:
-        pass
-        #setup.prependPath(p,'PYTHONPATH')
-        #setup.prependPath(p,'LD_LIBRARY_PATH')
-        #setup.prependPath(p,'PATH')  

--- a/python/GangaPanda/PACKAGE.py
+++ b/python/GangaPanda/PACKAGE.py
@@ -9,7 +9,7 @@
 
 _external_packages = {
     'panda-client' : { 'version' : '0.5.39', 
-                    'PYTHONPATH':['lib/python2.4/site-packages'],
+                    'syspath':['lib/python2.4/site-packages'],
                     'CONFIGEXTRACTOR_PATH':'etc/panda/share',
                     'PANDA_SYS':'.',
                     'noarch':True
@@ -22,7 +22,10 @@ setup = PackageSetup(_external_packages)
 
 def standardSetup(setup=setup):
     for p in setup.packages:
-        setup.prependPath(p,'PYTHONPATH')
         setup.prependPath(p,'LD_LIBRARY_PATH')
         setup.prependPath(p,'PATH')
         setup.setPath(p,'PANDA_SYS')
+
+    # update the syspath and PYTHONPATH for the packages
+    for name in setup.packages:
+        setup.setSysPath(name)

--- a/python/GangaPanda/__init__.py
+++ b/python/GangaPanda/__init__.py
@@ -45,10 +45,10 @@ if not _after_bootstrap:
 
 
 
-def getEnvironment(c):
+def standardSetup():
     import PACKAGE
     PACKAGE.standardSetup()
-    return {}
+
     
 def loadPlugins(c):
 

--- a/python/GangaPanda/__init__.py
+++ b/python/GangaPanda/__init__.py
@@ -1,47 +1,42 @@
 ## Config options
-from Ganga.Utility.Config import makeConfig, ConfigError
-
-from Ganga.Utility.Config.Config import _after_bootstrap
+from Ganga.Utility.Config import makeConfig
 from Ganga.Utility.logging import getLogger
 logger = getLogger()
 
-if not _after_bootstrap:
+# -------------------------------------------------
+# Panda Options
+config = makeConfig('Panda','Panda backend configuration parameters')
+config.addOption( 'prodSourceLabelBuild', 'panda', 'prodSourceLabelBuild')
+config.addOption( 'prodSourceLabelRun', 'user', 'prodSourceLabelRun')
+config.addOption( 'assignedPriorityBuild', 2000, 'assignedPriorityBuild' )
+config.addOption( 'assignedPriorityRun', 1000, 'assignedPriorityRun' )
+config.addOption( 'processingType', 'ganga', 'processingType' )
+config.addOption( 'specialHandling', '', 'specialHandling - Expert only.' )
+config.addOption( 'enableDownloadLogs', False , 'enableDownloadLogs' )
+config.addOption( 'trustIS', True , 'Trust the Information System' )
+config.addOption( 'serverMaxJobs', 5000 , 'Maximum number of subjobs to send to the Panda server' )
+config.addOption( 'chirpconfig', '' , 'Configuration string for chirp data output, e.g. "chirp^etpgrid01.garching.physik.uni-muenchen.de^/tanyasandoval^-d chirp" ' )
+config.addOption( 'chirpserver', '' , 'Configuration string for the chirp server, e.g. "voatlas92.cern.ch". If this variable is set config.Panda.chirpconfig is filled and chirp output will be enabled.' )
+config.addOption( 'siteType', 'analysis' , 'Expert only.' )
+config.addOption( 'baseURL', '' , 'Expert only.' )
+config.addOption( 'baseURLSSL', '' , 'Expert only.' )
+config.addOption( 'AllowDirectSubmission', False, 'Deprecated. Please use the Jedi backend' )
+config.addOption('AGISJSONFile', '/tmp/agis_pandaresources.json', 'Local AGIS JSON file for queue -> site mapping')
 
-
-    # -------------------------------------------------
-    # Panda Options
-    config = makeConfig('Panda','Panda backend configuration parameters')
-    config.addOption( 'prodSourceLabelBuild', 'panda', 'prodSourceLabelBuild')
-    config.addOption( 'prodSourceLabelRun', 'user', 'prodSourceLabelRun')
-    config.addOption( 'assignedPriorityBuild', 2000, 'assignedPriorityBuild' )
-    config.addOption( 'assignedPriorityRun', 1000, 'assignedPriorityRun' )
-    config.addOption( 'processingType', 'ganga', 'processingType' )
-    config.addOption( 'specialHandling', '', 'specialHandling - Expert only.' )
-    config.addOption( 'enableDownloadLogs', False , 'enableDownloadLogs' )  
-    config.addOption( 'trustIS', True , 'Trust the Information System' )  
-    config.addOption( 'serverMaxJobs', 5000 , 'Maximum number of subjobs to send to the Panda server' )  
-    config.addOption( 'chirpconfig', '' , 'Configuration string for chirp data output, e.g. "chirp^etpgrid01.garching.physik.uni-muenchen.de^/tanyasandoval^-d chirp" ' )  
-    config.addOption( 'chirpserver', '' , 'Configuration string for the chirp server, e.g. "voatlas92.cern.ch". If this variable is set config.Panda.chirpconfig is filled and chirp output will be enabled.' )  
-    config.addOption( 'siteType', 'analysis' , 'Expert only.' )  
-    config.addOption( 'baseURL', '' , 'Expert only.' )  
-    config.addOption( 'baseURLSSL', '' , 'Expert only.' )
-    config.addOption( 'AllowDirectSubmission', False, 'Deprecated. Please use the Jedi backend' )
-    config.addOption('AGISJSONFile', '/tmp/agis_pandaresources.json', 'Local AGIS JSON file for queue -> site mapping')
-
-    # -------------------------------------------------
-    # Jedi Options
-    config = makeConfig('Jedi','Jedi backend configuration parameters')
-    config.addOption( 'prodSourceLabelBuild', 'panda', 'prodSourceLabelBuild')
-    config.addOption( 'prodSourceLabelRun', 'user', 'prodSourceLabelRun')
-    config.addOption( 'assignedPriorityBuild', 2000, 'assignedPriorityBuild' )
-    config.addOption( 'assignedPriorityRun', 1000, 'assignedPriorityRun' )
-    config.addOption( 'processingType', 'ganga', 'processingType' )
-    config.addOption( 'enableDownloadLogs', False , 'enableDownloadLogs' )  
-    config.addOption( 'trustIS', True , 'Trust the Information System' )  
-    config.addOption( 'serverMaxJobs', 5000 , 'Maximum number of subjobs to send to the Panda server' )  
-    config.addOption( 'chirpconfig', '' , 'Configuration string for chirp data output, e.g. "chirp^etpgrid01.garching.physik.uni-muenchen.de^/tanyasandoval^-d chirp" ' )  
-    config.addOption( 'chirpserver', '' , 'Configuration string for the chirp server, e.g. "voatlas92.cern.ch". If this variable is set config.Panda.chirpconfig is filled and chirp output will be enabled.' )  
-    config.addOption( 'siteType', 'analysis' , 'Expert only.' )  
+# -------------------------------------------------
+# Jedi Options
+config = makeConfig('Jedi','Jedi backend configuration parameters')
+config.addOption( 'prodSourceLabelBuild', 'panda', 'prodSourceLabelBuild')
+config.addOption( 'prodSourceLabelRun', 'user', 'prodSourceLabelRun')
+config.addOption( 'assignedPriorityBuild', 2000, 'assignedPriorityBuild' )
+config.addOption( 'assignedPriorityRun', 1000, 'assignedPriorityRun' )
+config.addOption( 'processingType', 'ganga', 'processingType' )
+config.addOption( 'enableDownloadLogs', False , 'enableDownloadLogs' )
+config.addOption( 'trustIS', True , 'Trust the Information System' )
+config.addOption( 'serverMaxJobs', 5000 , 'Maximum number of subjobs to send to the Panda server' )
+config.addOption( 'chirpconfig', '' , 'Configuration string for chirp data output, e.g. "chirp^etpgrid01.garching.physik.uni-muenchen.de^/tanyasandoval^-d chirp" ' )
+config.addOption( 'chirpserver', '' , 'Configuration string for the chirp server, e.g. "voatlas92.cern.ch". If this variable is set config.Panda.chirpconfig is filled and chirp output will be enabled.' )
+config.addOption( 'siteType', 'analysis' , 'Expert only.' )
 
 
 

--- a/python/GangaSAGA/__init__.py
+++ b/python/GangaSAGA/__init__.py
@@ -1,10 +1,7 @@
-def getEnvironment( config = {} ):
-   import sys
-   import os.path
+def standardSetup():
    import PACKAGE
-
    PACKAGE.standardSetup()
-   return
+
 
 def loadPlugins( config = {} ):
    import Lib.SAGA

--- a/python/GangaSNOplus/PACKAGE.py
+++ b/python/GangaSNOplus/PACKAGE.py
@@ -15,10 +15,3 @@ external_packages = {
 from Ganga.Utility.Setup import PackageSetup
 
 setup = PackageSetup(external_packages)
-
-def standardSetup(setup=setup):
-    for p in setup.packages:
-        pass
-        #setup.prependPath(p,'PYTHONPATH')
-        #setup.prependPath(p,'LD_LIBRARY_PATH')
-        #setup.prependPath(p,'PATH')  

--- a/python/GangaSuperB/__init__.py
+++ b/python/GangaSuperB/__init__.py
@@ -17,10 +17,10 @@ if not _after_bootstrap:
     config.addOption('sbk_pass', '', 'sbk DB password')
 
 
-def getEnvironment(c):
+def standardSetup():
     import PACKAGE
     PACKAGE.standardSetup()
-    return {}
+
 
 def loadPlugins(c):
     import Lib.SBApp

--- a/python/GangaTest/__init__.py
+++ b/python/GangaTest/__init__.py
@@ -1,8 +1,8 @@
 
-def getEnvironment(c = None):
+def standardSetup():
     import PACKAGE
     PACKAGE.standardSetup()
-    return {}
+
 
 def loadPlugins( config = None ):
     import Lib.GListApp


### PR DESCRIPTION
This removes the re-exec machinery completely and makes Atlas work sensibly without it. Other than just the stopping of re-exec, this also checks for a `standardSetup` function in the `__init__.py` of any runtime packages and calls this during `initEnvironment`. This is essentially a name swap from `getEnvironment` as this is often used as a more general hook anyway. 

We could possibly split the runtime setup calls out completely from `initEnvionment` to make it obvious what's happening but I'll leave that for someone else to decide 😄 

Fixes #404, #52 