### PR TITLE
Fixing the IPython logging hook to not flush during text entry

### DIFF
--- a/python/Ganga/Runtime/bootstrap.py
+++ b/python/Ganga/Runtime/bootstrap.py
@@ -1248,7 +1248,7 @@ under certain conditions; type license() for details.
         from Ganga.Utility.logging import enableCaching
         enableCaching()
 
-        ipshell.set_hook("pre_prompt_hook", ganga_prompt)
+        ipshell.set_hook("pre_run_code_hook", ganga_prompt)
 
         from Ganga.Runtime.IPythonMagic import magic_ganga
         ipshell.define_magic('ganga', magic_ganga)


### PR DESCRIPTION
Fixes #546 

This PR is very short but worth documenting. I'm changing the IPython hook to be the `pre_run_code_hook` which is run after the text input in a command line has been finished.
This replaces our use of the `pre_prompt_hook` which is executed every time a user hits enter which for complex functions can be quite a few times before they've finished inputting a command.

The result is that the logging no longer flushes and interrupts the user input.