### PR TITLE
Node/GangaObject cleanup

### DIFF
--- a/python/Ganga/Core/GangaRepository/GangaRepository.py
+++ b/python/Ganga/Core/GangaRepository/GangaRepository.py
@@ -96,7 +96,7 @@ class GangaRepository(object):
     def update_index(self, id=None):
         """update_index(id = None) --> iterable of ids
         Read the index containing the given ID (or all indices if id is None).
-        Create objects as needed , and set the _index_cache through setNodeIndexCache
+        Create objects as needed , and set the _index_cache
         for all objects that are not fully loaded.
         Returns a list of ids of jobs that changed/removed/added
         Raise RepositoryError
@@ -201,10 +201,7 @@ class GangaRepository(object):
             self._found_classes[compound_name] = cls
         cls = self._found_classes[compound_name]
         obj = cls()
-        #setattr(obj, '_parent', None)
-        #obj.__init__()
-        obj.setNodeData({})
-        obj.setNodeAttribute('id', this_id)
+        obj._data = {}
 
         obj._setFlushed()
         self._internal_setitem__(this_id, obj)
@@ -217,13 +214,12 @@ class GangaRepository(object):
         if this_id in self.incomplete_objects:
             self.incomplete_objects.remove(this_id)
         self.objects[this_id] = obj
-        setattr(obj, "_registry_id", this_id)
-        setattr(obj, "_registry_locked", False)
-        setattr(obj, "_id", this_id)
-        #if obj.getNodeData() and "id" in obj.getNodeData().keys():  # MAGIC id
-        obj.setNodeAttribute('id', this_id)
+        obj._registry_id = this_id
+        obj._registry_locked = False
+        obj._id = this_id
+        if 'id' in obj._schema.allItemNames():
+            obj.setSchemaAttribute('id', this_id)  # Don't set the object as dirty
         obj._setRegistry(self.registry)
-
 
     def _internal_del__(self, id):
         """ Internal function for repository classes to (logically) delete items to the repository."""

--- a/python/Ganga/Core/GangaRepository/GangaRepositorySQLite.py
+++ b/python/Ganga/Core/GangaRepository/GangaRepositorySQLite.py
@@ -69,7 +69,7 @@ class GangaRepositorySQLite(GangaRepository):
                 obj = self.objects[id]
             else:
                 obj = self._make_empty_object_(id, e[2], e[1])
-            obj.setNodeIndexCache(pickle.loads(e[3]))
+            obj._index_cache = pickle.loads(e[3])
         logger.debug("updated index done")
 
     def add(self, objs, force_ids=None):
@@ -85,9 +85,9 @@ class GangaRepositorySQLite(GangaRepository):
         for i in range(0, len(objs)):
             cls = objs[i]._name
             cat = objs[i]._category
-            objs[i].setNodeIndexCache(self.registry.getIndexCache(objs[i]))
-            data = pickle.dumps(objs[i].getNodeData()).replace("'", "''")
-            idx = pickle.dumps(objs[i].getNodeIndexCache()).replace("'", "''")
+            objs[i]._index_cache = self.registry.getIndexCache(objs[i])
+            data = pickle.dumps(objs[i]._data).replace("'", "''")
+            idx = pickle.dumps(objs[i]._index_cache).replace("'", "''")
             if force_ids is None:
                 self.cur.execute("INSERT INTO objects (id,classname,category,idx,data) VALUES (NULL,'%s','%s','%s','%s')" % (
                     cls, cat, idx, data))
@@ -103,9 +103,9 @@ class GangaRepositorySQLite(GangaRepository):
         for id in ids:
             obj = self.objects[id]
             if obj._name != "EmptyGangaObject":
-                obj.setNodeIndexCache(self.registry.getIndexCache(obj))
-                data = pickle.dumps(obj.getNodeData()).replace("'", "''")
-                idx = pickle.dumps(obj.getNodeIndexCache()).replace("'", "''")
+                obj._index_cache = self.registry.getIndexCache(obj)
+                data = pickle.dumps(obj._data).replace("'", "''")
+                idx = pickle.dumps(obj._index_cache).replace("'", "''")
                 self.cur.execute(
                     "UPDATE objects SET idx='%s',data='%s' WHERE id=%s" % (idx, data, id))
                 # print "flushing id ", id, " backend ", obj.backend._name
@@ -123,8 +123,8 @@ class GangaRepositorySQLite(GangaRepository):
                 obj = self._make_empty_object_(id, e[2], e[1])
             else:
                 obj = self.objects[id]
-            if obj.getNodeData() is None:
-                obj.setNodeData( pickle.loads(e[3]) )
+            if obj._data is None:
+                obj._data = pickle.loads(e[3])
             ids.remove(id)
         if len(ids) > 0:
             raise KeyError(ids[0])

--- a/python/Ganga/Core/GangaRepository/GangaRepositoryXML.py
+++ b/python/Ganga/Core/GangaRepository/GangaRepositoryXML.py
@@ -268,12 +268,12 @@ class GangaRepositoryLocal(GangaRepository):
                     obj = self._make_empty_object_(this_id, cat, cls)
                 except Exception as err:
                     raise IOError('Failed to Parse information in Index file: %s. Err: %s' % (fn, err))
-            this_cache = obj.getNodeIndexCache()
+            this_cache = obj._index_cache
             this_data = this_cache if this_cache else {}
             for k, v in cache.iteritems():
                 this_data[k] = v
             #obj.setNodeData(this_data)
-            obj.setNodeIndexCache(cache)
+            obj._index_cache = cache
             self._cache_load_timestamp[this_id] = os.stat(fn).st_ctime
             self._cached_cat[this_id] = cat
             self._cached_cls[this_id] = cls
@@ -281,7 +281,7 @@ class GangaRepositoryLocal(GangaRepository):
             return True
         elif this_id not in self.objects:
             self.objects[this_id] = self._make_empty_object_(this_id, self._cached_cat[this_id], self._cached_cls[this_id])
-            self.objects[this_id].setNodeIndexCache( self._cached_obj[this_id] )
+            self.objects[this_id]._index_cache = self._cached_obj[this_id]
             setattr(self.objects[this_id], '_registry_refresh', True)
             return True
         else:
@@ -305,7 +305,7 @@ class GangaRepositoryLocal(GangaRepository):
                     logger.debug("Writing: %s" % str(new_index))
                     pickle_to_file(new_index, this_file)
                 self._cached_obj[this_id] = new_cache
-                obj.setNodeIndexCache({})
+                obj._index_cache = {}
             self._cached_obj[this_id] = new_idx_cache
         except IOError as err:
             logger.error("Index saving to '%s' failed: %s %s" % (ifn, getName(err), err))
@@ -409,7 +409,6 @@ class GangaRepositoryLocal(GangaRepository):
                             if len(self.lock(arr_k)) != 0:
                                 self.index_write(k)
                                 self.unlock(arr_k)
-                                #stripProxy(obj).setNodeIndexCache(new_index)
                                 self._cached_obj[k] = new_index
 
                 except Exception as err:
@@ -597,12 +596,12 @@ class GangaRepositoryLocal(GangaRepository):
             self._internal_setitem__(ids[i], objs[i])
 
             # Set subjobs dirty - they will not be flushed if they are not.
-            if self.sub_split and self.sub_split in objs[i].getNodeData():
+            if self.sub_split and self.sub_split in objs[i]._data:
                 try:
-                    sj_len = len(objs[i].getNodeAttribute(self.sub_split))
+                    sj_len = len(getattr(objs[i], self.sub_split))
                     if sj_len > 0:
                         for j in range(sj_len):
-                            objs[i].getNodeAttribute(self.sub_split)[j]._dirty = True
+                            getattr(objs[i], self.sub_split)[j]._dirty = True
                 except AttributeError as err:
                     logger.debug("RepoXML add Exception: %s" % err)
 
@@ -623,19 +622,19 @@ class GangaRepositoryLocal(GangaRepository):
             split_cache = None
 
             has_children = (not self.sub_split is None) and\
-                    (self.sub_split in obj.getNodeData()) and obj.getNodeAttribute(self.sub_split) and len(obj.getNodeAttribute(self.sub_split)) > 0
+                    (self.sub_split in obj._data) and hasattr(obj, self.sub_split) and len(getattr(obj, self.sub_split)) > 0
 
             if has_children:
 
                 logger.debug("has_children")
 
-                if hasattr(obj.getNodeAttribute(self.sub_split), 'flush'):
+                if hasattr(getattr(obj, self.sub_split), 'flush'):
                     # I've been read from disk in the new SubJobXMLList format I know how to flush
-                    obj.getNodeAttribute(self.sub_split).flush()
+                    getattr(obj, self.sub_split).flush()
                 else:
                     # I have been constructed in this session, I don't know how to flush!
-                    if hasattr(obj.getNodeAttribute(self.sub_split)[0], "_dirty"):
-                        split_cache = obj.getNodeAttribute(self.sub_split)
+                    if hasattr(getattr(obj, self.sub_split)[0], "_dirty"):
+                        split_cache = getattr(obj, self.sub_split)
                         for i in range(len(split_cache)):
                             if not split_cache[i]._dirty:
                                 continue
@@ -653,7 +652,7 @@ class GangaRepositoryLocal(GangaRepository):
                     ## equivalent to for sj in job.subjobs
                     tempSubJList._setParent(obj)
                     job_dict = {}
-                    for sj in obj.getNodeAttribute(self.sub_split):
+                    for sj in getattr(obj, self.sub_split):
                         job_dict[sj.id] = stripProxy(sj)
                     tempSubJList._reset_cachedJobs(job_dict)
                     tempSubJList.flush()
@@ -662,7 +661,7 @@ class GangaRepositoryLocal(GangaRepository):
                 safe_save(fn, obj, self.to_file, self.sub_split)
                 # clean files not in subjobs anymore... (bug 64041)
                 for idn in os.listdir(os.path.dirname(fn)):
-                    split_cache = obj.getNodeAttribute(self.sub_split)
+                    split_cache = getattr(obj, self.sub_split)
                     if idn.isdigit() and int(idn) >= len(split_cache):
                         rmrf(os.path.join(os.path.dirname(fn), idn))
             else:
@@ -675,7 +674,6 @@ class GangaRepositoryLocal(GangaRepository):
                     if idn.isdigit():
                         rmrf(os.path.join(os.path.dirname(fn), idn))
             self.index_write(this_id)
-            #obj.setNodeIndexCache(None)
             obj._setFlushed()
         else:
             raise RepositoryError(self, "Cannot flush an Empty object for ID: %s" % this_id)
@@ -699,7 +697,7 @@ class GangaRepositoryLocal(GangaRepository):
                 self._cache_load_timestamp[this_id] = time.time()
                 self._cached_cls[this_id] = getName(self.objects[this_id])
                 self._cached_cat[this_id] = self.objects[this_id]._category
-                self._cached_obj[this_id] = self.objects[this_id].getNodeIndexCache()
+                self._cached_obj[this_id] = self.objects[this_id]._index_cache
 
                 try:
                     self.index_write(this_id)
@@ -718,7 +716,7 @@ class GangaRepositoryLocal(GangaRepository):
         Has "this_id" been loaded from disk already
         Check self.objects for the ._data sttribute
         """
-        return (this_id in self.objects) and (self.objects[this_id].getNodeData() is not None)
+        return (this_id in self.objects) and (self.objects[this_id]._data is not None)
 
     def count_nodes(self, this_id):
         """
@@ -751,32 +749,31 @@ class GangaRepositoryLocal(GangaRepository):
         If there is a problem then the object is unloaded from memory but will not do anything if everything agrees here
         """
         new_idx_cache = self.registry.getIndexCache(stripProxy(obj))
-        if new_idx_cache != obj.getNodeIndexCache():
+        if new_idx_cache != obj._index_cache:
             logger.debug("NEW: %s" % new_idx_cache)
-            logger.debug("OLD: %s" % obj.getNodeIndexCache())
+            logger.debug("OLD: %s" % obj._index_cache)
             # index is wrong! Try to get read access - then we can fix this
             if len(self.lock([this_id])) != 0:
                 self.index_write(this_id)
                 # self.unlock([this_id])
 
-                old_idx_subset = all((k in new_idx_cache and new_idx_cache[k] == v) for k, v in obj.getNodeIndexCache().iteritems())
+                old_idx_subset = all((k in new_idx_cache and new_idx_cache[k] == v) for k, v in obj._index_cache.iteritems())
                 if not old_idx_subset:
                     # Old index cache isn't subset of new index cache
-                    new_idx_subset = all((k in obj.getNodeIndexCache() and obj.getNodeIndexCache()[k] == v) for k, v in new_idx_cache.iteritems())
+                    new_idx_subset = all((k in obj._index_cache and obj._index_cache[k] == v) for k, v in new_idx_cache.iteritems())
                 else:
                     # Old index cache is subset of new index cache so no need to check
                     new_idx_subset = True
 
                 if not old_idx_subset and not new_idx_subset:
                     logger.warning("Incorrect index cache of '%s' object #%s was corrected!" % (self.registry.name, this_id))
-                    logger.debug("old cache: %s\t\tnew cache: %s" % (obj.getNodeIndexCache(), new_idx_cache))
+                    logger.debug("old cache: %s\t\tnew cache: %s" % (obj._index_cache, new_idx_cache))
                     self.unlock([this_id])
             else:
                 pass
                 # if we cannot lock this, the inconsistency is
                 # most likely the result of another ganga
                 # process modifying the repo
-                #obj.setNodeIndexCache(None)
 
     def _must_actually_load_xml(self, fn, this_id, load_backup, has_children, tmpobj):
         """
@@ -786,29 +783,29 @@ class GangaRepositoryLocal(GangaRepository):
         The fn of the job is passed to the SubbJobXMLList and there is some knowledge of if we should be loading the backup passed as well
         """
         obj = self.objects[this_id]
-        for key, val in tmpobj.getNodeData().iteritems():
-            obj.setNodeAttribute(key, val)
+        for key, val in tmpobj._data.items():
+            obj.setSchemaAttribute(key, val)
         for attr_name, attr_val in obj._schema.allItems():
-            if attr_name not in tmpobj.getNodeData().keys():
-                obj.setNodeAttribute(attr_name, obj._schema.getDefaultValue(attr_name))
+            if attr_name not in tmpobj._data:
+                obj.setSchemaAttribute(attr_name, obj._schema.getDefaultValue(attr_name))
 
         if has_children:
         #    logger.info("Adding children")
-            obj.setNodeAttribute(self.sub_split, SubJobXMLList.SubJobXMLList(os.path.dirname(fn), self.registry, self.dataFileName, load_backup, parent=obj))
+            obj.setSchemaAttribute(self.sub_split, SubJobXMLList.SubJobXMLList(os.path.dirname(fn), self.registry, self.dataFileName, load_backup, parent=obj))
         else:
-            obj.setNodeAttribute(self.sub_split, None)
+            obj.setSchemaAttribute(self.sub_split, None)
 
         from Ganga.GPIDev.Base.Objects import do_not_copy
-        for node_key, node_val in obj.getNodeData().iteritems():
+        for node_key, node_val in obj._data.items():
             if isType(node_val, Node):
                 if node_key not in do_not_copy:
                     node_val._setParent(obj)
 
         # Check if index cache; if loaded; was valid:
-        if obj.getNodeIndexCache() not in [{}]:
+        if obj._index_cache not in [{}]:
             self._check_index_cache(obj, this_id)
 
-        obj.setNodeIndexCache({})
+        obj._index_cache = {}
 
         if this_id not in self._fully_loaded.keys():
             self._fully_loaded[this_id] = obj
@@ -834,13 +831,12 @@ class GangaRepositoryLocal(GangaRepository):
                 logger.error("#%s Error(s) Loading File: %s" % (len(errs), fobj.name))
                 raise InaccessibleObjectError(self, this_id, errs[0])
 
-            has_children = (self.sub_split is not None) and (self.sub_split in tmpobj.getNodeData()) and len(tmpobj.getNodeAttribute(self.sub_split)) == 0
+            has_children = (self.sub_split is not None) and hasattr(tmpobj, self.sub_split) and len(getattr(tmpobj, self.sub_split)) == 0
 
             if this_id in self.objects:
                 self._must_actually_load_xml(fn, this_id, load_backup, has_children, tmpobj)
 
             else:
-                #tmpobj.setNodeIndexCache(None)
                 self._internal_setitem__(this_id, tmpobj)
 
             if hasattr(self.objects[this_id], self.sub_split):
@@ -1073,6 +1069,5 @@ class GangaRepositoryLocal(GangaRepository):
         """
         This method should be obsoleted fairly soon as it's no longer needed. We now handle caches correctly
         """
-        #stripProxy(obj).setNodeIndexCache(self.registry.getIndexCache(stripProxy(obj)))
         pass
 

--- a/python/Ganga/Core/GangaRepository/Registry.py
+++ b/python/Ganga/Core/GangaRepository/Registry.py
@@ -906,7 +906,7 @@ class Registry(object):
         return res
 
     def getIndexCache(self, obj):
-        """Returns a dictionary to be put into obj._index_cache through setNodeIndexCache
+        """Returns a dictionary to be put into obj._index_cache
         This can and should be overwritten by derived Registries to provide more index values."""
         return {}
 

--- a/python/Ganga/Core/GangaRepository/SubJobXMLList.py
+++ b/python/Ganga/Core/GangaRepository/SubJobXMLList.py
@@ -92,29 +92,19 @@ class SubJobXMLList(GangaObject):
     ## THIS CLASS DOES NOT MAKE USE OF THE SCHEMA TO STORE INFORMATION AS TRANSIENT OR UNCOPYABLE
     ## THIS CLASS CONTAINS A LOT OF OBJECT REFERENCES WHICH SHOULD NOT BE DEEPCOPIED!!!
     def __deepcopy__(self, memo=None):
-        if not isType(self, SubJobXMLList):
-            logger.error("CANNOT COPY A SUBJOBXMLLIST FROM ANOTHER CLASS TYPE!!!")
-            return
-        cls = self.__class__
-        obj = cls()
-        new_dict = {}
-        for dict_key, dict_value in self.__dict__.iteritems():
+        obj = super(SubJobXMLList, self).__deepcopy__(memo)
 
-            ## Copy objects where it's sane to
-            if dict_key not in ['_cachedJobs', '_definedParent', '_registry', '_parent', '_load_lock']:
-                new_dict[dict_key] = deepcopy(dict_value)
-
-            ## Assign by reference objects where it's sane to
-            elif dict_key in ['_registry']:
-                new_dict[dict_key] = dict_value
-
-            else:
-                new_dict[dict_key] = dict_value
+        obj._subjobIndexData = copy.deepcopy(self._subjobIndexData, memo)
+        obj._jobDirectory = copy.deepcopy(self._jobDirectory, memo)
+        obj._registry = self._registry
+        obj._dataFileName = copy.deepcopy(self._dataFileName, memo)
+        obj._load_backup = copy.deepcopy(self._load_backup, memo)
+        obj._cached_filenames = copy.deepcopy(self._cached_filenames, memo)
+        obj._stored_len = copy.deepcopy(self._stored_len, memo)
 
         ## Manually define unsafe/uncopyable objects
-        new_dict['_definedParent'] = None
-        new_dict['_cachedJobs'] = {}
-        obj.__dict__ = new_dict
+        obj._definedParent = None
+        obj._cachedJobs = {}
         return obj
 
     def _reset_cachedJobs(self, obj):

--- a/python/Ganga/Core/GangaRepository/VStreamer.py
+++ b/python/Ganga/Core/GangaRepository/VStreamer.py
@@ -121,7 +121,7 @@ def fastXML(obj, indent='', ignore_subs=''):
     elif hasattr(obj, '_data'):
         v = obj._schema.version
         sl = ['\n', indent, '<class name="%s" version="%i.%i" category="%s">\n' % (getName(obj), v.major, v.minor, obj._category)]
-        for k, o in obj.getNodeData().iteritems():
+        for k, o in obj._data.items():
             if k != ignore_subs:
                 try:
                     if not obj._schema[k]._meta["transient"]:
@@ -352,7 +352,7 @@ class Loader(object):
                 aname = self.stack.pop()
                 obj = self.stack[-1]
                 # update the object's attribute
-                obj.setNodeAttribute(aname, value)
+                obj.setSchemaAttribute(aname, value)
                 #logger.info("Setting: %s = %s" % (aname, value))
 
             # when </value> is seen the value_construct buffer (CDATA) should
@@ -381,13 +381,13 @@ class Loader(object):
             if name == 'class':
                 obj = self.stack[-1]
                 for attr, item in obj._schema.allItems():
-                    if not attr in obj.getNodeData():
+                    if not attr in obj._data:
                         #logger.info("Opening: %s" % attr)
                         if item._meta["sequence"] == 1:
-                            obj.setNodeAttribute(attr, makeGangaListByRef(obj._schema.getDefaultValue(attr)))
+                            obj.setSchemaAttribute(attr, makeGangaListByRef(obj._schema.getDefaultValue(attr)))
                             #setattr(obj, attr, makeGangaListByRef(obj._schema.getDefaultValue(attr)))
                         else:
-                            obj.setNodeAttribute(attr, obj._schema.getDefaultValue(attr))
+                            obj.setSchemaAttribute(attr, obj._schema.getDefaultValue(attr))
                             #setattr(obj, attr, obj._schema.getDefaultValue(attr))
 
                 #print("Constructed: %s" % getName(obj))
@@ -418,7 +418,7 @@ class Loader(object):
 
         # Raise Exception if object is incomplete
         for attr, item in obj._schema.allItems():
-            if not attr in obj.getNodeData():
+            if not attr in obj._data:
                 raise AssertionError("incomplete XML file")
         return obj, self.errors
 

--- a/python/Ganga/GPIDev/Adapters/IPrepareApp.py
+++ b/python/Ganga/GPIDev/Adapters/IPrepareApp.py
@@ -178,6 +178,15 @@ class IPrepareApp(IApplication):
             # the repository
             return digest.hexdigest() == self.hash
 
+    #printPrepTree is only ever run on applications, from within IPrepareApp.py
+    #if you (manually) try to run printPrepTree on anything other than an application, it will not work as expected
+    #see the relevant code in VPrinter to understand why
+    def printPrepTree(self, f=None, sel='preparable' ):
+        ## After fixing some bugs we are left with incompatible job hashes. This should be addressd before removing
+        ## This particular class!
+        from Ganga.GPIDev.Base.VPrinterOld import VPrinterOld
+        self.accept(VPrinterOld(f, sel))
+
     def incrementShareCounter(self, shared_directory_name):
         """
         Function which is used to increment the number of (sub)jobs which share the prepared sandbox

--- a/python/Ganga/GPIDev/Base/Objects.py
+++ b/python/Ganga/GPIDev/Base/Objects.py
@@ -13,6 +13,7 @@
 #   and followed by
 #    obj._setDirty()
 
+import abc
 import threading
 from contextlib import contextmanager
 import functools
@@ -41,7 +42,7 @@ logger = Ganga.Utility.logging.getLogger(modulename=1)
 
 _imported_GangaList = None
 
-do_not_copy = ['_index_cache', '_parent', '_registry', '_data', '_read_lock', '_write_lock', '_proxyObject']
+do_not_copy = ['_index_cache_dict', '_parent', '_registry', '_data_dict', '_read_lock', '_write_lock', '_proxyObject']
 
 def _getGangaList():
     global _imported_GangaList
@@ -64,37 +65,27 @@ def synchronised(f):
 
 
 class Node(object):
+    """
+    The Node class is the code of the Ganga heirachy. It allows objects to keep
+    track of their parent, whether they're dirty and take part in the visitor
+    pattern.
+
+    It also provides access to tree-aware read/write locks to provide
+    thread-safe usage.
+    """
+    __metaclass__ = abc.ABCMeta
 
     def __init__(self, parent=None):
-        self._data = {}
-        self._parent = parent
-        self._index_cache = {}
-        self._registry = None
-        self._read_lock = threading.RLock() # Don't read out of thread whilst we're making a change
-        self._write_lock = threading.RLock() # Don't write from out of thread when modifying an object
         super(Node, self).__init__()
-
-    def __copy__(self, memo=None):
-        cls = self.__class__
-        obj = cls()
-        # FIXME: this is different than for deepcopy... is this really correct?
-        this_dict = copy(self.__dict__)
-        global do_not_copy
-        for elem in this_dict.keys():
-            if elem not in do_not_copy:
-                this_dict[elem] = copy(this_dict[elem])
-            else:
-                this_dict[elem] = None
-        obj._setParent(self._getParent())
-        setattr(obj, '_index_cache', {})
-        setattr(obj, '_registry', self._registry)
-        return obj
+        self._parent = parent
+        self._read_lock = threading.RLock()  # Don't read out of thread whilst we're making a change
+        self._write_lock = threading.RLock()  # Don't write from out of thread when modifying an object
+        self._dirty = False  # dirty flag is true if the object has been modified locally and its contents is out-of-sync with its repository
 
     def __deepcopy__(self, memo=None):
         cls = self.__class__
         obj = cls()
         this_dict = copy(self.__dict__)
-        global do_not_copy
         for elem in this_dict.keys():
             if elem not in do_not_copy:
                 this_dict[elem] = deepcopy(this_dict[elem], memo)  # FIXED
@@ -102,14 +93,15 @@ class Node(object):
         obj.__dict__ = this_dict
         if self._getParent() is not None:
             obj._setParent(self._getParent())
-        setattr(obj, '_registry', self._registry)
         return obj
 
     def _getParent(self):
+        # type: () -> Node
         return self._parent
 
     @synchronised  # This will lock the _current_ (soon to be _old_) root object
     def _setParent(self, parent):
+        # type: (Node) -> None
         if parent is None:
             setattr(self, '_parent', parent)
         else:
@@ -149,11 +141,14 @@ class Node(object):
         finally:
             root._write_lock.release()
 
-    # get the root of the object tree
-    # if parent does not exist then the root is the 'self' object
-    # cond is an optional function which may cut the search path: when it
-    # returns True, then the parent is returned as root
     def _getRoot(self, cond=None):
+        # type: () -> Node
+        """
+        get the root of the object tree
+        if parent does not exist then the root is the 'self' object
+        cond is an optional function which may cut the search path: when it
+        returns True, then the parent is returned as root
+        """
         if self._getParent() is None:
             return self
         root = None
@@ -167,129 +162,26 @@ class Node(object):
             obj = obj._getParent()
         return root
 
-    def _getdata(self, name):
-        #logger.debug("Getting: %s" % name)
-        if hasattr(self, name):
-            return getattr(self, name)
-        else:
-            if name in self._data:
-                return self._data[name]
-            else:
-                return None
-
     # accept a visitor pattern
-    @synchronised
+    @abc.abstractmethod
     def accept(self, visitor):
+        pass
 
-        if not hasattr(self, '_schema'):
-            return
-        elif self._schema is None:
-            visitor.nodeBegin(self)
-            visitor.nodeEnd(self)
-            return
+    # mark object as "dirty" and inform the registry about it
+    # the registry is always associated with the root object
+    def _setDirty(self):
+        """ Set the dirty flag all the way up to the parent"""
+        self._dirty = True
+        parent = self._getParent()
+        if parent is not None:
+            parent._setDirty()
 
-        visitor.nodeBegin(self)
-
-        for (name, item) in self._schema.simpleItems():
-            if item['visitable']:
-                visitor.simpleAttribute(self, name, self._getdata(name), item['sequence'])
-
-        for (name, item) in self._schema.sharedItems():
-            if item['visitable']:
-                visitor.sharedAttribute(self, name, self._getdata(name), item['sequence'])
-
-        for (name, item) in self._schema.componentItems():
-            if item['visitable']:
-                visitor.componentAttribute(self, name, self._getdata(name), item['sequence'])
-
-        visitor.nodeEnd(self)
-
-    # clone self and return a properly initialized object
-    def clone(self):
-        new_obj = deepcopy(self)
-
-        return new_obj
-
-    # copy all the properties recursively from the srcobj
-    # if schema of self and srcobj are not compatible raises a ValueError
-    # ON FAILURE LEAVES SELF IN INCONSISTENT STATE
-    def copyFrom(self, srcobj, _ignore_atts=None):
-
-        if _ignore_atts is None:
-            _ignore_atts = []
-        _srcobj = srcobj
-        # Check if this object is derived from the source object, then the copy
-        # will not throw away information
-
-        if not hasattr(_srcobj, '__class__') and not inspect.isclass(_srcobj.__class__):
-            raise GangaValueError("Can't copyFrom a non-class object: %s isclass: %s" % (_srcobj, inspect.isclass(_srcobj)))
-
-        if not isinstance(self, _srcobj.__class__) and not isinstance(_srcobj, self.__class__):
-            raise GangaValueError("copyFrom: Cannot copy from %s to %s!" % (_getName(_srcobj), _getName(self)))
-
-        if not hasattr(self, '_schema'):
-            logger.debug("No Schema found for myself")
-            return
-
-        if self._schema is None and _srcobj._schema is None:
-            logger.debug("Schema object for one of these classes is None!")
-            return
-
-        if _srcobj._schema is None:
-            self._schema = None
-            return
-
-        self._actually_copyFrom(_srcobj, _ignore_atts)
-
-        ## Fix some objects losing parent knowledge
-        src_dict = srcobj.__dict__
-        for key, val in src_dict.iteritems():
-            this_attr = getattr(srcobj, key)
-            if isinstance(this_attr, Node) and key not in do_not_copy:
-                #logger.debug("k: %s  Parent: %s" % (key, (srcobj)))
-                this_attr._setParent(srcobj)
-
-    def _actually_copyFrom(self, _srcobj, _ignore_atts):
-
-        for name, item in self._schema.allItems():
-            if name in _ignore_atts:
-                continue
-
-            #logger.debug("Copying: %s : %s" % (name, item))
-            if name == 'application' and hasattr(_srcobj.application, 'is_prepared'):
-                _app = _srcobj.application
-                if _app.is_prepared not in [None, True]:
-                    _app.incrementShareCounter(_app.is_prepared.name)
-
-            if not self._schema.hasAttribute(name):
-                #raise ValueError('copyFrom: incompatible schema: source=%s destination=%s'%(_getName(_srcobj), _getName(self)))
-                if not hasattr(self, name):
-                    setattr(self, name, self._schema.getDefaultValue(name))
-                this_attr = getattr(self, name)
-                if isinstance(this_attr, Node) and name not in do_not_copy:
-                    this_attr._setParent(self)
-            elif not item['copyable']: ## Default of '1' instead of True...
-                if not hasattr(self, name):
-                    setattr(self, name, self._schema.getDefaultValue(name))
-                this_attr = getattr(self, name)
-                if isinstance(this_attr, Node) and name not in do_not_copy:
-                    this_attr._setParent(self)
-            else:
-                copy_obj = deepcopy(getattr(_srcobj, name))
-                setattr(self, name, copy_obj)
+    def _setFlushed(self):
+        self._dirty = False
 
     def printTree(self, f=None, sel=''):
         from Ganga.GPIDev.Base.VPrinter import VPrinter
         self.accept(VPrinter(f, sel))
-
-    #printPrepTree is only ever run on applications, from within IPrepareApp.py
-    #if you (manually) try to run printPrepTree on anything other than an application, it will not work as expected
-    #see the relevant code in VPrinter to understand why
-    def printPrepTree(self, f=None, sel='preparable' ):
-        ## After fixing some bugs we are left with incompatible job hashes. This should be addressd before removing
-        ## This particular class!
-        from Ganga.GPIDev.Base.VPrinterOld import VPrinterOld
-        self.accept(VPrinterOld(f, sel))
 
     def printSummaryTree(self, level=0, verbosity_level=0, whitespace_marker='', out=None, selection='', interactive=False):
         """If this method is overridden, the following should be noted:
@@ -304,77 +196,12 @@ class Node(object):
         from Ganga.GPIDev.Base.VPrinter import VSummaryPrinter
         self.accept(VSummaryPrinter(level, verbosity_level, whitespace_marker, out, selection, interactive))
 
+    @abc.abstractmethod
     def __eq__(self, node):
-        if self is node:
-            return True
-
-        if not isinstance(node, type(self)):
-            return False
-
-        # Compare the schemas against each other
-        if (hasattr(self, '_schema') and self._schema is None) and (hasattr(node, '_schema') and node._schema is None):
-            return True  # If they're both `None`
-        elif (hasattr(self, '_schema') and self._schema is None) or (hasattr(node, '_schema') and node._schema is None):
-            return False  # If just one of them is `None`
-        elif not self._schema.isEqual(node._schema):
-            return False  # Both have _schema but do not match
-
-        # Check each schema item in turn and check for equality
-        for (name, item) in self._schema.allItems():
-            if item['comparable'] == True:
-                #logger.info("testing: %s::%s" % (_getName(self), name))
-                if getattr(self, name) != getattr(node, name):
-                    #logger.info( "diff: %s::%s" % (_getName(self), name))
-                    return False
-
-        return True
+        pass
 
     def __ne__(self, node):
         return not self.__eq__(node)
-
-    def getNodeData(self):
-        return self._data
-
-    def setNodeData(self, new_data):
-        self._data = new_data
-        for k, v in self._data.iteritems():
-            if isinstance(v, Node):
-                v._setParent(self)
-
-    def getNodeAttribute(self, attrib_name):
-        return self.getNodeData()[attrib_name]
-
-    def setNodeAttribute(self, attrib_name, attrib_value):
-        self.getNodeData()[attrib_name] = attrib_value
-        ## ALL of the functions are in the NODE class not GANGAOBJECT
-        if isinstance(attrib_value, Node):
-            self.getNodeData()[attrib_name]._setParent(self)
-
-    def removeNodeAttribute(self, attrib_name):
-        if attrib_name in self._data.keys():
-            del self._data[attrib_name]
-
-    def setNodeIndexCache(self, new_index_cache):
-        if self.fullyLoadedFromDisk():
-            logger.debug("Warning: Setting IndexCache data on live object, please avoid!")
-        setattr(self, '_index_cache', new_index_cache)
-
-    def getNodeIndexCache(self, force_cache=False):
-        if not force_cache and self.fullyLoadedFromDisk():
-            if self._getRegistry() is not None:
-                ## Fully loaded so lets regenerate this on the fly to avoid losing data
-                return self._getRegistry().getIndexCache(self)
-            else:
-                ## No registry therefore can't work out the Cache, probably empty, lets return that
-                return self._index_cache
-        ## Not in registry or not loaded, so can't re-generate if requested
-        return self._index_cache
-                                                                 
-    def fullyLoadedFromDisk(self):
-        """This returns a boolean. and it's related to if self has_loaded in the Registry of this object"""
-        if self._getRegistry() is not None:
-            return self._getRegistry().has_loaded(self)
-        return True
 
 ##########################################################################
 
@@ -392,6 +219,7 @@ def synchronised_get_descriptor(get_function):
             return get_function(self, obj, type_or_value)
 
     return decorated
+
 
 def synchronised_set_descriptor(set_function):
     """
@@ -457,12 +285,12 @@ class Descriptor(object):
 
         # ._data takes priority ALWAYS over ._index_cache
         # This access should not cause the object to be loaded
-        obj_data = obj.getNodeData()
+        obj_data = obj._data
         if name in obj_data:
             return obj_data[name]
 
         # Then try to get it from the index cache
-        obj_index = obj.getNodeIndexCache(force_cache=True)
+        obj_index = obj._index_cache
         if name in obj_index:
             return obj_index[name]
 
@@ -472,8 +300,8 @@ class Descriptor(object):
         obj._getReadAccess()
 
         # First try to load the object from the attributes on disk
-        if name in obj.getNodeData():
-            return obj.getNodeAttribute(name)
+        if name in obj._data:
+            return obj._data[name]
 
         # Finally, get the default value from the schema
         if obj._schema.hasItem(name):
@@ -696,7 +524,7 @@ class Descriptor(object):
         if isinstance(new_val, Node):
             new_val._setParent(obj)
 
-        obj.setNodeAttribute(_getName(self), new_val)
+        obj.setSchemaAttribute(_getName(self), new_val)
 
         obj._setDirty()
 
@@ -704,7 +532,7 @@ class Descriptor(object):
         """
         Delete an attribute from teh Descriptor(?) and Node
         """
-        obj.removeNodeAttribute(_getName(self))
+        del obj._data[_getName(self)]
 
     @staticmethod
     def __createNewList(final_list, input_elements, action=None):
@@ -724,7 +552,7 @@ class Descriptor(object):
         return
 
 
-class ObjectMetaclass(type):
+class ObjectMetaclass(abc.ABCMeta):
     _descriptor = Descriptor
 
     """
@@ -792,7 +620,6 @@ class GangaObject(Node):
     __metaclass__ = ObjectMetaclass
     _schema = None  # obligatory, specified in the derived classes
     _category = None  # obligatory, specified in the derived classes
-    _registry = None  # automatically set for Root objects
     _exportmethods = []  # optional, specified in the derived classes
 
     # by default classes are not hidden, config generation and plugin
@@ -817,11 +644,9 @@ class GangaObject(Node):
         """
         super(GangaObject, self).__init__(None)
 
-        # IMPORTANT: if you add instance attributes like in the line below
-        # make sure to update the __getstate__ method as well
-        # dirty flag is true if the object has been modified locally and its
-        # contents is out-of-sync with its repository
-        self._dirty = False
+        self._data_dict = {}
+        self._index_cache_dict = {}
+        self._registry = None
 
         #Node.__init__(self, None)
 
@@ -862,6 +687,181 @@ class GangaObject(Node):
             from Ganga.GPIDev.Base.Proxy import TypeMismatchError
             raise TypeMismatchError("Constructor expected one or zero non-keyword arguments, got %i" % len(args))
 
+    @synchronised
+    def accept(self, visitor):
+
+        if not hasattr(self, '_schema'):
+            return
+        elif self._schema is None:
+            visitor.nodeBegin(self)
+            visitor.nodeEnd(self)
+            return
+
+        visitor.nodeBegin(self)
+
+        for (name, item) in self._schema.simpleItems():
+            if item['visitable']:
+                visitor.simpleAttribute(self, name, getattr(self, name), item['sequence'])
+
+        for (name, item) in self._schema.sharedItems():
+            if item['visitable']:
+                visitor.sharedAttribute(self, name, getattr(self, name), item['sequence'])
+
+        for (name, item) in self._schema.componentItems():
+            if item['visitable']:
+                visitor.componentAttribute(self, name, getattr(self, name), item['sequence'])
+
+        visitor.nodeEnd(self)
+
+    def copyFrom(self, srcobj, _ignore_atts=None):
+        # type: (GangaObject, Optional[Sequence[str]]) -> None
+        """
+        copy all the properties recursively from the srcobj
+        if schema of self and srcobj are not compatible raises a ValueError
+        ON FAILURE LEAVES SELF IN INCONSISTENT STATE
+        """
+
+        if _ignore_atts is None:
+            _ignore_atts = []
+        _srcobj = srcobj
+        # Check if this object is derived from the source object, then the copy
+        # will not throw away information
+
+        if not hasattr(_srcobj, '__class__') and not inspect.isclass(_srcobj.__class__):
+            raise GangaValueError("Can't copyFrom a non-class object: %s isclass: %s" % (_srcobj, inspect.isclass(_srcobj)))
+
+        if not isinstance(self, _srcobj.__class__) and not isinstance(_srcobj, self.__class__):
+            raise GangaValueError("copyFrom: Cannot copy from %s to %s!" % (_getName(_srcobj), _getName(self)))
+
+        if not hasattr(self, '_schema'):
+            logger.debug("No Schema found for myself")
+            return
+
+        if self._schema is None and _srcobj._schema is None:
+            logger.debug("Schema object for one of these classes is None!")
+            return
+
+        if _srcobj._schema is None:
+            self._schema = None
+            return
+
+        self._actually_copyFrom(_srcobj, _ignore_atts)
+
+        ## Fix some objects losing parent knowledge
+        src_dict = srcobj.__dict__
+        for key, val in src_dict.iteritems():
+            this_attr = getattr(srcobj, key)
+            if isinstance(this_attr, Node) and key not in do_not_copy:
+                #logger.debug("k: %s  Parent: %s" % (key, (srcobj)))
+                this_attr._setParent(srcobj)
+
+    def _actually_copyFrom(self, _srcobj, _ignore_atts):
+        # type: (GangaObject, Optional[Sequence[str]]) -> None
+
+        for name, item in self._schema.allItems():
+            if name in _ignore_atts:
+                continue
+
+            #logger.debug("Copying: %s : %s" % (name, item))
+            if name == 'application' and hasattr(_srcobj.application, 'is_prepared'):
+                _app = _srcobj.application
+                if _app.is_prepared not in [None, True]:
+                    _app.incrementShareCounter(_app.is_prepared.name)
+
+            if not self._schema.hasAttribute(name):
+                #raise ValueError('copyFrom: incompatible schema: source=%s destination=%s'%(_getName(_srcobj), _getName(self)))
+                if not hasattr(self, name):
+                    setattr(self, name, self._schema.getDefaultValue(name))
+                this_attr = getattr(self, name)
+                if isinstance(this_attr, Node) and name not in do_not_copy:
+                    this_attr._setParent(self)
+            elif not item['copyable']: ## Default of '1' instead of True...
+                if not hasattr(self, name):
+                    setattr(self, name, self._schema.getDefaultValue(name))
+                this_attr = getattr(self, name)
+                if isinstance(this_attr, Node) and name not in do_not_copy:
+                    this_attr._setParent(self)
+            else:
+                copy_obj = deepcopy(getattr(_srcobj, name))
+                setattr(self, name, copy_obj)
+
+    def __eq__(self, obj):
+        if self is obj:
+            return True
+
+        if not isinstance(obj, type(self)):
+            return False
+
+        # Compare the schemas against each other
+        if self._schema is None and obj._schema is None:
+            return True  # If they're both `None`
+        elif self._schema is None or obj._schema is None:
+            return False  # If just one of them is `None`
+        elif not self._schema.isEqual(obj._schema):
+            return False  # Both have _schema but do not match
+
+        # Check each schema item in turn and check for equality
+        for (name, item) in self._schema.allItems():
+            if item['comparable']:
+                #logger.info("testing: %s::%s" % (_getName(self), name))
+                if getattr(self, name) != getattr(obj, name):
+                    #logger.info( "diff: %s::%s" % (_getName(self), name))
+                    return False
+
+        return True
+
+    @property
+    def _data(self):
+        # type: () -> Dict[str, Any]
+        return self._data_dict
+
+    @_data.setter
+    def _data(self, new_data):
+        # type: (Dict[str, Any]) -> None
+        for v in new_data.values():
+            if isinstance(v, Node):
+                v._setParent(self)
+        self._data_dict = new_data
+
+    def setSchemaAttribute(self, attrib_name, attrib_value):
+        # type: (str, Any) -> None
+        """
+        This sets the value of a schema attribute directly by circumventing the descriptor
+
+        Args:
+            attrib_name: the name of the schema attribute
+            attrib_value: the value to set it to
+
+        """
+        self._data[attrib_name] = attrib_value
+        if isinstance(attrib_value, Node):
+            self._data[attrib_name]._setParent(self)
+
+    @property
+    def _index_cache(self):
+        if self._fullyLoadedFromDisk():
+            if self._getRegistry() is not None:
+                # Fully loaded so lets regenerate this on the fly to avoid losing data
+                return self._getRegistry().getIndexCache(self)
+            else:
+                # No registry therefore can't work out the Cache, probably empty, lets return that
+                return self._index_cache_dict
+        # Not in registry or not loaded, so can't re-generate if requested
+        return self._index_cache_dict
+
+    @_index_cache.setter
+    def _index_cache(self, new_index_cache):
+        if self._fullyLoadedFromDisk():
+            logger.debug("Warning: Setting IndexCache data on live object, please avoid!")
+        self._index_cache_dict = new_index_cache
+
+    def _fullyLoadedFromDisk(self):
+        # type: () -> bool
+        """This returns a boolean. and it's related to if self has_loaded in the Registry of this object"""
+        if self._getRegistry() is not None:
+            return self._getRegistry().has_loaded(self)
+        return True
+
     @staticmethod
     def __incrementShareRef(obj, attr_name):
         """
@@ -877,6 +877,21 @@ class GangaObject(Node):
             logger.debug("Increasing shareref")
             shareref.increase(shared_dir.name)
 
+    def __copy__(self):
+        cls = self.__class__
+        obj = cls()
+        # FIXME: this is different than for deepcopy... is this really correct?
+        this_dict = copy(self.__dict__)
+        for elem in this_dict.keys():
+            if elem not in do_not_copy:
+                this_dict[elem] = copy(this_dict[elem])
+            else:
+                this_dict[elem] = None
+        obj._setParent(self._getParent())
+        obj._index_cache = {}
+        obj._registry = self._registry
+        return obj
+
     # on the deepcopy reset all non-copyable properties as defined in the
     # schema
     def __deepcopy__(self, memo=None):
@@ -886,9 +901,7 @@ class GangaObject(Node):
         true_parent = self._getParent()
         ## This triggers a read of the job from disk
         self._getReadAccess()
-        classname = _getName(self)
-        category = self._category
-        cls = self.__class__#allPlugins.find(category, classname)
+        cls = self.__class__
 
         self_copy = cls()
 
@@ -920,7 +933,12 @@ class GangaObject(Node):
         if true_parent is not None:
             self._setParent(true_parent)
             self_copy._setParent(true_parent)
+        setattr(self_copy, '_registry', self._registry)
         return self_copy
+
+    def clone(self):
+        """Clone self and return a properly initialized object"""
+        return deepcopy(self)
 
     def _getIOTimeOut(self):
         """
@@ -1027,15 +1045,6 @@ class GangaObject(Node):
             logger.debug("_getRegistryID Exception: %s" % err)
             return None
 
-    # mark object as "dirty" and inform the registry about it
-    # the registry is always associated with the root object
-    def _setDirty(self):
-        """ Set the dirty flag all the way up to the parent"""
-        self._dirty = True
-        parent = self._getParent()
-        if parent is not None:
-            parent._setDirty()
-
     def _setFlushed(self):
         """Un-Set the dirty flag all of the way down the schema."""
         if self._schema:
@@ -1046,7 +1055,7 @@ class GangaObject(Node):
                 this_attr = getattr(self, k)
                 if isinstance(this_attr, Node):
                     this_attr._setFlushed()
-        self._dirty = False
+        super(GangaObject, self)._setFlushed()
 
     # post __init__ hook automatically called by GPI Proxy __init__
     def _auto__init__(self):

--- a/python/Ganga/GPIDev/Base/Proxy.py
+++ b/python/Ganga/GPIDev/Base/Proxy.py
@@ -781,14 +781,13 @@ def GPIProxyClassFactory(name, pluginclass):
 
         instance._auto__init__()
 
-        from Ganga.GPIDev.Base.Objects import do_not_copy
         ## All objects with an _auto__init__ method need to have that method called and we set the various node attributes here based upon the schema
         for key, _val in stripProxy(self)._schema.allItems():
-            if not _val['protected'] and not _val['hidden'] and isType(_val, ComponentItem) and key not in do_not_copy:
+            if not _val['protected'] and not _val['hidden'] and isType(_val, ComponentItem):
                 val = stripProxy(getattr(self, key))
                 if isinstance(val, GangaObject):
                     val._auto__init__()
-                instance.setNodeAttribute(key, instance._attribute_filter__set__(key, stripProxy(val)))
+                instance.setSchemaAttribute(key, instance._attribute_filter__set__(key, stripProxy(val)))
 
 
         ## THIRD(?) CONSTRUCT THE OBJECT USING THE ARGUMENTS WHICH HAVE BEEN PASSED
@@ -831,7 +830,7 @@ def GPIProxyClassFactory(name, pluginclass):
                         this_arg._auto__init__()
 
                 if type(this_arg) is str:
-                    raw_self.setNodeAttribute(k, raw_self._attribute_filter__set__(k, this_arg))
+                    raw_self.setSchemaAttribute(k, raw_self._attribute_filter__set__(k, this_arg))
                     continue
                 else:
                     item = pluginclass._schema.getItem(k)
@@ -856,7 +855,7 @@ def GPIProxyClassFactory(name, pluginclass):
                     if hasattr(this_arg, '_auto__init__'):
                         this_arg._auto__init__()
 
-                    raw_self.setNodeAttribute(k, raw_self._attribute_filter__set__(k, this_arg))
+                    raw_self.setSchemaAttribute(k, raw_self._attribute_filter__set__(k, this_arg))
             else:
                 logger.warning('keyword argument in the %s constructur ignored: %s=%s (not defined in the schema)', name, k, kwds[k])
 

--- a/python/Ganga/GPIDev/Lib/File/File.py
+++ b/python/Ganga/GPIDev/Lib/File/File.py
@@ -145,7 +145,6 @@ class ShareDir(GangaObject):
     _category = 'shareddirs'
     _exportmethods = ['add', 'ls']
     _name = "ShareDir"
-    _data = None
 #    def _readonly(self):
 #        return True
 

--- a/python/Ganga/GPIDev/Lib/File/File.py
+++ b/python/Ganga/GPIDev/Lib/File/File.py
@@ -178,9 +178,6 @@ class ShareDir(GangaObject):
         # shareref.increase(self.name)
         # shareref.decrease(self.name)
 
-    def __deepcopy__(self, memo):
-        return super(ShareDir, self).__deepcopy__(memo)
-
     def add(self, input):
         from Ganga.Core.GangaRepository import getRegistry
         if not isType(input, list):

--- a/python/Ganga/GPIDev/Lib/GangaList/GangaList.py
+++ b/python/Ganga/GPIDev/Lib/GangaList/GangaList.py
@@ -277,12 +277,12 @@ class GangaList(GangaObject):
         self.checkReadOnly()
         self.__delslice__(start, end)
 
-    def __deepcopy__(self, memo):
+    def __deepcopy__(self, memo=None):
         """Bypass any checking when making the copy"""
         #logger.info("memo: %s" % str(memo))
         #logger.info("self.len: %s" % str(len(self._list)))
         if self._list != []:
-            return makeGangaListByRef(_list=copy.deepcopy(self._list), preparable=self._is_preparable)
+            return makeGangaListByRef(_list=copy.deepcopy(self._list, memo), preparable=self._is_preparable)
         else:
             new_list = GangaList()
             new_list._is_preparable = self._is_preparable

--- a/python/Ganga/GPIDev/Lib/GangaList/GangaList.py
+++ b/python/Ganga/GPIDev/Lib/GangaList/GangaList.py
@@ -88,7 +88,6 @@ class GangaList(GangaObject):
                                      '_is_preparable': SimpleItem(defvalue=False, doc='defines if prepare lock is checked', hidden=1),
                                     })
     _enable_config = 1
-    _data={}
 
     def __init__(self):
         self._is_a_ref = False
@@ -580,17 +579,17 @@ class GangaList(GangaObject):
 
         for (name, item) in self._schema.simpleItems():
             if name == "_list":
-                visitor.componentAttribute(self, "_list", self._getdata("_list"), 1)
+                visitor.componentAttribute(self, "_list", self._data["_list"], 1)
             elif item['visitable']:
-                visitor.simpleAttribute(self, name, self._getdata(name), item['sequence'])
+                visitor.simpleAttribute(self, name, getattr(self, name), item['sequence'])
 
         for (name, item) in self._schema.sharedItems():
             if item['visitable']:
-                visitor.sharedAttribute(self, name, self._getdata(name), item['sequence'])
+                visitor.sharedAttribute(self, name, getattr(self, name), item['sequence'])
 
         for (name, item) in self._schema.componentItems():
             if item['visitable']:
-                visitor.componentAttribute(self, name, self._getdata(name), item['sequence'])
+                visitor.componentAttribute(self, name, getattr(self, name), item['sequence'])
 
         visitor.nodeEnd(self)
 

--- a/python/Ganga/GPIDev/Lib/Job/Job.py
+++ b/python/Ganga/GPIDev/Lib/Job/Job.py
@@ -65,7 +65,7 @@ def lazyLoadJobObject(raw_job, this_attr, do_eval=True):
             return getattr(this_job, this_attr)
 
     lzy_loading_str = 'display:'+ this_attr
-    job_index_cache = this_job.getNodeIndexCache()
+    job_index_cache = this_job._index_cache
     if isinstance(job_index_cache, dict) and lzy_loading_str in job_index_cache.keys():
         obj_name = job_index_cache[lzy_loading_str]
         if obj_name is not None and do_eval:
@@ -979,7 +979,7 @@ class Job(GangaObject):
         cfg = Ganga.Utility.Config.getConfig('Configuration')
         if cfg['autoGenerateJobWorkspace']:
             ## This needs to use the NodeAttribute to AVOID causing loading of a Job during initialization!
-            return self.getInputWorkspace(create=stripProxy(self).getNodeAttribute('status') != 'removed').getPath()
+            return self.getInputWorkspace(create=stripProxy(self).status != 'removed').getPath()
         else:
             return self.getInputWorkspace(create=False).getPath()
 
@@ -989,7 +989,7 @@ class Job(GangaObject):
         cfg = Ganga.Utility.Config.getConfig('Configuration')
         if cfg['autoGenerateJobWorkspace']:
             ## This needs to use the NodeAttribute to AVOID causing loading of a Job during initialization!
-            return self.getOutputWorkspace(create=stripProxy(self).getNodeAttribute('status') != 'removed').getPath()
+            return self.getOutputWorkspace(create=stripProxy(self).status != 'removed').getPath()
         else:
             return self.getOutputWorkspace(create=False).getPath()
 

--- a/python/Ganga/GPIDev/Lib/Registry/RegistrySlice.py
+++ b/python/Ganga/GPIDev/Lib/Registry/RegistrySlice.py
@@ -463,9 +463,9 @@ class RegistrySlice(object):
                     width = self._display_columns_width.get(item, default_width)
                     try:
                         if item == "fqid":
-                            vals.append(str(obj.getNodeIndexCache()[display_str]))
+                            vals.append(str(obj._index_cache[display_str]))
                         else:
-                            vals.append(str(obj.getNodeIndexCache()[display_str])[0:width])
+                            vals.append(str(obj._index_cache[display_str])[0:width])
                         continue
                     except KeyError as err:
                         logger.debug("_display KeyError: %s" % err)

--- a/python/Ganga/GPIDev/Lib/Tasks/IUnit.py
+++ b/python/Ganga/GPIDev/Lib/Tasks/IUnit.py
@@ -366,13 +366,13 @@ class IUnit(GangaObject):
             j = stripProxy(job)
 
             # try to preserve lazy loading
-            if hasattr(j, 'getNodeIndexCache') and j.getNodeIndexCache() and 'subjobs:status' in j.getNodeIndexCache():
-                if len(j.getNodeIndexCache()['subjobs:status']) > 0:
-                    for sj_stat in j.getNodeIndexCache()['subjobs:status']:
+            if hasattr(j, '_index_cache') and j._index_cache and 'subjobs:status' in j._index_cache:
+                if len(j._index_cache['subjobs:status']) > 0:
+                    for sj_stat in j._index_cache['subjobs:status']:
                         if sj_stat in active_states:
                             tot_active += 1
                 else:
-                    if j.getNodeIndexCache()['status'] in active_states:
+                    if j._index_cache['status'] in active_states:
                         tot_active += 1
             else:
                 #logger.warning("WARNING: (active check) No index cache for job object %d" % jid)
@@ -403,13 +403,13 @@ class IUnit(GangaObject):
             j = stripProxy(job)
 
             # try to preserve lazy loading
-            if hasattr(j, 'getNodeIndexCache') and j.getNodeIndexCache() and 'subjobs:status' in j.getNodeIndexCache():
-                if len(j.getNodeIndexCache()['subjobs:status']) > 0:
-                    for sj_stat in j.getNodeIndexCache()['subjobs:status']:
+            if hasattr(j, '_index_cache') and j._index_cache and 'subjobs:status' in j._index_cache:
+                if len(j._index_cache['subjobs:status']) > 0:
+                    for sj_stat in j._index_cache['subjobs:status']:
                         if sj_stat == status:
                             tot_active += 1
                 else:
-                    if j.getNodeIndexCache()['status'] == status:
+                    if j._index_cache['status'] == status:
                         tot_active += 1
 
             else:
@@ -441,9 +441,9 @@ class IUnit(GangaObject):
             j = stripProxy(job)
 
             # try to preserve lazy loading
-            if hasattr(j, 'getNodeIndexCache') and j.getNodeIndexCache() and 'subjobs:status' in j.getNodeIndexCache():
-                if len(j.getNodeIndexCache()['subjobs:status']) != 0:
-                    total += len(j.getNodeIndexCache()['subjobs:status'])
+            if hasattr(j, '_index_cache') and j._index_cache and 'subjobs:status' in j._index_cache:
+                if len(j._index_cache['subjobs:status']) != 0:
+                    total += len(j._index_cache['subjobs:status'])
                 else:
                     total += 1
             else:

--- a/python/Ganga/GPIDev/Lib/Tasks/TaskRegistry.py
+++ b/python/Ganga/GPIDev/Lib/Tasks/TaskRegistry.py
@@ -40,13 +40,13 @@ class TaskRegistry(Registry):
         return self.stored_proxy
 
     def getIndexCache(self, obj):
-        if obj.getNodeData() is None:
+        if obj._data is None:
             raise Exception("Currently don't support Index Caching")
         cached_values = ['status', 'id', 'name']
         c = {}
         for cv in cached_values:
-            if cv in obj.getNodeData():
-                c[cv] = obj.getNodeAttribute(cv)
+            if cv in obj._data:
+                c[cv] = getattr(obj, cv)
         this_slice = TaskRegistrySlice("tmp")
         for dpv in this_slice._display_columns:
             c["display:" + dpv] = this_slice._get_display_value(obj, dpv)

--- a/python/Ganga/Lib/Executable/Executable.py
+++ b/python/Ganga/Lib/Executable/Executable.py
@@ -65,9 +65,6 @@ class Executable(IPrepareApp):
     def __init__(self):
         super(Executable, self).__init__()
 
-    def __deepcopy__(self, memo):
-        return super(Executable, self).__deepcopy__(memo)
-
     def unprepare(self, force=False):
         """
         Revert an Executable() application back to it's unprepared state.

--- a/python/Ganga/test/Unit/TestGangaObject.py
+++ b/python/Ganga/test/Unit/TestGangaObject.py
@@ -71,9 +71,6 @@ class TestGangaObject(unittest.TestCase):
     def testPrintTree(self):
         self.obj.printTree()
 
-    def testPrintPrepTree(self):
-        self.obj.printPrepTree()
-
     def testPrintSummaryTree(self):
         self.obj.printSummaryTree()
 
@@ -82,40 +79,6 @@ class TestGangaObject(unittest.TestCase):
 
     def test__ne__(self):
         self.obj != GangaObject()
-
-    def tearDown(self):
-        pass
-
-
-class TestNode(unittest.TestCase):
-
-    def setUp(self):
-        self.obj = Node(None)
-
-    def test__copy__(self):
-        temp = self.obj
-
-    def test_getParent(self):
-        self.obj._getParent()
-
-    def test_setParent(self):
-        self.obj._setParent(None)
-
-    def test_getRoot(self):
-        self.obj._getRoot()
-
-#    def testAccept(self):
-#        self.obj.accept(visitor)
-
-    def testClone(self):
-        temp = self.obj.clone()
-
-    def testCopyFrom(self):
-        temp = Node(None)
-        temp.copyFrom(self.obj)
-
-    def testPrintTree(self):
-        self.obj.printTree()
 
     def tearDown(self):
         pass

--- a/python/GangaDirac/Lib/Files/DiracFile.py
+++ b/python/GangaDirac/Lib/Files/DiracFile.py
@@ -148,7 +148,7 @@ class DiracFile(IGangaFile):
 
         return
 
-    def __deepcopy__(self, memo):
+    def __deepcopy__(self, memo=None):
 
         cls = type(stripProxy(self))
         c = super(cls, cls).__new__(cls)


### PR DESCRIPTION
The primary aim of this PR is to more cleanly delineate what is `Node` and what is `GangaObject`. `Node` should be used only for keeping track of the hierarchical things like parents, `accept()` and the dirty flag. Anything to do with auto-plugins, schemas or proxy-exporting should be the domain of `GangaObject` only.

The other thing that this PR does is replace the `setNodeData`, `setNodeIndexCache`, etc. methods with Pythonic property accesses so that you can just do `obj._data['subfiles']` and it works as expected.

The separation of `Node` and `GangaObject` is needed for the `GangaList` changes I have incoming as in that branch, a `List` is not a `GangaObject` but it *is* a `Node`.