### PR TITLE
If default_se is not in all_storage_elements add it

### DIFF
--- a/python/Ganga/Utility/decorators.py
+++ b/python/Ganga/Utility/decorators.py
@@ -1,0 +1,16 @@
+def static_vars(**kwargs):
+    """
+    Decorate a function and provide it with some static variables.
+    >>> @static_vars(counter=0)
+    ... def foo():
+    ...     foo.counter += 1
+    ...     return foo.counter
+    >>> foo()
+    1
+    >>> foo()
+    2
+    """
+    def decorate(func):
+        func.__dict__.update(kwargs)
+        return func
+    return decorate


### PR DESCRIPTION
Previously, if these were not perfectly matched, an exception would be raised. This means that the user can set `defaultSE` on their `DiracFile` without also having to set the config option `allDiracSE`.

Also, add and use Mark Slater's static_vars() decorator for the global state.