### PR TITLE
Feature/no multiple mon loops

### DIFF
--- a/python/Ganga/Core/GangaRepository/Registry.py
+++ b/python/Ganga/Core/GangaRepository/Registry.py
@@ -959,12 +959,6 @@ class Registry(object):
                 s += ", %i other concurrent sessions:\n * %s" % (len(other_sessions), "\n * ".join(other_sessions))
         return s
 
-    def get_other_sessions(self):
-        """
-        Returns a list of information describing other sessions which are currently active
-        """
-        return self.repository.get_other_sessions()
-
     @synchronised
     def has_loaded(self, obj):
         """Returns True/False for if a given object has been fully loaded by the Registry.

--- a/python/Ganga/Core/GangaRepository/Registry.py
+++ b/python/Ganga/Core/GangaRepository/Registry.py
@@ -997,9 +997,17 @@ class Registry(object):
                 s += ", %i other concurrent sessions:\n * %s" % (len(other_sessions), "\n * ".join(other_sessions))
         return s
 
+    def other_session_active(self):
+        """ Returns a True/False for if other sessions have been detected from the Repository """
+        if self.repository.get_other_sessions():
+            return True
+        else:
+            return False
+
     def print_other_sessions(self):
-        other_sessions = self.repository.get_other_sessions()
-        if len(other_sessions) > 0:
+        """ Prints a warning if other active sessions have been detected """
+        if self.other_session_active():
+            other_sessions = self.repository.get_other_sessions()
             logger.warning("%i other concurrent sessions:\n * %s" % (len(other_sessions), "\n * ".join(other_sessions)))
 
     def has_loaded(self, obj):

--- a/python/Ganga/Core/GangaRepository/SessionLock.py
+++ b/python/Ganga/Core/GangaRepository/SessionLock.py
@@ -43,7 +43,7 @@ except ConfigError, err:
 
 session_lock_refresher = None
 
-def getGlobalLockRef(session_name, sdir, gfn, _on_afs):
+def setupGlobalLockRef(session_name, sdir, gfn, _on_afs):
     global session_lock_refresher
     if session_lock_refresher is None:
         try:
@@ -404,9 +404,9 @@ class SessionLockManager(object):
                 logger.debug("Startup Session Exception: %s" % err)
                 raise RepositoryError(self.repo, "Error on session file '%s' creation: %s" % (self.fn, err))
 
-            local_session_lock_refresher = getGlobalLockRef(self.session_name, self.sdir, self.gfn, self.afs)
+            setupGlobalLockRef(self.session_name, self.sdir, self.gfn, self.afs)
 
-            local_session_lock_refresher.addRepo(self.fn, self.repo)
+            session_lock_refresher.addRepo(self.fn, self.repo)
             self.session_write()
         finally:
             self.global_lock_release()

--- a/python/Ganga/Core/GangaRepository/SessionLock.py
+++ b/python/Ganga/Core/GangaRepository/SessionLock.py
@@ -422,8 +422,7 @@ class SessionLockManager(object):
         self.locked = set()
         try:
             global session_lock_refresher
-            if session_lock_refresher and not session_lock_refresher.should_stop():
-                session_lock_refresher.stop()
+            session_lock_refresher.stop()
             if session_lock_refresher is not None:
                 # try:
                 session_lock_refresher.removeRepo(self.fn, self.repo)

--- a/python/Ganga/Core/GangaRepository/SessionLock.py
+++ b/python/Ganga/Core/GangaRepository/SessionLock.py
@@ -28,28 +28,8 @@ from Ganga.Utility.logging import getLogger
 from Ganga.Utility.Config.Config import getConfig, ConfigError
 from Ganga.GPIDev.Base.Proxy import getName
 
-try:
-    from Ganga.Core.GangaThread import GangaThread
-    from Ganga.Core.GangaRepository import RepositoryError
-except ImportError:
-    from threading import Thread
-
-    print("IMPORT ERROR SHOULD NOT OCCUR IN PRODUCTION CODE!!!!!!!!!!!!!!!!!!!!!!")
-    
-
-    class GangaThread(Thread):
-    
-        def __init__(self, name):
-            self.name = name
-            super(GangaThread, self).__init__()
-
-        def should_stop(self):
-            return False
-
-
-    class RepositoryError(Exception):
-        pass
-
+from Ganga.Core.GangaThread import GangaThread
+from Ganga.Core.GangaRepository import RepositoryError
 
 logger = getLogger()
 

--- a/python/Ganga/Core/InternalServices/ShutdownManager.py
+++ b/python/Ganga/Core/InternalServices/ShutdownManager.py
@@ -57,10 +57,6 @@ def _ganga_run_exitfuncs():
 
     from Ganga.GPIDev.Base.Proxy import getName
 
-    #print("Shutting Down Ganga Repositories")
-    from Ganga.Runtime import Repository_runtime
-    Repository_runtime.flush_all()
-
     from Ganga.Utility.logging import getLogger
     logger = getLogger()
 

--- a/python/Ganga/Runtime/Repository_runtime.py
+++ b/python/Ganga/Runtime/Repository_runtime.py
@@ -134,9 +134,11 @@ def bootstrap():
         registry.startup()
         logger.debug("started " + registry.info(full=False))
         if registry.name == "prep":
-            registry.print_other_sessions()
+            # Get a list of strings describing other running sessions
+            other_sessions = registry.get_other_sessions()
 
-            if registry.other_session_active():
+            if other_sessions:
+                logger.warning("%i other concurrent sessions:\n * %s" % (len(other_sessions), "\n * ".join(other_sessions)))
                 logger.warning("Multiple Ganga sessions detected. The Monitoring Thread is being disabled.")
                 logger.warning("Type 'enableMonitoring' to restart")
                 setConfigOption('PollThread', 'autostart', False)

--- a/python/Ganga/Runtime/Repository_runtime.py
+++ b/python/Ganga/Runtime/Repository_runtime.py
@@ -133,23 +133,21 @@ def bootstrap():
         logger.debug("Loc: %s" % registry.location)
         registry.startup()
         logger.debug("started " + registry.info(full=False))
-        if registry.name == "prep":
-            # Get a list of strings describing other running sessions
-            other_sessions = registry.get_other_sessions()
-
-            if other_sessions:
-                logger.warning("%i other concurrent sessions:\n * %s" % (len(other_sessions), "\n * ".join(other_sessions)))
-                logger.warning("Multiple Ganga sessions detected. The Monitoring Thread is being disabled.")
-                logger.warning("Type 'enableMonitoring' to restart")
-                setConfigOption('PollThread', 'autostart', False)
 
         started_registries.append(registry.name)
         proxied_registry_slice = registry.getProxy()
         retval.append((registry.name, proxied_registry_slice, registry.doc))
 
-    #import atexit
-    #atexit.register(shutdown)
-    #logger.debug("Registries: %s" % started_registries)
+    # Assuming all registries are started for all instances of Ganga atm
+    # Avoid ever, ever, calling the repository from behind the registry. This allows for all forms of bad behaviour.
+    other_sessions = bootstrap_getreg()[0].repository.get_other_sessions()
+    if other_sessions:
+        # Just print this from 1 repo only so chose the zeorth, nothing special
+        logger.warning("%i other concurrent sessions:\n * %s" % (len(other_sessions), "\n * ".join(other_sessions)))
+        logger.warning("Multiple Ganga sessions detected. The Monitoring Thread is being disabled.")
+        logger.warning("Type 'enableMonitoring' to restart")
+        setConfigOption('PollThread', 'autostart', False)
+
     return retval
 
 

--- a/python/Ganga/Runtime/Repository_runtime.py
+++ b/python/Ganga/Runtime/Repository_runtime.py
@@ -139,7 +139,9 @@ def bootstrap():
         retval.append((registry.name, proxied_registry_slice, registry.doc))
 
     # Assuming all registries are started for all instances of Ganga atm
-    # Avoid ever, ever, calling the repository from behind the registry. This allows for all forms of bad behaviour.
+    # Avoid ever, ever, calling the repository from behind the registry. This allows for all forms of bad behaviour
+    # This is a form of trade off but still is something which should be strongly discouraged!
+    # TODO investigate putting access to the repository behind a getter/setter which keeps the registry locked
     other_sessions = bootstrap_getreg()[0].repository.get_other_sessions()
     if other_sessions:
         # Just print this from 1 repo only so chose the zeorth, nothing special

--- a/python/Ganga/Runtime/Repository_runtime.py
+++ b/python/Ganga/Runtime/Repository_runtime.py
@@ -2,7 +2,7 @@
 Internal initialization of the repositories.
 """
 
-import Ganga.Utility.Config
+from Ganga.Utility.Config import getConfig, setConfigOption
 from Ganga.Utility.logging import getLogger
 import os.path
 from Ganga.Utility.files import expandfilename, fullpath
@@ -10,7 +10,7 @@ from Ganga.Core.GangaRepository import getRegistries
 from Ganga.Core.GangaRepository import getRegistry
 from Ganga.Core.exceptions import GangaException
 
-config = Ganga.Utility.Config.getConfig('Configuration')
+config = getConfig('Configuration')
 logger = getLogger()
 
 _runtime_interface = None
@@ -135,6 +135,12 @@ def bootstrap():
         logger.debug("started " + registry.info(full=False))
         if registry.name == "prep":
             registry.print_other_sessions()
+
+            if registry.other_session_active():
+                logger.warning("Multiple Ganga sessions detected. The Monitoring Thread is being disabled.")
+                logger.warning("Type 'enableMonitoring' to restart")
+                setConfigOption('PollThread', 'autostart', False)
+
         started_registries.append(registry.name)
         proxied_registry_slice = registry.getProxy()
         retval.append((registry.name, proxied_registry_slice, registry.doc))

--- a/python/Ganga/Runtime/Repository_runtime.py
+++ b/python/Ganga/Runtime/Repository_runtime.py
@@ -169,6 +169,10 @@ def shutdown():
     logger.info('Registry Shutdown')
     #import traceback
     #traceback.print_stack()
+
+    # Flush all repos before we shut them down
+    flush_all()
+
     # shutting down the prep registry (i.e. shareref table) first is necessary to allow the closedown()
     # method to perform actions on the box and/or job registries.
     logger.debug(started_registries)

--- a/python/GangaDirac/Lib/Files/DiracFile.py
+++ b/python/GangaDirac/Lib/Files/DiracFile.py
@@ -85,10 +85,7 @@ class DiracFile(IGangaFile):
         super(DiracFile, self).__init__()
         self.locations = []
 
-        if len(namePattern) >= 4 and str(namePattern).upper()[0:4] == "LFN:" and lfn == '':
-            self._setLFNnamePattern(_lfn=namePattern[4:], _namePattern='')
-
-        self._setLFNnamePattern(_lfn=lfn, _namePattern = namePattern)
+        self._setLFNnamePattern(lfn, namePattern)
 
         if localDir is not None:
             self.localDir = expandfilename(localDir)
@@ -116,21 +113,21 @@ class DiracFile(IGangaFile):
         # LFN ONLY
         if len(args) == 1 and type(args[0]) == type(''):
             if str(str(args[0]).upper()[0:4]) == str("LFN:"):
-                self._setLFNnamePattern(_lfn=args[0][4:], _namePattern="")
+                self._setLFNnamePattern(lfn=args[0][4:], namePattern="")
             else:
-                self._setLFNnamePattern(_lfn="", _namePattern=args[0])
+                self._setLFNnamePattern(lfn="", namePattern=args[0])
 
         # NAMEPATTERN AND LFN
         elif len(args) == 2 and type(args[0]) == type('') and type(args[1]) == type(''):
             self.namePattern = args[0]
-            self._setLFNnamePattern(_lfn='', _namePattern=self.namePattern)
+            self._setLFNnamePattern(lfn='', namePattern=self.namePattern)
             self.localDir = expandfilename(args[1])
 
         # NAMEPATTERN AND LFN AND LOCALDIR
         elif len(args) == 3 and type(args[0]) == type('') and type(args[1]) == type('') and type(args[2]) == type(''):
             self.namePattern = args[0]
             self.lfn = args[2]
-            self._setLFNnamePattern(_lfn=self.lfn, _namePattern=self.namePattern)
+            self._setLFNnamePattern(lfn=self.lfn, namePattern=self.namePattern)
             self.localDir = expandfilename(args[1])
 
         # NAMEPATTERN AND LFN AND LOCALDIR AND REMOTEDIR
@@ -138,7 +135,7 @@ class DiracFile(IGangaFile):
                 and type(args[2]) == type('') and type(args[3]) == type(''):
             self.namePattern = args[0]
             self.lfn = args[2]
-            self._setLFNnamePattern(_lfn=lfn, _namePattern=namePattern)
+            self._setLFNnamePattern(lfn=lfn, namePattern=namePattern)
             self.localDir = expandfilename(args[1])
             self.remoteDir = args[3]
 
@@ -191,37 +188,37 @@ class DiracFile(IGangaFile):
 
         return self.locations
 
-    def _setLFNnamePattern(self, _lfn="", _namePattern=""):
+    def _setLFNnamePattern(self, lfn="", namePattern=""):
 
-        ## TODO REPLACE THIS WITH IN LIST OF VONAMES KNOWN
-        # Check for /lhcb/some/path or /gridpp/some/path
-        if _namePattern.split(os.pathsep)[0] == self.defaultSE \
-            or (len(_lfn) > 3 and _lfn[0:4] == "LFN:" and len(_namePattern.split(os.pathsep)) >= 1\
-                    and _namePattern.split(os.pathsep)[1] == self.defaultSE):
-            # Check for LFN:/gridpp/some/path or others...
-            temp = _lfn
-            _lfn = _namePattern
-            _namePattern = temp
+        if self.defaultSE != "":
+            ## TODO REPLACE THIS WITH IN LIST OF VONAMES KNOWN
+            # Check for /lhcb/some/path or /gridpp/some/path
+            if namePattern.split(os.pathsep)[0] == self.defaultSE \
+                or (len(namePattern) > 3 and namePattern[0:4].upper() == "LFN:"\
+                    or len(namePattern.split(os.pathsep)) > 1 and namePattern.split(os.pathsep)[1] == self.defaultSE):
+                # Check for LFN:/gridpp/some/path or others...
+                lfn = namePattern
+                namePattern = ""
 
-        if _lfn != "" and _lfn is not None:
-            if len(_lfn) > 3 and _lfn[0:4] == "LFN:":
-                _lfn = _lfn[4:]
+        if lfn:
+            if len(lfn) > 3 and lfn[0:4].upper() == "LFN:":
+                lfn = lfn[4:]
 
-        if _lfn != "" and _namePattern != "":
-            self.lfn = _lfn
-            self.remoteDir = os.path.dirname(_lfn)
-            self.namePattern = os.path.basename(_namePattern)
-            self.localDir = os.path.dirname(expandfilename(_namePattern))
+        if lfn != "" and namePattern != "":
+            self.lfn = lfn
+            self.remoteDir = os.path.dirname(lfn)
+            self.namePattern = os.path.basename(namePattern)
+            self.localDir = os.path.dirname(expandfilename(namePattern))
 
-        elif _lfn != "" and _namePattern == "":
-            self.lfn = _lfn
+        elif lfn != "" and namePattern == "":
+            self.lfn = lfn
             self.remoteDir = os.path.dirname(self.lfn)
             self.namePattern = os.path.basename(self.lfn)
             self.localDir = ""
 
-        elif _namePattern != "" and _lfn == "":
-            self.namePattern = os.path.basename(_namePattern)
-            self.localDir = os.path.dirname(expandfilename(_namePattern))
+        elif namePattern != "" and lfn == "":
+            self.namePattern = os.path.basename(namePattern)
+            self.localDir = os.path.dirname(expandfilename(namePattern))
             self.remoteDir = ""
             self.lfn = ""
 

--- a/python/GangaLHCb/test/GPI/TestDataFiles.py
+++ b/python/GangaLHCb/test/GPI/TestDataFiles.py
@@ -6,7 +6,6 @@ from Ganga.testlib.GangaUnitTest import GangaUnitTest
 
 class TestDataFiles(GangaUnitTest):
 
-    @external
     def testDataFiles(self):
 
         from Ganga.GPI import DiracFile, config
@@ -25,6 +24,8 @@ class TestDataFiles(GangaUnitTest):
         lfn = DiracFile('pfn:'+name)
 
 
+    @external
+    def testDataFilesExternal(self):
         # Methods
         lfn = DiracFile(lfn='/lhcb/data/2010/DIMUON.DST/00008395/0000/00008395_00000326_1.dimuon.dst')
         assert lfn.getReplicas()


### PR DESCRIPTION
This PR turns off the monitoring loop when other another Ganga session is found to be running on a repo.
This should be possible to override by typing ```enableMonitoring``` from the interactive prompt if the monitoring loop is expected to run no matter what.

I've also included some code cleanup I have against ```SessionLock``` as well as a synchronize method against the GangaThread as I've seen threads change running state whilst running based upon the input from other threads so I thought it best just to keep each thread consistent even if this should rarely happen.

Fixes #236