### PR TITLE
Export the GPI into the global namespace of Ganga

### DIFF
--- a/python/Ganga/Runtime/bootstrap.py
+++ b/python/Ganga/Runtime/bootstrap.py
@@ -1279,7 +1279,8 @@ under certain conditions; type license() for details.
         ipshell.confirm_exit = config['confirm_exit']
 
         # Launch embedded shell
-        ipshell(local_ns=local_ns)
+        from Ganga import GPI
+        ipshell(local_ns=local_ns, module=Ganga.GPI)
 
     @staticmethod
     def ganga_prompt(dummy=None):


### PR DESCRIPTION
When reviewing #395 I didn't realise that the error message that spawned that PR was:
```
DeprecationWarning:  global_ns is deprecated, use module instead.
```
As such, simply removing `global_ns` has broken running scripts with `execfile` inside Ganga. This PR correctly *replaces* `global_ns` with `module` rather than removing it entirely.

What we're exporting to what probably needs a little looking at (i.e. not exporting the namespace of bootstrap.py into `locals()`) but this for now mostly maps to the old behaviour.