### PR TITLE
Making chosen_lfns use sets instead of lists

### DIFF
--- a/python/GangaDirac/Lib/Splitters/OfflineGangaDiracSplitter.py
+++ b/python/GangaDirac/Lib/Splitters/OfflineGangaDiracSplitter.py
@@ -384,7 +384,7 @@ def OfflineGangaDiracSplitter(_inputs, filesPerJob, maxFiles, ignoremissing):
         # NB: Can't modify this list and iterate over it directly in python
         LFN_instances = site_dict.keys()
         # Already used LFN
-        chosen_lfns = []
+        chosen_lfns = set([])
 
         for iterating_LFN in LFN_instances:
 
@@ -429,7 +429,7 @@ def OfflineGangaDiracSplitter(_inputs, filesPerJob, maxFiles, ignoremissing):
                 for lfn in _this_subset:
                     site_dict.pop(lfn)
                     allChosenSets.pop(lfn)
-                    chosen_lfns.append(lfn)
+                    chosen_lfns.add(lfn)
 
         # Lets keep track of how many times we've tried this
         iterations = iterations + 1

--- a/python/GangaDirac/Lib/Splitters/OfflineGangaDiracSplitter.py
+++ b/python/GangaDirac/Lib/Splitters/OfflineGangaDiracSplitter.py
@@ -384,7 +384,7 @@ def OfflineGangaDiracSplitter(_inputs, filesPerJob, maxFiles, ignoremissing):
         # NB: Can't modify this list and iterate over it directly in python
         LFN_instances = site_dict.keys()
         # Already used LFN
-        chosen_lfns = set([])
+        chosen_lfns = set()
 
         for iterating_LFN in LFN_instances:
 


### PR DESCRIPTION
The code in `OfflineGangaDiracSplitter` is checking for already used lfns with:
```
if iterating_LFN in chosen_lfns:
```
This is fine until the `chosen_lfns` list goes above a few hundred at which point everything grinds to a halt. This PR changes `chosen_lfns` to use a `set` instead. In a very quick & dirty splitting test over the 2015 data, this speeds this part of the function (not the whole thing) up from 2+ hours (on a ~fast desktop) to ~1 sec.

There are still other areas in this code that could be looked at to speed things up but this is a big improvement with minimal changes.