### PR TITLE
Small DIRAC tidy

### DIFF
--- a/python/GangaDirac/Lib/Files/DiracFile.py
+++ b/python/GangaDirac/Lib/Files/DiracFile.py
@@ -629,24 +629,20 @@ class DiracFile(IGangaFile):
         logger.error("Error in getting file '%s' : %s" % (self.lfn, str(stdout)))
         return stdout
 
-    def replicate(self, destSE):
+    def replicate(self, destSE, sourceSE=''):
         """
-        Replicate this file from self.locations[0] to destSE
+        Replicate an LFN to another SE
 
-        If self.locations is empty, let DIRAC work it out.
+        Args:
+            destSE (str): the SE to replicate the file to
+            sourceSE (str): the se to use as a cource for the file
         """
 
         if not self.lfn:
-            if not self.locations:
-                raise GangaException('Can\'t replicate a file if it isn\'t already on a DIRAC SE, upload it first')
-            else:
-                raise GangaException('Must supply an lfn to replicate')
+            raise GangaException('Must supply an lfn to replicate')
 
         logger.info("Replicating file %s to %s" % (self.lfn, destSE))
-        if self.locations:
-            stdout = execute('replicateFile("%s", "%s", "%s")' % (self.lfn, destSE, self.locations[0]))
-        else:
-            stdout = execute('replicateFile("%s", "%s")' % (self.lfn, destSE))
+        stdout = execute('replicateFile("%s", "%s", "%s")' % (self.lfn, destSE, sourceSE))
         if isinstance(stdout, dict) and stdout.get('OK', False) and self.lfn in stdout.get('Value', {'Successful': {}})['Successful']:
             self.locations.append(destSE)
             return

--- a/python/GangaDirac/Lib/Files/__init__.py
+++ b/python/GangaDirac/Lib/Files/__init__.py
@@ -1,1 +1,0 @@
-from DiracFile import DiracFile

--- a/python/GangaDirac/Lib/Server/DiracCommands.py
+++ b/python/GangaDirac/Lib/Server/DiracCommands.py
@@ -63,7 +63,7 @@ def getFile(lfns, destDir=''):
     output(dirac.getFile(lfns, destDir=destDir))
 
 
-def replicateFile(lfn, destSE, srcSE, locCache=''):
+def replicateFile(lfn, destSE, srcSE='', locCache=''):
     ''' Replicate a given LFN from a srcSE to a destSE'''
     res = dirac.replicateFile(lfn, destSE, srcSE, locCache)
     output(res)

--- a/python/GangaDirac/Lib/Splitters/SplitterUtils.py
+++ b/python/GangaDirac/Lib/Splitters/SplitterUtils.py
@@ -3,7 +3,7 @@ from Ganga.GPIDev.Adapters.ISplitter import SplittingError
 from GangaDirac.Lib.Utilities.DiracUtilities import execute
 from GangaDirac.Lib.Backends.DiracUtils import result_ok
 from Ganga.Utility.Config import getConfig
-from GangaDirac.Lib.Files import DiracFile
+from GangaDirac.Lib.Files.DiracFile import DiracFile
 from Ganga.Utility.logging import getLogger
 logger = getLogger()
 

--- a/python/GangaDirac/Lib/Utilities/DiracUtilities.py
+++ b/python/GangaDirac/Lib/Utilities/DiracUtilities.py
@@ -191,7 +191,7 @@ def execute(command,
     
     Args:
         command (str): This is the command we're running within our DIRAC session
-        timeout (bool): This is the length of time that a DIRAC call has before it's decided some interaction has timed out
+        timeout (int): This is the length of time that a DIRAC call has before it's decided some interaction has timed out
         env (dict): an optional environment to execute the DIRAC code in
         cwd (str): an optional string to a valid path where this code should be executed
         shell (bool): Should this code be executed in a new shell environment

--- a/python/GangaLHCb/Lib/RTHandlers/LHCbRootDiracRunTimeHandler.py
+++ b/python/GangaLHCb/Lib/RTHandlers/LHCbRootDiracRunTimeHandler.py
@@ -13,7 +13,7 @@ from Ganga.Core.exceptions import ApplicationConfigurationError
 from Ganga.Utility.Config import getConfig
 from Ganga.Utility.logging import getLogger
 from Ganga.GPIDev.Base.Proxy import isType
-from GangaDirac.Lib.Files import DiracFile
+from GangaDirac.Lib.Files.DiracFile import DiracFile
 logger = getLogger()
 
 #\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\#

--- a/python/GangaLSST/Lib/Im3ShapeApp/Im3ShapeApp.py
+++ b/python/GangaLSST/Lib/Im3ShapeApp/Im3ShapeApp.py
@@ -20,7 +20,7 @@ import os
 import shutil
 from Ganga.Utility.files import expandfilename
 
-from GangaDirac.Lib.Files import DiracFile
+from GangaDirac.Lib.Files.DiracFile import DiracFile
 from Ganga.GPIDev.Lib.File import LocalFile
 
 logger = getLogger()


### PR DESCRIPTION
These are some change I've made in order to get the legacy DIRAC tests ported over (PR incoming soon). The changes to the imports are needed in order to correctly mock the `execute` function. 

The removal of the call to `getReplicas()` was done since the mock system was flagging that `execute` was being called multiple times for a single call to `replicate()`. It seems like the calls were added in order to be able to call `replicate()` even if `locations` was not set (by requesting the current replica SEs from DIRAC). The change was made in ecbb34b71bf14247205d9a8f81844e73939bd979 but the commit message doesn't help with working out the exact reason. In fact it doesn't matter too much since it's possible to call DIRAC's [`replicateFile()`](http://diracgrid.org/files/docs/CodeDocumentation/Interfaces/API/Dirac.html#DIRAC.Interfaces.API.Dirac.Dirac.replicateFile) without a source SE anyway (since at least 2008).