### PR TITLE
Removed proxy_delegation which was C+P error from CREAM

### DIFF
--- a/python/Ganga/Lib/LCG/ARC.py
+++ b/python/Ganga/Lib/LCG/ARC.py
@@ -1109,10 +1109,6 @@ sys.exit(0)
 
         ick = False
 
-        # delegate proxy to ARC CE
-        if not grids['GLITE'].arc_proxy_delegation(self.CE):
-            logger.warning('proxy delegation to %s failed' % self.CE)
-
         if not job.master and len(job.subjobs) == 0:
             # case 1: master job normal resubmission
             logger.debug('rjobs: %s' % str(rjobs))


### PR DESCRIPTION
There was some old proxy delegation code from the initial copy+paste job from CREAM backend that stopped the resubmission mechanism. This removes this and fixes #50 