### PR TITLE
Move construction of DiracLFNBase into a function

### DIFF
--- a/python/GangaDirac/BOOT.py
+++ b/python/GangaDirac/BOOT.py
@@ -86,7 +86,7 @@ def getDiracFiles():
     import os
     from GangaDirac.Lib.Files.DiracFile import DiracFile
     from Ganga.GPIDev.Lib.GangaList.GangaList import GangaList
-    filename = getConfig('DIRAC')['DiracLFNBase'].replace('/', '-') + '.lfns'
+    filename = DiracFile.diracLFNBase().replace('/', '-') + '.lfns'
     logger.info('Creating list, this can take a while if you have a large number of SE files, please wait...')
     execute('dirac-dms-user-lfns &> /dev/null', shell=True, timeout=None)
     g = GangaList()

--- a/python/GangaDirac/Lib/Files/DiracFile.py
+++ b/python/GangaDirac/Lib/Files/DiracFile.py
@@ -14,6 +14,7 @@ from Ganga.Utility.files import expandfilename
 from GangaDirac.Lib.Utilities.DiracUtilities import getDiracEnv, execute
 from Ganga.Utility.Config import getConfig
 from Ganga.Utility.logging import getLogger
+config = getConfig('Configuration')
 configDirac = getConfig('DIRAC')
 logger = getLogger()
 regex = re.compile('[*?\[\]]')
@@ -734,7 +735,7 @@ class DiracFile(IGangaFile):
             import datetime
             t = datetime.datetime.now()
             this_date = t.strftime("%H.%M_%A_%d_%B_%Y")
-            self.lfn = os.path.join(configDirac['DiracLFNBase'], 'GangaFiles_%s' % this_date)
+            self.lfn = os.path.join(DiracFile.diracLFNBase(), 'GangaFiles_%s' % this_date)
             selfConstructedLFN = True
 
         if self.remoteDir[:4] == 'LFN:':
@@ -902,11 +903,11 @@ for f in glob.glob('###NAME_PATTERN###'):
             import datetime
             t = datetime.datetime.now()
             this_date = t.strftime("%H.%M_%A_%d_%B_%Y")
-            self.lfn = os.path.join(configDirac['DiracLFNBase'], 'GangaFiles_%s' % this_date)
+            self.lfn = os.path.join(DiracFile.diracLFNBase(), 'GangaFiles_%s' % this_date)
             selfConstructedLFNs = True
 
         if self.remoteDir == '' and self.lfn != '':
-            self.remoteDir = configDirac['DiracLFNBase']
+            self.remoteDir = DiracFile.diracLFNBase()
 
         if self.remoteDir[:4] == 'LFN:':
             lfn_base = self.remoteDir[4:]
@@ -955,6 +956,17 @@ for f in glob.glob('###NAME_PATTERN###'):
         else:
             logger.error("Failed to Match file:\n%s" % str(self))
             return False
+
+    @staticmethod
+    def diracLFNBase():
+        """
+        Compute a sensible default LFN base name
+        If ``DiracLFNBase`` has been defined, use that.
+        Otherwise, construct one from the user name and the user VO
+        """
+        if configDirac['DiracLFNBase']:
+            return configDirac['DiracLFNBase']
+        return '/{}/user/{}/{}'.format(configDirac['userVO'], config['user'][0], config['user'])
 
 # add DiracFile objects to the configuration scope (i.e. it will be
 # possible to write instatiate DiracFile() objects via config file)

--- a/python/GangaDirac/__init__.py
+++ b/python/GangaDirac/__init__.py
@@ -42,10 +42,7 @@ if not _after_bootstrap:
     ## TODO this would be nice to move from here once the credentials branch is up and running
     configDirac.addOption('userVO', '', 'The name of the VO that the user belongs to')
 
-    # Problem if installing Ganga as config isn't setup properly
-    if 'user' in config:
-        configDirac.addOption('DiracLFNBase', '/%s/user/%s/%s' % (configDirac['userVO'], config['user'][0], config['user']),
-                          "Base dir appended to create LFN name from DiracFile('name')")
+    configDirac.addOption('DiracLFNBase', '', "Base dir prepended to create LFN name from DiracFile('name'). If this is unset then it will default to /[userVO]/user/[first letter of user name]/[user name]")
 
     configDirac.addOption('ReplicateOutputData', False,
                       'Determines whether outputdata stored on Dirac is replicated')


### PR DESCRIPTION
If it is in the `__init__.py` then some information set by the user will
not yet be available. Deferring it to point of use allows user settings
to be used.