### PR TITLE
Set the default value rather than the session value for the LHCb cache

### DIFF
--- a/python/GangaLHCb/__init__.py
+++ b/python/GangaLHCb/__init__.py
@@ -101,8 +101,6 @@ def _store_dirac_environment():
 
 if not _after_bootstrap:
     _store_dirac_environment()
-    configDirac.setSessionValue('DiracEnvJSON', os.environ['GANGADIRACENVIRONMENT'])
-
     _store_root_version()
 
 
@@ -134,6 +132,10 @@ def loadPlugins(config=None):
     logger.debug("Importing LHCbTasks")
     import Lib.Tasks
     logger.debug("Finished Importing")
+
+
+def postBootstrapHook():
+    configDirac.setSessionValue('DiracEnvJSON', os.environ['GANGADIRACENVIRONMENT'])
 
 from Ganga.GPIDev.Lib.File.Configure import outputconfig
 


### PR DESCRIPTION
For consistency (and to prevent it being reset between test runs), set the LHCb env cache as the default value rather than the session value.

I think this should fix the nightly tests.