### PR TITLE
Defer creating the proxy object until the first time it is requested

### DIFF
--- a/python/GangaDirac/Lib/Utilities/DiracUtilities.py
+++ b/python/GangaDirac/Lib/Utilities/DiracUtilities.py
@@ -14,7 +14,7 @@ from Ganga.GPIDev.Credentials import getCredential
 import Ganga.Utility.execute as gexecute
 
 logger = getLogger()
-proxy = getCredential('GridProxy', '')
+proxy = None
 
 # Cache
 # /\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\
@@ -164,6 +164,8 @@ def _dirac_check_proxy( renew = True, shouldRaise = True):
     """
     global last_modified_valid
     global proxy
+    if proxy is None:
+        proxy = getCredential('GridProxy', '')
     _isValid = proxy.isValid()
     if not _isValid:
         if renew is True:


### PR DESCRIPTION
This ensures that the LHCb plugin has finished loading before the proxy is created. Objects should not be created at import time.

This is one half (the less controversial half) of #555.