### PR TITLE
Read the env file directly

### DIFF
--- a/python/GangaDirac/Lib/Utilities/DiracUtilities.py
+++ b/python/GangaDirac/Lib/Utilities/DiracUtilities.py
@@ -49,9 +49,12 @@ def getDiracEnv(force=False):
             if getConfig('DIRAC')['DiracEnvFile'] != "" and os.path.exists(absolute_path):
 
                 env_dict = {}
-                execute('source {0}'.format(absolute_path), shell=True, env=env_dict, update_env=True)
+                with open(absolute_path) as env_file:
+                    for line in env_file:
+                        varval = line.strip().split('=')
+                        env_dict[varval[0]] = ''.join(varval[1:])
 
-                if env_dict is not None:
+                if env_dict:
                     DIRAC_ENV = env_dict
                 else:
                     logger.error("Error determining DIRAC environment")


### PR DESCRIPTION
It turns out there was an issue with how I was reading the env file for LHCb. In my Dirac config I was was using the Dirac `bashrc` file which is `source`able but the LHCb DIRAC environment that we cache is not sourceable. This PR fixes it so that our DIRAC code can read both DIRAC `envfile`-style files as well as our LHCb DIRAC cache.

It also avoids having to load a full shell and an external Python interpreter along with a few threads, just read the environment. This is what is being done in `ganga-proxy.py` anyway.