### PR TITLE
Speed up tests

### DIFF
--- a/python/Ganga/GPIDev/Adapters/IBackend.py
+++ b/python/Ganga/GPIDev/Adapters/IBackend.py
@@ -410,8 +410,8 @@ class IBackend(GangaObject):
         updateMonitoringInformation().
         """
 
-        ## Have to import here so it's actually defined
         from Ganga.Core import monitoring_component
+        was_monitoring_running = monitoring_component and monitoring_component.isEnabled(False)
 
         logger.debug("Running Monitoring for Jobs: %s" % [j.getFQID('.') for j in jobs])
 
@@ -476,7 +476,8 @@ class IBackend(GangaObject):
 
                 for this_block in monitorable_blocks:
 
-                    if monitoring_component and not monitoring_component.isEnabled(False) or not monitoring_component:
+                    # If the monitoring function was running at the start of the function but has since stopped, break.
+                    if was_monitoring_running and monitoring_component and not monitoring_component.isEnabled(False) or not monitoring_component:
                         break
 
                     try:

--- a/python/Ganga/test/GPI/Bugs/TestSavannah28511.py
+++ b/python/Ganga/test/GPI/Bugs/TestSavannah28511.py
@@ -1,24 +1,23 @@
 from __future__ import absolute_import
 
 from Ganga.testlib.GangaUnitTest import GangaUnitTest
+from Ganga.testlib.monitoring import run_until_completed, run_until_state
 
 
 class TestSavannah28511(GangaUnitTest):
     def test_Savannah28511(self):
         from Ganga.GPI import Job, TestSubmitter
 
-        from GangaTest.Framework.utils import sleep_until_completed, sleep_until_state
-
         j = Job()
 
         j.submit()
-        self.assertTrue(sleep_until_completed(j, 20), 'Job is not completed')
+        assert run_until_completed(j, timeout=20), 'Job is not completed'
 
         j.resubmit()
-        self.assertTrue(sleep_until_completed(j, 30), 'Job is not completed after fail during resubmit')
+        assert run_until_completed(j, timeout=30), 'Job is not completed after fail during resubmit'
 
         j._impl.updateStatus('failed')
-        self.assertTrue(sleep_until_state(j, 20, 'failed'), 'Job is not failed')
+        assert run_until_state(j, timeout=20, state='failed'), 'Job is not failed'
 
         j.resubmit()
-        self.assertTrue(sleep_until_completed(j, 20), 'Job is not completed after resubmit')
+        assert run_until_completed(j, timeout=20), 'Job is not completed after resubmit'

--- a/python/Ganga/test/GPI/Checkers/TestFileChecker.py
+++ b/python/Ganga/test/GPI/Checkers/TestFileChecker.py
@@ -1,13 +1,13 @@
 from __future__ import absolute_import
 
 from Ganga.testlib.GangaUnitTest import GangaUnitTest
+from Ganga.testlib.monitoring import run_until_completed
 
 
 class TestFileChecker(GangaUnitTest):
     def setUp(self):
         super(TestFileChecker, self).setUp()
         from Ganga.GPI import Job, FileChecker, Executable, Local
-        from GangaTest.Framework.utils import sleep_until_completed
 
         self.c = FileChecker()
         self.jobslice = []
@@ -20,7 +20,7 @@ class TestFileChecker(GangaUnitTest):
 
         for j in self.jobslice:
             j.submit()
-            self.assertTrue(sleep_until_completed(j), 'Timeout on job submission: job is still not finished')
+            assert run_until_completed(j), 'Timeout on job submission: job is still not finished'
             self.assertEqual(j.status, 'completed')
 
     def checkFail(self, message):

--- a/python/Ganga/test/GPI/GangaList/TestMutableMethods.py
+++ b/python/Ganga/test/GPI/GangaList/TestMutableMethods.py
@@ -3,6 +3,7 @@ import string
 import time
 
 from Ganga.testlib.GangaUnitTest import GangaUnitTest
+from Ganga.testlib.monitoring import run_until_completed
 from Ganga.GPIDev.Lib.GangaList.GangaList import decorateListEntries
 from Ganga.GPIDev.Adapters.IGangaFile import IGangaFile
 from Ganga.GPIDev.Base.Proxy import ReadOnlyObjectError
@@ -246,9 +247,8 @@ class TestMutableMethods(GangaUnitTest):
         j = Job(application=Executable(), backend=TestSubmitter())
         j.splitter = ArgSplitter(args=[['A'], ['B'], ['C']])
 
-        from GangaTest.Framework.utils import sleep_until_completed
         j.submit()
-        assert sleep_until_completed(j), 'Job must complete'
+        assert run_until_completed(j), 'Job must complete'
         assert len(j.subjobs) == 3, 'splitting must occur'
         assert j.status == 'completed', 'Job must complete'
         for jj in j.subjobs:

--- a/python/Ganga/test/GPI/GangaList/TestMutableMethods.py
+++ b/python/Ganga/test/GPI/GangaList/TestMutableMethods.py
@@ -244,7 +244,7 @@ class TestMutableMethods(GangaUnitTest):
         from Ganga.GPIDev.Lib.GangaList.GangaList import GangaList as gangaList
         from Ganga.GPIDev.Base.Proxy import isType
 
-        j = Job(application=Executable(), backend=TestSubmitter())
+        j = Job(application=Executable(), backend=TestSubmitter(time=1))
         j.splitter = ArgSplitter(args=[['A'], ['B'], ['C']])
 
         j.submit()

--- a/python/Ganga/test/GPI/Internals/TestRegistry.py
+++ b/python/Ganga/test/GPI/Internals/TestRegistry.py
@@ -148,7 +148,7 @@ class HammerThread(threading.Thread):
         self.logger.info(str(self.id) + ' unlock(%s) done!' % _id)
 
     def run(self):
-        for i in range(100):
+        for i in range(50):
             choices = []
             choices.extend([self.updown] * 1)
             choices.extend([self.uindex] * 1)

--- a/python/Ganga/test/GPI/Internals/TestRepo.py
+++ b/python/Ganga/test/GPI/Internals/TestRepo.py
@@ -134,7 +134,7 @@ class HammerThread(threading.Thread):
         self.logger.info(str(self.id) + ' delete(%s) done!' % ids)
 
     def run(self):
-        for i in range(100):
+        for i in range(50):
             choices = []
             choices.extend([self.updown] * 1)
             choices.extend([self.uindex] * 2)

--- a/python/Ganga/test/GPI/Mergers/TestCustomMerger.py
+++ b/python/Ganga/test/GPI/Mergers/TestCustomMerger.py
@@ -5,11 +5,12 @@ import tempfile
 
 import pytest
 
-from GangaTest.Framework.utils import sleep_until_completed, write_file
+from GangaTest.Framework.utils import write_file
 from Ganga.GPIDev.Base.Proxy import getProxyClass
 from Ganga.GPIDev.Adapters.IPostProcessor import PostProcessException
 
 from Ganga.testlib.GangaUnitTest import GangaUnitTest
+from Ganga.testlib.monitoring import run_until_completed, run_until_state
 from .CopySplitter import CopySplitter
 
 CopySplitter = getProxyClass(CopySplitter)
@@ -47,11 +48,9 @@ class TestCustomMerger(GangaUnitTest):
             self.jobslice.append(j)
 
     def runJobSlice(self):
-
         for j in self.jobslice:
             j.submit()
-
-            assert sleep_until_completed(j), 'Timeout on job submission: job is still not finished'
+            assert run_until_completed(j), 'Timeout on job submission: job is still not finished'
 
     def tearDown(self):
         for j in self.jobslice:
@@ -109,5 +108,5 @@ def mergefiles(file_list, output_file):
         j.postprocessors = cm
         j.submit()
 
-        sleep_until_completed(j)
+        run_until_state(j, state='failed')
         assert j.status == 'failed'

--- a/python/Ganga/test/GPI/Mergers/TestMergeFailures.py
+++ b/python/Ganga/test/GPI/Mergers/TestMergeFailures.py
@@ -4,7 +4,8 @@ import os
 
 import pytest
 
-from GangaTest.Framework.utils import sleep_until_completed, sleep_until_state
+from GangaTest.Framework.utils import sleep_until_state
+from Ganga.testlib.monitoring import run_until_completed, run_until_state
 from Ganga.GPIDev.Base.Proxy import getProxyClass
 
 from Ganga.testlib.GangaUnitTest import GangaUnitTest
@@ -29,7 +30,7 @@ class TestMergeFailures(GangaUnitTest):
 
         j.submit()
 
-        sleep_until_completed(j, 60)
+        run_until_completed(j, timeout=60)
         assert j.status == 'failed'
         assert os.path.exists(os.path.join(j.outputdir, 'out.txt.merge_summary')), 'Summary file should be created'
 
@@ -45,7 +46,7 @@ class TestMergeFailures(GangaUnitTest):
 
         j.submit()
 
-        sleep_until_completed(j, 60)
+        run_until_completed(j, timeout=60)
         assert j.status == 'failed'
         assert os.path.exists(os.path.join(j.outputdir, 'out.txt.merge_summary')), 'Summary file should be created'
 
@@ -61,7 +62,7 @@ class TestMergeFailures(GangaUnitTest):
 
         j.submit()
 
-        sleep_until_completed(j, 60)
+        run_until_completed(j, timeout=60)
         assert j.status == 'failed'
         assert os.path.exists(os.path.join(j.outputdir, 'out.txt.merge_summary')), 'Summary file should be created'
 
@@ -78,7 +79,7 @@ class TestMergeFailures(GangaUnitTest):
 
         j.submit()
 
-        sleep_until_completed(j, 60)
+        run_until_completed(j, timeout=60)
         assert j.status == 'failed'
         assert os.path.exists(os.path.join(j.outputdir, 'out.txt.merge_summary')), 'Summary file should be created'
 
@@ -101,7 +102,7 @@ class TestMergeFailures(GangaUnitTest):
         j.postprocessors[0].wait = 10
 
         j.submit()
-        sleep_until_state(j, state='running')
+        run_until_state(j, state='running')
         j.remove()
 
         with pytest.raises(KeyError):

--- a/python/Ganga/test/GPI/Mergers/TestSmartMerger.py
+++ b/python/Ganga/test/GPI/Mergers/TestSmartMerger.py
@@ -3,10 +3,12 @@ from __future__ import absolute_import
 import os
 import tempfile
 
-from GangaTest.Framework.utils import sleep_until_completed, file_contains, write_file
+
+from GangaTest.Framework.utils import file_contains, write_file
 from Ganga.Lib.Mergers.Merger import findFilesToMerge
 
 from Ganga.testlib.GangaUnitTest import GangaUnitTest
+from Ganga.testlib.monitoring import run_until_completed
 
 
 class TestSmartMerger(GangaUnitTest):
@@ -46,7 +48,7 @@ class TestSmartMerger(GangaUnitTest):
 
         for j in self.jobslice:
             j.submit()
-            assert sleep_until_completed(j), 'Timeout on job submission: job is still not finished'
+            assert run_until_completed(j), 'Timeout on job submission: job is still not finished'
             assert j.status == 'completed'
 
     def tearDown(self):

--- a/python/Ganga/test/GPI/Mergers/TestStdOut.py
+++ b/python/Ganga/test/GPI/Mergers/TestStdOut.py
@@ -4,6 +4,7 @@ import os
 import tempfile
 
 from Ganga.testlib.GangaUnitTest import GangaUnitTest
+from Ganga.testlib.monitoring import run_until_completed
 
 
 class TestStdOut(GangaUnitTest):
@@ -40,11 +41,9 @@ class TestStdOut(GangaUnitTest):
             self.jobslice.append(j)
 
     def runJobSlice(self):
-        from GangaTest.Framework.utils import sleep_until_completed
-
         for j in self.jobslice:
             j.submit()
-            assert sleep_until_completed(j, timeout=60), 'Timeout on job submission: job is still not finished'
+            assert run_until_completed(j, timeout=60), 'Timeout on job submission: job is still not finished'
             assert j.status == 'completed'
 
     def testCanSetStdOutMerge(self):

--- a/python/Ganga/test/GPI/Mergers/TestStructure.py
+++ b/python/Ganga/test/GPI/Mergers/TestStructure.py
@@ -6,6 +6,7 @@ import tempfile
 import pytest
 
 from Ganga.testlib.GangaUnitTest import GangaUnitTest
+from Ganga.testlib.monitoring import run_until_completed
 from Ganga.GPIDev.Adapters.IPostProcessor import PostProcessException
 
 
@@ -43,12 +44,11 @@ class TestStructure(GangaUnitTest):
             self.jobslice.append(j)
 
     def runJobSlice(self):
-        from GangaTest.Framework.utils import sleep_until_completed
 
         for j in self.jobslice:
             j.submit()
         for j in self.jobslice:
-            assert sleep_until_completed(j, timeout=10, verbose=True), 'Timeout on job submission: job is still not finished'
+            assert run_until_completed(j, timeout=10), 'Timeout on job submission: job is still not finished'
             print('# upcoming status')
             print("Status 3: %s" % j.status)
             print('# printed status')

--- a/python/Ganga/test/GPI/Monitoring/TestMonitoring.py
+++ b/python/Ganga/test/GPI/Monitoring/TestMonitoring.py
@@ -6,13 +6,12 @@ from Ganga.testlib.GangaUnitTest import GangaUnitTest
 
 master_timeout = 300.
 
+
 def dummySleep(someJob):
     my_timeout = 0.
     while someJob.status not in ['completed', 'failed', 'killed', 'removed'] and my_timeout < master_timeout:
         time.sleep(1.)
-        my_timeout+=1.
-
-    return
+        my_timeout += 1.
 
 class TestMonitoring(GangaUnitTest):
 
@@ -88,8 +87,6 @@ class TestMonitoring(GangaUnitTest):
         disableMonitoring()
         j=Job()
         j.submit()
-
-        time.sleep(20.)
 
         self.assertEqual(j.status, 'submitted')
 

--- a/python/Ganga/test/GPI/Parallel/TestQueuedSJSubmit.py
+++ b/python/Ganga/test/GPI/Parallel/TestQueuedSJSubmit.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, print_function
 
 from Ganga.testlib.GangaUnitTest import GangaUnitTest
+from Ganga.testlib.monitoring import run_until_completed
 
 import time
 
@@ -61,14 +62,13 @@ class TestQueuedSJSubmit(GangaUnitTest):
 
     def test_d_Finished(self):
         from Ganga.GPI import jobs, queues
-        from GangaTest.Framework.utils import sleep_until_completed
 
         print('waiting on job', end=' ')
         for j in jobs:
             print(j.id, end=' ')
             import sys
             sys.stdout.flush()
-            assert sleep_until_completed(j), 'Timeout on job submission: job is still not finished'
+            assert run_until_completed(j, sleep_period=0.1), 'Timeout on job submission: job is still not finished'
             assert j.status == 'completed'
 
     def test_e_Cleanup(self):

--- a/python/Ganga/test/GPI/Parallel/TestQueuedSubmit.py
+++ b/python/Ganga/test/GPI/Parallel/TestQueuedSubmit.py
@@ -5,7 +5,7 @@ from Ganga.testlib.monitoring import run_until_completed
 
 import time
 
-global_num_threads = 20
+global_num_threads = 10
 global_num_jobs = global_num_threads*5
 
 

--- a/python/Ganga/test/GPI/Parallel/TestQueuedSubmit.py
+++ b/python/Ganga/test/GPI/Parallel/TestQueuedSubmit.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, print_function
 
 from Ganga.testlib.GangaUnitTest import GangaUnitTest
+from Ganga.testlib.monitoring import run_until_completed
 
 import time
 
@@ -61,14 +62,13 @@ class TestQueuedSubmit(GangaUnitTest):
 
     def test_d_Finished(self):
         from Ganga.GPI import jobs, queues
-        from GangaTest.Framework.utils import sleep_until_completed
 
         print('waiting on job', end=' ')
         for j in jobs:
             print(j.id, end=' ')
             import sys
             sys.stdout.flush()
-            assert sleep_until_completed(j), 'Timeout on job submission: job is still not finished'
+            assert run_until_completed(j, sleep_period=0.1), 'Timeout on job submission: job is still not finished'
             assert j.status == 'completed'
 
     def test_e_Cleanup(self):

--- a/python/Ganga/test/GPI/TestJob.py
+++ b/python/Ganga/test/GPI/TestJob.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 from Ganga.testlib.GangaUnitTest import GangaUnitTest
+from Ganga.testlib.monitoring import run_until_completed
 
 from Ganga.GPIDev.Base.Proxy import stripProxy
 
@@ -15,6 +16,13 @@ class TestJob(GangaUnitTest):
         from Ganga.GPI import Job
         j = Job()
         j.submit()
+
+    def testJobCompleted(self):
+        from Ganga.GPI import Job
+        j = Job()
+        j.submit()
+        run_until_completed(j)
+        assert j.status == 'completed'
 
     def testJobAssignment(self):
         """Test assignment of all job properties"""

--- a/python/Ganga/test/GPI/TutorialTests.py
+++ b/python/Ganga/test/GPI/TutorialTests.py
@@ -432,7 +432,7 @@ j.submit()
         queues
 
         # -- QUEUES EXAMPLE START
-        for i in range(1, 20):
+        for i in range(1, 10):
             j = Job()
             queues.add(j.submit)
         # -- QUEUES EXAMPLE STOP
@@ -448,7 +448,7 @@ j.submit()
         j = Job()
         j.splitter = GenericSplitter()
         j.splitter.attribute = 'application.args'
-        j.splitter.values = [i for i in range(0, 50)]
+        j.splitter.values = [i for i in range(0, 10)]
         j.parallel_submit = True
         j.submit()
         # -- QUEUES SPLIT STOP

--- a/python/Ganga/testlib/GangaUnitTest.py
+++ b/python/Ganga/testlib/GangaUnitTest.py
@@ -48,6 +48,7 @@ def start_ganga(gangadir_for_test, extra_opts=[]):
         ('Configuration', 'gangadir', gangadir_for_test),
         ('Configuration', 'user', 'testframework'),
         ('Configuration', 'repositorytype', 'LocalXML'),
+        ('Configuration', 'UsageMonitoringMSG', False),  # Turn off spyware
         ('TestingFramework', 'ReleaseTesting', True),
         ('Queues', 'NumWorkerThreads', 2),
     ]

--- a/python/Ganga/testlib/monitoring.py
+++ b/python/Ganga/testlib/monitoring.py
@@ -1,0 +1,64 @@
+"""
+Monitoring functions for tests to allow the status of jobs to be progressed.
+"""
+
+import logging
+import time
+from datetime import datetime, timedelta
+
+from Ganga.GPIDev.Base.Proxy import proxy_wrap
+
+
+@proxy_wrap
+def run_until_state(j, state, timeout=60, break_states=None, sleep_period=0.5):
+    # type: (Job, str, float, List[str], float) -> bool
+    """
+    Run the desired job until it reaches a specific state
+    Args:
+        j (Job): the job object to monitor
+        timeout (float): the time in seconds to try for
+        state (str): the state to aim for
+        break_states (List[str]): a list of states on which to fail early
+        sleep_period (float): How long to wait between loop cycles
+
+    Returns:
+        bool: ``True`` if the job reached the appropriate state, ``False`` otherwise.
+    """
+    logger = logging.getLogger(__name__)
+
+    logger.info('Monitoring job %s until state "%s"', j.id, state)
+
+    if break_states is None:
+        break_states = []
+
+    backend = type(j.backend)
+
+    end_time = datetime.utcnow() + timedelta(seconds=timeout)
+
+    while j.status != state and datetime.utcnow() < end_time:
+        backend.master_updateMonitoringInformation([j])
+        logger.info('Job %s is in state %s', j.id, j.status)
+        if j.status in break_states:
+            logger.info('Monitoring returning False due to break state "%s"', j.status)
+            return False
+        time.sleep(sleep_period)
+    return j.status == state
+
+
+@proxy_wrap
+def run_until_completed(j, timeout=60, sleep_period=0.5):
+    # type: (Job, float, List[str], float) -> bool
+    """
+    A shortcut function to run ``run_until_state`` with ``state='completed'``
+    and a sensible set of ``break_states``
+
+    Args:
+        j (Job): the job object to monitor
+        timeout (float): the time in seconds to try for
+        sleep_period (float): How long to wait between loop cycles
+
+    Returns:
+        bool: ``True`` if the job reached 'completed', ``False`` otherwise.
+
+    """
+    return run_until_state(j, 'completed', timeout, ['new', 'killed', 'failed', 'unknown', 'removed'], sleep_period)

--- a/python/GangaDirac/old_test/GPI/Files/TestDiracFile.py
+++ b/python/GangaDirac/old_test/GPI/Files/TestDiracFile.py
@@ -4,7 +4,7 @@ from GangaTest.Framework.tests import GangaGPITestCase
 #from Ganga.GPIDev.Adapters.StandardJobConfig       import StandardJobConfig
 #from Ganga.Core.exceptions                         import ApplicationConfigurationError, GangaException
 from Ganga.GPI import *
-from Ganga.test import generateUniqueTempFile
+from Ganga.old_test import generateUniqueTempFile
 #import GangaDirac.Lib.Server.DiracServer as DiracServer
 # GangaTest.Framework.utils defines some utility methods
 from GangaTest.Framework.utils import sleep_until_completed, sleep_until_state

--- a/python/GangaLHCb/old_test/Bugs/JIRA1943.gpi
+++ b/python/GangaLHCb/old_test/Bugs/JIRA1943.gpi
@@ -1,5 +1,5 @@
 from tempfile import mkdtemp
-from GangaLHCb.test import *
+from GangaLHCb.old_test import *
 from os.path import join, basename
 from os import remove
 

--- a/python/GangaLHCb/old_test/Bugs/Savannah13943.gpi
+++ b/python/GangaLHCb/old_test/Bugs/Savannah13943.gpi
@@ -1,7 +1,7 @@
 import os,os.path
 from GangaTest.Framework.utils import sleep_until_completed,sleep_until_state
 import tempfile
-from GangaLHCb.test import *
+from GangaLHCb.old_test import *
 
 tmpdir = tempfile.mktemp()
 os.mkdir(tmpdir)

--- a/python/GangaLHCb/old_test/Bugs/Savannah20538.gpi
+++ b/python/GangaLHCb/old_test/Bugs/Savannah20538.gpi
@@ -1,5 +1,5 @@
 from tempfile import mkdtemp
-from GangaLHCb.test import *
+from GangaLHCb.old_test import *
 from os.path import join,basename
 from os import remove
 

--- a/python/GangaLHCb/old_test/Bugs/Savannah36400.gpi
+++ b/python/GangaLHCb/old_test/Bugs/Savannah36400.gpi
@@ -1,4 +1,4 @@
-from GangaLHCb.test import *
+from GangaLHCb.old_test import *
 addDiracTestSubmitter()
 
 #set a version that does't exist in the config

--- a/python/GangaLHCb/old_test/GPI/DaVinci/TestDaVinci.py
+++ b/python/GangaLHCb/old_test/GPI/DaVinci/TestDaVinci.py
@@ -4,7 +4,7 @@ from GangaTest.Framework.utils import sleep_until_completed
 
 import Ganga.Utility.Config.Config
 
-from GangaLHCb.test import getDiracAppPlatform
+from GangaLHCb.old_test import getDiracAppPlatform
 
 import Ganga.Utility.logging
 logger = Ganga.Utility.logging.getLogger()

--- a/python/GangaLHCb/old_test/GPI/Dirac/GaudiPythonDirac.gpi
+++ b/python/GangaLHCb/old_test/GPI/Dirac/GaudiPythonDirac.gpi
@@ -1,4 +1,4 @@
-from GangaLHCb.test import *
+from GangaLHCb.old_test import *
 addDiracTestSubmitter()
 
 ap = GaudiPython()

--- a/python/GangaLHCb/old_test/GPI/Dirac/RootTestSubmitDirac.gpi
+++ b/python/GangaLHCb/old_test/GPI/Dirac/RootTestSubmitDirac.gpi
@@ -1,4 +1,4 @@
-from GangaLHCb.test import *
+from GangaLHCb.old_test import *
 
 ganga_path = os.path.abspath(os.path.dirname(__file__))
 script_file = ganga_path + '/../python/GangaLHCb/old_test/GPI/Dirac/test.C'

--- a/python/GangaLHCb/old_test/GPI/Dirac/TestSubmitDirac.gpi
+++ b/python/GangaLHCb/old_test/GPI/Dirac/TestSubmitDirac.gpi
@@ -1,4 +1,4 @@
-from GangaLHCb.test import *
+from GangaLHCb.old_test import *
 
 ap = DaVinci()
 j = Job(application=ap, backend=DiracTestSubmitter())

--- a/python/GangaLHCb/old_test/GPI/GaudiPython/TestBender.gpip
+++ b/python/GangaLHCb/old_test/GPI/GaudiPython/TestBender.gpip
@@ -6,10 +6,10 @@ from os.path import join
 from GangaTest.Framework.tests import GangaGPITestCase, ICheckTest
 from GangaTest.Framework.utils import file_contains, is_job_finished, write_file
 
-from GangaLHCb.test import *
+from GangaLHCb.old_test import *
 
 import Ganga.Utility.Config.Config
-from GangaLHCb.test import *
+from GangaLHCb.old_test import *
 
 import Ganga.Utility.Config
 

--- a/python/GangaLHCb/old_test/GPI/GaudiPython/TestGaudiPython.py
+++ b/python/GangaLHCb/old_test/GPI/GaudiPython/TestGaudiPython.py
@@ -6,9 +6,9 @@ import shutil
 import tempfile
 from os.path import join
 
-from GangaLHCb.test import *
+from GangaLHCb.old_test import *
 
-#from GangaLHCb.test import *
+#from GangaLHCb.old_test import *
 
 import Ganga.Utility.Config
 configDaVinci = Ganga.Utility.Config.getConfig('defaults_DaVinci')

--- a/python/GangaLHCb/old_test/GPI/GaudiSplitters/SplitByFiles.gpi
+++ b/python/GangaLHCb/old_test/GPI/GaudiSplitters/SplitByFiles.gpi
@@ -1,6 +1,6 @@
 # Test the SplitByFiles algorithm using the TestSubmitter
 
-from GangaLHCb.test import *
+from GangaLHCb.old_test import *
 
 addLocalTestSubmitter()
 

--- a/python/GangaLHCb/old_test/GPI/GaudiSplitters/TestDiracSplitter.py
+++ b/python/GangaLHCb/old_test/GPI/GaudiSplitters/TestDiracSplitter.py
@@ -21,8 +21,8 @@ if doConfig:
     #from GangaGaudi.Lib.Splitters.GaudiInputDataSplitter import GaudiInputDataSplitter
     #from GangaLHCb.Lib.Splitters.SplitByFiles import SplitByFiles
     from GangaLHCb.Lib.LHCbDataset.LHCbDataset import LHCbDataset
-    from GangaLHCb.test import addDiracTestSubmitter
-    GangaLHCb.test.addDiracTestSubmitter()
+    from GangaLHCb.old_test import addDiracTestSubmitter
+    GangaLHCb.old_test.addDiracTestSubmitter()
 
 # LFNs = [ 'LFN:/lhcb/data/2010/DIMUON.DST/00008395/0000/00008395_00000919_1.dimuon.dst',
 #         'LFN:/lhcb/data/2010/DIMUON.DST/00008395/0000/00008395_00000922_1.dimuon.dst',

--- a/python/GangaLHCb/old_test/GPI/GaudiSplitters/TestSplitBigDataset.gpi
+++ b/python/GangaLHCb/old_test/GPI/GaudiSplitters/TestSplitBigDataset.gpi
@@ -1,4 +1,4 @@
-from GangaLHCb.test import *
+from GangaLHCb.old_test import *
 
 addLocalTestSubmitter()
 

--- a/python/GangaLHCb/old_test/Lib/DIRAC/TestLHCbGaudiDiracRunTimeHandler.py
+++ b/python/GangaLHCb/old_test/Lib/DIRAC/TestLHCbGaudiDiracRunTimeHandler.py
@@ -23,7 +23,7 @@ class TestLHCbGaudiDiracRunTimeHandler(GangaGPITestCase):
         j.outputfiles = ['dummy1.out', 'dummy2.out', 'dummy3.out']
         self.j = j
         self.app = j.application._impl
-        from GangaLHCb.test import getDiracAppPlatform
+        from GangaLHCb.old_test import getDiracAppPlatform
         self.app.platform = getDiracAppPlatform()
         #self.extra = GaudiExtras()
         # self.extra.master_input_buffers['master.buffer'] = '###MASTERBUFFER###'

--- a/python/GangaLHCb/old_test/config/default.ini
+++ b/python/GangaLHCb/old_test/config/default.ini
@@ -6,7 +6,7 @@
 ###    - the default timeout for Ganga tests
 
 [Configuration]
-RUNTIME_PATH = GangaTest:GangaLHCb
+RUNTIME_PATH = GangaTest:GangaDirac:GangaGaudi:GangaLHCb
 #disable usage monitoring
 #UsageMonitoringURL=
 user = testframework

--- a/python/GangaLHCb/old_test/config/localxml.ini
+++ b/python/GangaLHCb/old_test/config/localxml.ini
@@ -6,7 +6,7 @@
 ###    - the default timeout for Ganga tests
 
 [Configuration]
-RUNTIME_PATH = GangaTest:GangaLHCb
+RUNTIME_PATH = GangaTest:GangaDirac:GangaLHCb
 #disable usage monitoring
 #UsageMonitoringURL=
 user = testframework

--- a/python/GangaLHCb/old_test/config/localxml.ini
+++ b/python/GangaLHCb/old_test/config/localxml.ini
@@ -6,7 +6,7 @@
 ###    - the default timeout for Ganga tests
 
 [Configuration]
-RUNTIME_PATH = GangaTest:GangaDirac:GangaLHCb
+RUNTIME_PATH = GangaTest:GangaDirac:GangaGaudi:GangaLHCb
 #disable usage monitoring
 #UsageMonitoringURL=
 user = testframework

--- a/python/GangaLHCb/old_test/config/remote.ini
+++ b/python/GangaLHCb/old_test/config/remote.ini
@@ -6,7 +6,7 @@
 ###    - the default timeout for Ganga tests
 
 [Configuration]
-RUNTIME_PATH = GangaTest:GangaLHCb
+RUNTIME_PATH = GangaTest:GangaDirac:GangaGaudi:GangaLHCb
 gangadir = ~/gangadir_testing
 user = testframework
 repositorytype = RemoteAMGA

--- a/release/tools/schema_gen.sh
+++ b/release/tools/schema_gen.sh
@@ -101,7 +101,7 @@ case `whoami` in
     gangaat )
         export LOAD_PACKAGES='GangaTest:GangaAtlas' ;;
     gangalb )
-        export LOAD_PACKAGES='GangaTest:GangaLHCb' ;;
+        export LOAD_PACKAGES='GangaTest:GangaDirac:GangaGaudi:GangaLHCb' ;;
 esac
 
 ##Run the repo generation 

--- a/release/tools/schema_test.sh
+++ b/release/tools/schema_test.sh
@@ -108,7 +108,7 @@ case `whoami` in
     gangaat )
         export LOAD_PACKAGES='GangaTest:GangaAtlas' ;;
     gangalb )
-        export LOAD_PACKAGES='GangaTest:GangaLHCb' ;;
+        export LOAD_PACKAGES='GangaTest:GangaDirac:GangaGaudi:GangaLHCb' ;;
 esac
 
 GANGA_TEST='Ganga/old_test/Schema/Test'


### PR DESCRIPTION
This makes various changes to speed up the test execution. We'll see how much of a difference it makes when it runs on ganga-ci. Nothing here touches any runtime code except the single small change to `IBackend`.

The majority of the speed-up is due to a change from `sleep_until_completed` to `run_until_completed`.

On a few tests I have tweaked the number of 'iterations' to reduce it to a better level.