### PR TITLE
Fix LHCb test imports

### DIFF
--- a/python/GangaDirac/old_test/GPI/Files/TestDiracFile.py
+++ b/python/GangaDirac/old_test/GPI/Files/TestDiracFile.py
@@ -4,7 +4,7 @@ from GangaTest.Framework.tests import GangaGPITestCase
 #from Ganga.GPIDev.Adapters.StandardJobConfig       import StandardJobConfig
 #from Ganga.Core.exceptions                         import ApplicationConfigurationError, GangaException
 from Ganga.GPI import *
-from Ganga.test import generateUniqueTempFile
+from Ganga.old_test import generateUniqueTempFile
 #import GangaDirac.Lib.Server.DiracServer as DiracServer
 # GangaTest.Framework.utils defines some utility methods
 from GangaTest.Framework.utils import sleep_until_completed, sleep_until_state

--- a/python/GangaLHCb/old_test/Bugs/JIRA1943.gpi
+++ b/python/GangaLHCb/old_test/Bugs/JIRA1943.gpi
@@ -1,5 +1,5 @@
 from tempfile import mkdtemp
-from GangaLHCb.test import *
+from GangaLHCb.old_test import *
 from os.path import join, basename
 from os import remove
 

--- a/python/GangaLHCb/old_test/Bugs/Savannah13943.gpi
+++ b/python/GangaLHCb/old_test/Bugs/Savannah13943.gpi
@@ -1,7 +1,7 @@
 import os,os.path
 from GangaTest.Framework.utils import sleep_until_completed,sleep_until_state
 import tempfile
-from GangaLHCb.test import *
+from GangaLHCb.old_test import *
 
 tmpdir = tempfile.mktemp()
 os.mkdir(tmpdir)

--- a/python/GangaLHCb/old_test/Bugs/Savannah20538.gpi
+++ b/python/GangaLHCb/old_test/Bugs/Savannah20538.gpi
@@ -1,5 +1,5 @@
 from tempfile import mkdtemp
-from GangaLHCb.test import *
+from GangaLHCb.old_test import *
 from os.path import join,basename
 from os import remove
 

--- a/python/GangaLHCb/old_test/Bugs/Savannah36400.gpi
+++ b/python/GangaLHCb/old_test/Bugs/Savannah36400.gpi
@@ -1,4 +1,4 @@
-from GangaLHCb.test import *
+from GangaLHCb.old_test import *
 addDiracTestSubmitter()
 
 #set a version that does't exist in the config

--- a/python/GangaLHCb/old_test/GPI/DaVinci/TestDaVinci.py
+++ b/python/GangaLHCb/old_test/GPI/DaVinci/TestDaVinci.py
@@ -4,7 +4,7 @@ from GangaTest.Framework.utils import sleep_until_completed
 
 import Ganga.Utility.Config.Config
 
-from GangaLHCb.test import getDiracAppPlatform
+from GangaLHCb.old_test import getDiracAppPlatform
 
 import Ganga.Utility.logging
 logger = Ganga.Utility.logging.getLogger()

--- a/python/GangaLHCb/old_test/GPI/Dirac/GaudiPythonDirac.gpi
+++ b/python/GangaLHCb/old_test/GPI/Dirac/GaudiPythonDirac.gpi
@@ -1,4 +1,4 @@
-from GangaLHCb.test import *
+from GangaLHCb.old_test import *
 addDiracTestSubmitter()
 
 ap = GaudiPython()

--- a/python/GangaLHCb/old_test/GPI/Dirac/RootTestSubmitDirac.gpi
+++ b/python/GangaLHCb/old_test/GPI/Dirac/RootTestSubmitDirac.gpi
@@ -1,4 +1,4 @@
-from GangaLHCb.test import *
+from GangaLHCb.old_test import *
 
 ganga_path = os.path.abspath(os.path.dirname(__file__))
 script_file = ganga_path + '/../python/GangaLHCb/old_test/GPI/Dirac/test.C'

--- a/python/GangaLHCb/old_test/GPI/Dirac/TestSubmitDirac.gpi
+++ b/python/GangaLHCb/old_test/GPI/Dirac/TestSubmitDirac.gpi
@@ -1,4 +1,4 @@
-from GangaLHCb.test import *
+from GangaLHCb.old_test import *
 
 ap = DaVinci()
 j = Job(application=ap, backend=DiracTestSubmitter())

--- a/python/GangaLHCb/old_test/GPI/GaudiPython/TestBender.gpip
+++ b/python/GangaLHCb/old_test/GPI/GaudiPython/TestBender.gpip
@@ -6,10 +6,10 @@ from os.path import join
 from GangaTest.Framework.tests import GangaGPITestCase, ICheckTest
 from GangaTest.Framework.utils import file_contains, is_job_finished, write_file
 
-from GangaLHCb.test import *
+from GangaLHCb.old_test import *
 
 import Ganga.Utility.Config.Config
-from GangaLHCb.test import *
+from GangaLHCb.old_test import *
 
 import Ganga.Utility.Config
 

--- a/python/GangaLHCb/old_test/GPI/GaudiPython/TestGaudiPython.py
+++ b/python/GangaLHCb/old_test/GPI/GaudiPython/TestGaudiPython.py
@@ -6,9 +6,9 @@ import shutil
 import tempfile
 from os.path import join
 
-from GangaLHCb.test import *
+from GangaLHCb.old_test import *
 
-#from GangaLHCb.test import *
+#from GangaLHCb.old_test import *
 
 import Ganga.Utility.Config
 configDaVinci = Ganga.Utility.Config.getConfig('defaults_DaVinci')

--- a/python/GangaLHCb/old_test/GPI/GaudiSplitters/SplitByFiles.gpi
+++ b/python/GangaLHCb/old_test/GPI/GaudiSplitters/SplitByFiles.gpi
@@ -1,6 +1,6 @@
 # Test the SplitByFiles algorithm using the TestSubmitter
 
-from GangaLHCb.test import *
+from GangaLHCb.old_test import *
 
 addLocalTestSubmitter()
 

--- a/python/GangaLHCb/old_test/GPI/GaudiSplitters/TestDiracSplitter.py
+++ b/python/GangaLHCb/old_test/GPI/GaudiSplitters/TestDiracSplitter.py
@@ -21,8 +21,8 @@ if doConfig:
     #from GangaGaudi.Lib.Splitters.GaudiInputDataSplitter import GaudiInputDataSplitter
     #from GangaLHCb.Lib.Splitters.SplitByFiles import SplitByFiles
     from GangaLHCb.Lib.LHCbDataset.LHCbDataset import LHCbDataset
-    from GangaLHCb.test import addDiracTestSubmitter
-    GangaLHCb.test.addDiracTestSubmitter()
+    from GangaLHCb.old_test import addDiracTestSubmitter
+    GangaLHCb.old_test.addDiracTestSubmitter()
 
 # LFNs = [ 'LFN:/lhcb/data/2010/DIMUON.DST/00008395/0000/00008395_00000919_1.dimuon.dst',
 #         'LFN:/lhcb/data/2010/DIMUON.DST/00008395/0000/00008395_00000922_1.dimuon.dst',

--- a/python/GangaLHCb/old_test/GPI/GaudiSplitters/TestSplitBigDataset.gpi
+++ b/python/GangaLHCb/old_test/GPI/GaudiSplitters/TestSplitBigDataset.gpi
@@ -1,4 +1,4 @@
-from GangaLHCb.test import *
+from GangaLHCb.old_test import *
 
 addLocalTestSubmitter()
 

--- a/python/GangaLHCb/old_test/Lib/DIRAC/TestLHCbGaudiDiracRunTimeHandler.py
+++ b/python/GangaLHCb/old_test/Lib/DIRAC/TestLHCbGaudiDiracRunTimeHandler.py
@@ -23,7 +23,7 @@ class TestLHCbGaudiDiracRunTimeHandler(GangaGPITestCase):
         j.outputfiles = ['dummy1.out', 'dummy2.out', 'dummy3.out']
         self.j = j
         self.app = j.application._impl
-        from GangaLHCb.test import getDiracAppPlatform
+        from GangaLHCb.old_test import getDiracAppPlatform
         self.app.platform = getDiracAppPlatform()
         #self.extra = GaudiExtras()
         # self.extra.master_input_buffers['master.buffer'] = '###MASTERBUFFER###'

--- a/python/GangaLHCb/old_test/config/default.ini
+++ b/python/GangaLHCb/old_test/config/default.ini
@@ -6,7 +6,7 @@
 ###    - the default timeout for Ganga tests
 
 [Configuration]
-RUNTIME_PATH = GangaTest:GangaLHCb
+RUNTIME_PATH = GangaTest:GangaDirac:GangaGaudi:GangaLHCb
 #disable usage monitoring
 #UsageMonitoringURL=
 user = testframework

--- a/python/GangaLHCb/old_test/config/localxml.ini
+++ b/python/GangaLHCb/old_test/config/localxml.ini
@@ -6,7 +6,7 @@
 ###    - the default timeout for Ganga tests
 
 [Configuration]
-RUNTIME_PATH = GangaTest:GangaLHCb
+RUNTIME_PATH = GangaTest:GangaDirac:GangaLHCb
 #disable usage monitoring
 #UsageMonitoringURL=
 user = testframework

--- a/python/GangaLHCb/old_test/config/localxml.ini
+++ b/python/GangaLHCb/old_test/config/localxml.ini
@@ -6,7 +6,7 @@
 ###    - the default timeout for Ganga tests
 
 [Configuration]
-RUNTIME_PATH = GangaTest:GangaDirac:GangaLHCb
+RUNTIME_PATH = GangaTest:GangaDirac:GangaGaudi:GangaLHCb
 #disable usage monitoring
 #UsageMonitoringURL=
 user = testframework

--- a/python/GangaLHCb/old_test/config/remote.ini
+++ b/python/GangaLHCb/old_test/config/remote.ini
@@ -6,7 +6,7 @@
 ###    - the default timeout for Ganga tests
 
 [Configuration]
-RUNTIME_PATH = GangaTest:GangaLHCb
+RUNTIME_PATH = GangaTest:GangaDirac:GangaGaudi:GangaLHCb
 gangadir = ~/gangadir_testing
 user = testframework
 repositorytype = RemoteAMGA

--- a/release/tools/schema_gen.sh
+++ b/release/tools/schema_gen.sh
@@ -101,7 +101,7 @@ case `whoami` in
     gangaat )
         export LOAD_PACKAGES='GangaTest:GangaAtlas' ;;
     gangalb )
-        export LOAD_PACKAGES='GangaTest:GangaLHCb' ;;
+        export LOAD_PACKAGES='GangaTest:GangaDirac:GangaGaudi:GangaLHCb' ;;
 esac
 
 ##Run the repo generation 

--- a/release/tools/schema_test.sh
+++ b/release/tools/schema_test.sh
@@ -108,7 +108,7 @@ case `whoami` in
     gangaat )
         export LOAD_PACKAGES='GangaTest:GangaAtlas' ;;
     gangalb )
-        export LOAD_PACKAGES='GangaTest:GangaLHCb' ;;
+        export LOAD_PACKAGES='GangaTest:GangaDirac:GangaGaudi:GangaLHCb' ;;
 esac
 
 GANGA_TEST='Ganga/old_test/Schema/Test'


### PR DESCRIPTION
The main important change in this PR is that to  `python/GangaLHCb/old_test/config/localxml.ini`. We now need to explicitly add `GangaDirac` to the runtime path before `GangaLHCb` so that the config has been set up by the time that the LHCb statup runs.

The other changes are just fixes to accidental leftovers from the `test`→`old_test` changes.