### PR TITLE
Create DIRAC proxy

### DIFF
--- a/python/Ganga/Runtime/bootstrap.py
+++ b/python/Ganga/Runtime/bootstrap.py
@@ -150,7 +150,7 @@ def manualExportToGPI(my_interface=None):
     # At this point we expect to have the GridProxy already created
     # by one of the Grid plugins (LCG/NG/etc) so we search for it in creds
     # cache
-    credential = getCredential(name='GridProxy', create=False)
+    credential = getCredential(name='GridProxy')
     if credential:
         exportToInterface(my_interface, 'gridProxy', credential, 'Objects', 'Grid proxy management object.')
 

--- a/python/GangaDirac/Lib/Utilities/DiracUtilities.py
+++ b/python/GangaDirac/Lib/Utilities/DiracUtilities.py
@@ -222,7 +222,7 @@ def execute(command,
             python_setup='',
             eval_includes=None,
             update_env=False,
-            renew=False):
+            ):
     """
     Execute a command on the local DIRAC server.
 
@@ -235,7 +235,7 @@ def execute(command,
         cwd (str): an optional string to a valid path where this code should be executed
         shell (bool): Should this code be executed in a new shell environment
         python_setup (str): Optional extra code to pass to python when executing
-        eval_incldes (???): TODO document me
+        eval_includes (???): TODO document me
         update_env (bool): Should this modify the given env object with the env after the command has executed
     """
 
@@ -245,7 +245,7 @@ def execute(command,
         python_setup = getDiracCommandIncludes()
 
     # We're about to perform an expensive operation so being safe before we run it shouldn't cost too much
-    _checkProxy(force = True, renew = renew)
+    _checkProxy(force = True)
 
     #logger.debug("Executing command:\n'%s'" % str(command))
     #logger.debug("python_setup:\n'%s'" % str(python_setup))

--- a/python/GangaDirac/Lib/Utilities/DiracUtilities.py
+++ b/python/GangaDirac/Lib/Utilities/DiracUtilities.py
@@ -14,7 +14,7 @@ from Ganga.GPIDev.Credentials import getCredential
 import Ganga.Utility.execute as gexecute
 
 logger = getLogger()
-proxy = getCredential('GridProxy', '')
+proxy = None
 
 # Cache
 # /\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\
@@ -164,6 +164,8 @@ def _dirac_check_proxy( renew = True, shouldRaise = True):
     """
     global last_modified_valid
     global proxy
+    if proxy is None:
+        proxy = getCredential('GridProxy', '')
     _isValid = proxy.isValid()
     if not _isValid:
         if renew is True:


### PR DESCRIPTION
This causes every call to DIRAC's `execute()` function to ask to make a proxy if it has expired. Currently, if there is no proxy present when Ganga starts, no proxy will ever be created and errors like:
```
AttributeError: 'NoneType' object has no attribute 'get'
```
will be raised.

Perhaps this is unsafe because it might be called in a background thread but somehow we need to get a proxy created.