### PR TITLE
Added missing homepackage setting when atlas_release is not set

### DIFF
--- a/python/GangaPanda/Lib/Athena/AthenaPandaRTHandler.py
+++ b/python/GangaPanda/Lib/Athena/AthenaPandaRTHandler.py
@@ -651,6 +651,10 @@ class AthenaPandaRTHandler(IRuntimeHandler):
             jspec.homepackage       = 'AnalysisTransforms'+self.cacheVer#+nightVer
             jspec.cmtConfig         = AthenaUtils.getCmtConfig(athenaVer=app.atlas_release, cmtConfig=app.atlas_cmtconfig)
         else:
+            # set the home package if we can otherwise the pilot won't set things up properly
+            if self.cacheVer:
+                jspec.homepackage   = 'AnalysisTransforms'+self.cacheVer
+
             # cmt config                                                                                                                                                                                                             
             jspec.cmtConfig         = AthenaUtils.getCmtConfig(athenaVer=app.atlas_release, cmtConfig=app.atlas_cmtconfig)
         if app.atlas_exetype in ['PYARA','ARES','ROOT','EXE']:


### PR DESCRIPTION
Minor addition from the previous set of Atlas fixes which I missed (#470).