### PR TITLE
Fix execute's update_env

### DIFF
--- a/python/Ganga/Utility/Shell.py
+++ b/python/Ganga/Utility/Shell.py
@@ -115,6 +115,7 @@ class Shell(object):
         """
 
         if setup is not None:
+            self.env = {}
             execute('source {0} {1}'.format(setup," ".join(setup_args)), shell=True, env=self.env, update_env=True)
 
         else:

--- a/python/Ganga/Utility/Shell.py
+++ b/python/Ganga/Utility/Shell.py
@@ -115,7 +115,7 @@ class Shell(object):
         """
 
         if setup is not None:
-            self.env = {}
+            self.env = dict(os.environ)
             execute('source {0} {1}'.format(setup," ".join(setup_args)), shell=True, env=self.env, update_env=True)
 
         else:

--- a/python/Ganga/Utility/execute.py
+++ b/python/Ganga/Utility/execute.py
@@ -111,7 +111,7 @@ def execute(command,
         # note the exec gets around the problem of indent and base64 gets
         # around the \n
         command_update, envread, envwrite = env_update_script()
-        command += ''';python -c ""from __future__ import print_function;import base64;exec(base64.b64decode('%s'))"''' % base64.b64encode(command_update)
+        command += ''';python -c "from __future__ import print_function;import base64;exec(base64.b64decode('%s'))"''' % base64.b64encode(command_update)
 
     if env is None and not update_env:
         pipe = subprocess.Popen('python -c "from __future__ import print_function;import os;print(os.environ)"',

--- a/python/GangaDirac/Lib/Utilities/DiracUtilities.py
+++ b/python/GangaDirac/Lib/Utilities/DiracUtilities.py
@@ -6,7 +6,7 @@ import pickle
 import signal
 from Ganga.Utility.Config import getConfig
 from Ganga.Utility.logging import getLogger
-from Ganga.Utility.Shell import get_env_from_arg
+from Ganga.Utility.execute import execute
 from Ganga.Core.exceptions import GangaException
 from Ganga.GPIDev.Credentials import getCredential
 import Ganga.Utility.execute as gexecute
@@ -48,7 +48,8 @@ def getDiracEnv(force=False):
                 absolute_path = config_file
             if getConfig('DIRAC')['DiracEnvFile'] != "" and os.path.exists(absolute_path):
 
-                env_dict = get_env_from_arg(this_arg = absolute_path, def_env_on_fail = False)
+                env_dict = {}
+                execute('source {0}'.format(absolute_path), shell=True, env=env_dict, update_env=True)
 
                 if env_dict is not None:
                     DIRAC_ENV = env_dict


### PR DESCRIPTION
When working to port some of the DIRAC tests I came across a feature of `Ganga.Utility.execute.execute()` which allows it to update a dictionary based on the environment of the called command. This was accidentally broken in [`c637500`](https://github.com/ganga-devs/ganga/commit/c637500b68ebf9bc5e45ccbf03559868152d1949#diff-09802c04483863469997ddb0cb23bea3) but since the Dirac test was the only thing using it, it went unnoticed.

This PR fixes that command and then changes the two existing uses of `get_env_from_arg()` to use `update_env` instead.

Historically, it seems that `update_env` was added to the queues system's version of `execute()` in b46aa4ec327a494135e3092a2f02ec968949dd41 by @alexanderrichards before being migrated to the standard `execute()` function some time later.