### PR TITLE
Cleanup atexit handling

### DIFF
--- a/python/Ganga/Core/InternalServices/ShutdownManager.py
+++ b/python/Ganga/Core/InternalServices/ShutdownManager.py
@@ -38,6 +38,7 @@ Extend the behaviour of the default *atexit* module to support:
   registers the function with the lowest priority (sys.maxint)
 """
 
+# System imports
 import atexit
 
 from Ganga.Utility import stacktracer
@@ -174,16 +175,3 @@ def _ganga_run_exitfuncs():
     from Ganga.Runtime import bootstrap
     if bootstrap.DEBUGFILES or bootstrap.MONITOR_FILES:
         bootstrap.printOpenFiles()
-
-
-def install():
-    """
-    Install a new shutdown manager, by overriding methods from atexit module
-    """
-    # override the atexit exit function
-    atexit._run_exitfuncs = _ganga_run_exitfuncs
-    #del atexit
-
-    # override the default exit function
-    import sys
-    sys.exitfunc = atexit._run_exitfuncs

--- a/python/Ganga/Core/InternalServices/ShutdownManager.py
+++ b/python/Ganga/Core/InternalServices/ShutdownManager.py
@@ -125,7 +125,6 @@ def _ganga_run_exitfuncs():
 
     import inspect
     while atexit._exithandlers:
-
         (priority, func), targs, kargs = atexit._exithandlers.pop()
         try:
             if hasattr(func, 'im_class'):
@@ -188,11 +187,3 @@ def install():
     # override the default exit function
     import sys
     sys.exitfunc = atexit._run_exitfuncs
-
-#
-#$Log: not supported by cvs2svn $
-# Revision 1.2  2007/07/27 14:31:56  moscicki
-# credential and clean shutdown updates from Adrian (from Ganga-4-4-0-dev-branch)
-#
-# Revision 1.1.2.2  2007/07/27 13:03:17  amuraru
-#*** empty log message ***

--- a/python/Ganga/Core/InternalServices/ShutdownManager.py
+++ b/python/Ganga/Core/InternalServices/ShutdownManager.py
@@ -58,6 +58,11 @@ def _ganga_run_exitfuncs():
 
     from Ganga.GPIDev.Base.Proxy import getName
 
+    # shutdown the threads in the GangaThreadPool
+    from Ganga.Core.GangaThread import GangaThreadPool
+    from Ganga.Core import at_exit_should_wait_cb
+    GangaThreadPool.getInstance().shutdown(should_wait_cb=at_exit_should_wait_cb)
+
     #print("Shutting Down Ganga Repositories")
     from Ganga.Runtime import Repository_runtime
     Repository_runtime.flush_all()

--- a/python/Ganga/Core/__init__.py
+++ b/python/Ganga/Core/__init__.py
@@ -169,16 +169,7 @@ def change_atexitPolicy(interactive_session=True, new_policy=None):
                 should_wait_cb = should_wait_batch_cb
 
     global at_exit_should_wait_cb
-    if at_exit_should_wait_cb is None:
-        at_exit_should_wait_cb = should_wait_cb
-        import atexit
-        from Ganga.Core.GangaThread import GangaThreadPool
-        # create generic Ganga thread pool
-        thread_pool = GangaThreadPool.getInstance()
-        atexit.register(thread_pool.shutdown, should_wait_cb=at_exit_should_wait_cb)
-    else:
-        at_exit_should_wait_cb = should_wait_cb
-
+    at_exit_should_wait_cb = should_wait_cb
 
     global current_shutdown_policy
     current_shutdown_policy = forced_shutdown_policy

--- a/python/Ganga/GPIDev/Base/Objects.py
+++ b/python/Ganga/GPIDev/Base/Objects.py
@@ -860,7 +860,7 @@ class GangaObject(Node):
         """
         true_parent = self._getParent()
         ## This triggers a read of the job from disk
-        #self._getReadAccess()
+        self._getReadAccess()
         cls = self.__class__
 
         self_copy = cls()

--- a/python/Ganga/GPIDev/Base/Objects.py
+++ b/python/Ganga/GPIDev/Base/Objects.py
@@ -433,6 +433,9 @@ class Descriptor(object):
         else:
             val = temp_val
 
+        # LOCKING
+        obj._getWriteAccess()
+
         item = obj._schema[_getName(self)]
 
         def cloneVal(v):
@@ -856,6 +859,8 @@ class GangaObject(Node):
         Perform a deep copy of the GangaObject class
         """
         true_parent = self._getParent()
+        ## This triggers a read of the job from disk
+        #self._getReadAccess()
         cls = self.__class__
 
         self_copy = cls()

--- a/python/Ganga/GPIDev/Base/Objects.py
+++ b/python/Ganga/GPIDev/Base/Objects.py
@@ -856,8 +856,6 @@ class GangaObject(Node):
         Perform a deep copy of the GangaObject class
         """
         true_parent = self._getParent()
-        ## This triggers a read of the job from disk
-        self._getReadAccess()
         cls = self.__class__
 
         self_copy = cls()

--- a/python/Ganga/GPIDev/Base/Objects.py
+++ b/python/Ganga/GPIDev/Base/Objects.py
@@ -859,8 +859,6 @@ class GangaObject(Node):
         Perform a deep copy of the GangaObject class
         """
         true_parent = self._getParent()
-        ## This triggers a read of the job from disk
-        self._getReadAccess()
         cls = self.__class__
 
         self_copy = cls()

--- a/python/Ganga/GPIDev/Base/Objects.py
+++ b/python/Ganga/GPIDev/Base/Objects.py
@@ -433,9 +433,6 @@ class Descriptor(object):
         else:
             val = temp_val
 
-        # LOCKING
-        obj._getWriteAccess()
-
         item = obj._schema[_getName(self)]
 
         def cloneVal(v):

--- a/python/Ganga/Runtime/bootstrap.py
+++ b/python/Ganga/Runtime/bootstrap.py
@@ -836,7 +836,7 @@ under certain conditions; type license() for details.
 
         logger.debug("Installing Shutdown Manager")
         import atexit
-        from Ganga.Core.InternalServices import _ganga_run_exitfuncs
+        from Ganga.Core.InternalServices.ShutdownManager import _ganga_run_exitfuncs
         atexit.register(_ganga_run_exitfuncs)
 
         import Ganga.Utility.Config

--- a/python/Ganga/Runtime/bootstrap.py
+++ b/python/Ganga/Runtime/bootstrap.py
@@ -835,8 +835,9 @@ under certain conditions; type license() for details.
         logger = getLogger()
 
         logger.debug("Installing Shutdown Manager")
-        from Ganga.Core.InternalServices import ShutdownManager
-        ShutdownManager.install()
+        import atexit
+        from Ganga.Core.InternalServices import _ganga_run_exitfuncs
+        atexit.register(_ganga_run_exitfuncs)
 
         import Ganga.Utility.Config
         from Ganga.Utility.Runtime import RuntimePackage, allRuntimes

--- a/python/Ganga/test/GPI/Parallel/TestQueuedSJSubmit.py
+++ b/python/Ganga/test/GPI/Parallel/TestQueuedSJSubmit.py
@@ -12,7 +12,6 @@ global_num_threads = 5
 global_num_jobs = global_num_threads*5
 
 
-@nocoverage
 @add_config([('TestingFramework', 'AutoCleanup', False),
              ('Queues', 'NumWorkerThreads', global_num_threads)])
 @pytest.mark.usefixtures('gpi')

--- a/python/Ganga/test/GPI/Parallel/TestQueuedSJSubmit.py
+++ b/python/Ganga/test/GPI/Parallel/TestQueuedSJSubmit.py
@@ -4,6 +4,7 @@ import time
 
 import pytest
 
+from Ganga.testlib.mark import nocoverage
 from Ganga.testlib.decorators import add_config
 from Ganga.testlib.monitoring import run_until_completed
 
@@ -11,6 +12,7 @@ global_num_threads = 5
 global_num_jobs = global_num_threads*5
 
 
+@nocoverage
 @add_config([('TestingFramework', 'AutoCleanup', False),
              ('Queues', 'NumWorkerThreads', global_num_threads)])
 @pytest.mark.usefixtures('gpi')

--- a/python/Ganga/test/GPI/Parallel/TestQueuedSubmit.py
+++ b/python/Ganga/test/GPI/Parallel/TestQueuedSubmit.py
@@ -4,6 +4,7 @@ import time
 
 import pytest
 
+from Ganga.testlib.mark import nocoverage
 from Ganga.testlib.decorators import add_config
 from Ganga.testlib.monitoring import run_until_completed
 
@@ -11,6 +12,7 @@ global_num_threads = 10
 global_num_jobs = global_num_threads*5
 
 
+@nocoverage
 @add_config([('TestingFramework', 'AutoCleanup', False),
              ('Queues', 'NumWorkerThreads', global_num_threads)])
 @pytest.mark.usefixtures('gpi')

--- a/python/Ganga/test/GPI/Parallel/TestQueuedSubmit.py
+++ b/python/Ganga/test/GPI/Parallel/TestQueuedSubmit.py
@@ -12,7 +12,6 @@ global_num_threads = 10
 global_num_jobs = global_num_threads*5
 
 
-@nocoverage
 @add_config([('TestingFramework', 'AutoCleanup', False),
              ('Queues', 'NumWorkerThreads', global_num_threads)])
 @pytest.mark.usefixtures('gpi')

--- a/python/Ganga/testlib/mark.py
+++ b/python/Ganga/testlib/mark.py
@@ -1,6 +1,20 @@
+"""A set of useful decorators for testing"""
+
+# System imports
 import pytest
 
 external = pytest.mark.skipif(
     not pytest.config.getoption("--runexternals"),
     reason="need --runexternals option to run external tests"
 )
+"""decorator: Marks the test as depending on external services"""
+
+nocoverage = pytest.mark.skipif(
+    pytest.config.getoption("--cov"),
+    reason="exclude this test if running with coverage"
+)
+"""decorator: Excludes this test if running with coverage
+
+Some tests (generally the thread based ones) hang when run with coverage. If marked, they will be disabled when running
+with coverage switched on.
+"""

--- a/python/ganga/__init__.py
+++ b/python/ganga/__init__.py
@@ -1,10 +1,13 @@
 # Bootstrap all of ganga, setup GPI, registries, etc.
+import atexit
+
 from Ganga.Utility.Runtime import allRuntimes
 from Ganga.Utility.Config import getConfig
 from Ganga.Utility.logging import getLogger
 from Ganga import _gangaPythonPath
 import Ganga.Core
 from Ganga.Core.GangaRepository import getRegistry
+from Ganga.Core.InternalServices.ShutdownManager import _ganga_run_exitfuncs
 
 logger = getLogger(modulename=True)
 
@@ -17,8 +20,7 @@ def ganga_license():
 
 # ------------------------------------------------------------------------------------
 # Setup the shutdown manager
-from Ganga.Core.InternalServices import ShutdownManager
-ShutdownManager.install()
+atexit.register(_ganga_run_exitfuncs)
 
 ## TODO need to implement loading of the config system properly here.
 ## loadPlugins and autoPopulateGPI will take this into account when loading objects


### PR DESCRIPTION
This removes the messing about with atexit that was done and switches to just a single atexit handler (`_ganga_run_exitfuncs`) that shuts everything down in an order we control. This is registered in `bootstrap` as a normal atexit handler.

I believe the original code was put so plugins could at their own atexit handlers and then Ganga would shut them down but this was essentially just doing our own version of atexit. After @rob-c 's work, this also became almost entirely obsolete as the Ganga services were getting shutdown by hand anyway. One of the major problems of this original code was that it was shutting down the coverage after the first test, thus our coverage reporting was **very** wrong!

The only downside with this change is that running with coverage now adds ~50% to the time of the tests (assuming the CTracer is used) so I have also changed the PR Builder on the Jenkins box to not do the coverage and kept this for the nightlies.