### PR TITLE
Simplify default object lookup

### DIFF
--- a/python/Ganga/GPIDev/Schema/Schema.py
+++ b/python/Ganga/GPIDev/Schema/Schema.py
@@ -307,7 +307,7 @@ class Schema(object):
             from Ganga.GPIDev.Base.Proxy import isType, getRuntimeGPIObject, stripProxy, getName
             from Ganga.GPIDev.Base.Objects import Node
             if isinstance(defvalue, Node):
-                return stripProxy(getRuntimeGPIObject(getName(defvalue)))
+                return allPlugins.find(item['category'], getName(defvalue))()
             else:
                 return copy.deepcopy(defvalue)
         except ImportError:

--- a/python/Ganga/GPIDev/Schema/Schema.py
+++ b/python/Ganga/GPIDev/Schema/Schema.py
@@ -303,15 +303,7 @@ class Schema(object):
 
         # make a copy of the default value (to avoid strange effects if the
         # original modified)
-        try:
-            from Ganga.GPIDev.Base.Proxy import isType, getRuntimeGPIObject, stripProxy, getName
-            from Ganga.GPIDev.Base.Objects import Node
-            if isinstance(defvalue, Node):
-                return allPlugins.find(item['category'], getName(defvalue))()
-            else:
-                return copy.deepcopy(defvalue)
-        except ImportError:
-            return copy.deepcopy(defvalue)
+        return copy.deepcopy(defvalue)
 
 
 # Items in schema may be either Components,Simples, Files or BindingItems.


### PR DESCRIPTION
When getting the default value of a schema item, rather than relying on the GPI being populated and then having to strip the proxy from the result, instead search in the plugin system for the requested class object.