### PR TITLE
Fixing prepare step bug

### DIFF
--- a/python/Ganga/GPIDev/Adapters/IPrepareApp.py
+++ b/python/Ganga/GPIDev/Adapters/IPrepareApp.py
@@ -48,7 +48,7 @@ class IPrepareApp(IApplication):
         Base class for all applications which can be placed into a prepared\
         state. 
         Args:
-            force (bool) : Fforces the prepare function to be called no matter what when True
+            force (bool) : forces the prepare function to be called no matter what when True
         """
         pass
 

--- a/python/Ganga/GPIDev/Adapters/IPrepareApp.py
+++ b/python/Ganga/GPIDev/Adapters/IPrepareApp.py
@@ -70,6 +70,7 @@ class IPrepareApp(IApplication):
     def copyIntoPrepDir(self, obj2copy):
         """
         Method for actually copying the "obj2copy" object to the prepared state dir of this application
+        obj2copy is a string address of a file to be copied as it's passed to shutil.copy2
         """
         shared_path = os.path.join(expandfilename(getConfig('Configuration')['gangadir']), 'shared', getConfig('Configuration')['user'])
 

--- a/python/Ganga/GPIDev/Adapters/IPrepareApp.py
+++ b/python/Ganga/GPIDev/Adapters/IPrepareApp.py
@@ -67,6 +67,18 @@ class IPrepareApp(IApplication):
             self.is_prepared = None
         self.hash = None
 
+    def copyIntoPrepDir(self, obj2copy):
+        """
+        Method for actually copying the "obj2copy" object to the prepared state dir of this application
+        """
+        shared_path = os.path.join(expandfilename(getConfig('Configuration')['gangadir']), 'shared', getConfig('Configuration')['user'])
+
+        shr_dir = os.path.join(shared_path, self.is_prepared.name)
+        if not os.path.isdir(shr_dir):
+            os.makedirs(shr_dir)
+        shutil.copy2(obj2copy, shr_dir)
+        logger.debug("Copying %s into: %s" % (obj2copy, shr_dir))
+
     def copyPreparables(self):
         """
         This method iterates over all attributes in an application and decides\
@@ -81,7 +93,7 @@ class IPrepareApp(IApplication):
                 logger.debug('Found preparable %s' % (name))
                 logger.debug('adding to sharedir %s' % (self.__getattribute__(name)))
                 send_to_sharedir.append(self.__getattribute__(name))
-        shared_path = os.path.join(expandfilename(getConfig('Configuration')['gangadir']), 'shared', getConfig('Configuration')['user'])
+
         for prepitem in send_to_sharedir:
             logger.debug('working on %s' % (prepitem))
             # we may have a list of files/strings
@@ -94,22 +106,14 @@ class IPrepareApp(IApplication):
                         if os.path.abspath(subitem) == subitem:
                             logger.debug('Sending file %s to shared directory.' % (subitem))
                             try:
-                                shr_dir = os.path.join(shared_path, self.is_prepared.name)
-                                if not os.path.isidr(shr_dir):
-                                    os.makedirs(shr_dir)
-                                shutil.copy2(subitem, shr_dir)
-                                logger.debug("Copying into: %s" % shr_dir)
+                                self.copyIntoPrepDir(subitem)
                             except IOError as e:
                                 logger.error(e)
                                 return 0
                     elif isType(subitem, File) and subitem.name is not '':
                         logger.debug('Sending file object %s to shared directory' % subitem.name)
                         try:
-                            shr_dir = os.path.join(shared_path, self.is_prepared.name)
-                            if not os.path.isdir(shr_dir):
-                                os.makedirs(shr_dir)
-                                logger.debug("Copying into: %s" % shr_dir)
-                            shutil.copy2(subitem.name, shr_dir)
+                            self.copyIntoPrepDir(subitem.name)
                         except IOError as e:
                             logger.error(e)
                             return 0
@@ -120,11 +124,7 @@ class IPrepareApp(IApplication):
                 if os.path.abspath(prepitem) == prepitem:
                     logger.debug('Sending string file %s to shared directory.' % (prepitem))
                     try:
-                        shr_dir = os.path.join(shared_path, self.is_prepared.name)
-                        if not os.path.isdir(shr_dir):
-                            os.makedirs(shr_dir)
-                        logger.debug("Copying into: %s" % shr_dir)
-                        shutil.copy2(prepitem, shr_dir)
+                        self.copyIntoPrepDir(prepitem)
                     except IOError as e:
                         logger.error(e)
                         return 0
@@ -132,11 +132,7 @@ class IPrepareApp(IApplication):
                 logger.debug('found a file')
                 logger.debug('Sending "File" object %s to shared directory' % prepitem.name)
                 try:
-                    shr_dir = os.path.join(shared_path, self.is_prepared.name)
-                    if not os.path.isdir(shr_dir):
-                        os.makedirs(shr_dir)
-                    logger.debug("Copying into: %s" % shr_dir)
-                    shutil.copy2(prepitem.name, shr_dir)
+                    self.copyIntoPrepDir(prepitem.name, shr_dir)
                 except IOError as e:
                     logger.error(e)
                     return 0

--- a/python/Ganga/GPIDev/Adapters/IPrepareApp.py
+++ b/python/Ganga/GPIDev/Adapters/IPrepareApp.py
@@ -48,7 +48,7 @@ class IPrepareApp(IApplication):
         Base class for all applications which can be placed into a prepared\
         state. 
         Args:
-            force (bool) : ignored by the base class. Higher up forces the prepare function to be called no matter what
+            force (bool) : Fforces the prepare function to be called no matter what when True
         """
         pass
 
@@ -63,7 +63,7 @@ class IPrepareApp(IApplication):
         Revert an application back to the exact state it was in prior to being\
         prepared.
         Args:
-            force (bool): ignored from the base class, higher up causes unprepare to run always or not
+            force (bool): causes unprepare to run always or not if True
         """
         logger.debug("Running unprepare() from IPrepareApp")
         if self.is_prepared is True:

--- a/python/Ganga/GPIDev/Adapters/IPrepareApp.py
+++ b/python/Ganga/GPIDev/Adapters/IPrepareApp.py
@@ -33,17 +33,11 @@ class IPrepareApp(IApplication):
     _name = 'PrepareApp'
     _hidden = 1
 
-    def __init__(self):
-        """
-        default constructor
-        """
-        super(IPrepareApp, self).__init__()
-
     def _auto__init__(self, unprepare=None):
         """
-        Funiction called when initializing from the Proxy layer i.e. interactive prompt or 'import ganga'
+        Function called when initializing from the Proxy layer i.e. interactive prompt or 'import ganga'
         Args:
-            unprepare (bool): a bool which unprepares an app when it's created new i.e. don't copy prepared sandboxes
+            unprepare (bool): a parameter which unprepares an app when it's created new i.e. don't copy prepared sandboxes
         """
         if unprepare is True:
             logger.debug("Calling unprepare() from IPrepareApp's _auto__init__()")


### PR DESCRIPTION
This cleans up some code in the IPrepareApp and gives a hook to allow derrived classes to quickly and easily copy a file into the prepared state folder during the prepare step.
This is useful for my LSST work where I'm already using this and it fixes a typo which was left from this function already existing 4x in the exiting code.