### PR TITLE
Make the LHCbDIRAC env file cleanly sourceable

### DIFF
--- a/python/GangaLHCb/__init__.py
+++ b/python/GangaLHCb/__init__.py
@@ -117,6 +117,19 @@ def _store_dirac_environment():
         if count == 0:
             msg = 'Tried to setup Dirac version %s. For some reason this did not setup the DIRAC environment.' % diracversion
             raise OptionValueError(msg)
+            
+        # Now manipulate the file to make it cleanly sourceable
+        os.rename(fname, fname+'_tmp')
+        with open(fname+'_tmp') as env_file:
+            with open(fname, 'w') as new_env_file:
+                for line in env_file:
+                    line = line.strip()
+                    line = 'export ' + line
+                    line = line.replace('=', '="', 1)
+                    line += '"\n'
+                    new_env_file.write(line)
+        os.remove(fname+'_tmp')
+            
     os.environ['GANGADIRACENVIRONMENT'] = fname
 
 if not _after_bootstrap:


### PR DESCRIPTION
Make sure that each line is `export`ed and quoted correctly.

This turns a file like
```bash
Urania_release_area=/cvmfs/lhcb.cern.ch/lib/lhcb
GANGA_NEVER_REEXEC=1
GREP_COLOR=37;45
XDG_VTNR=1
LCG_GFAL_VO=lhcb
CMTDEB=x86_64-slc6-gcc49-dbg
```
into
```bash
export Urania_release_area="/cvmfs/lhcb.cern.ch/lib/lhcb"
export GANGA_NEVER_REEXEC="1"
export GREP_COLOR="37;45"
export XDG_VTNR="1"
export LCG_GFAL_VO="lhcb"
export CMTDEB="x86_64-slc6-gcc49-dbg"
```