### PR TITLE
Don't add the new SE to locations if it's already present

### DIFF
--- a/python/GangaDirac/Lib/Files/DiracFile.py
+++ b/python/GangaDirac/Lib/Files/DiracFile.py
@@ -644,7 +644,8 @@ class DiracFile(IGangaFile):
         logger.info("Replicating file %s to %s" % (self.lfn, destSE))
         stdout = execute('replicateFile("%s", "%s", "%s")' % (self.lfn, destSE, sourceSE))
         if isinstance(stdout, dict) and stdout.get('OK', False) and self.lfn in stdout.get('Value', {'Successful': {}})['Successful']:
-            self.locations.append(destSE)
+            if destSE not in self.locations:
+                self.locations.append(destSE)
             return
         logger.error("Error in replicating file '%s' : %s" % (self.lfn, stdout))
         return stdout


### PR DESCRIPTION
As an addendum to #509, this makes sure that the replicated SE is not added to `locations` if it's already there.