### PR TITLE
Cleanup Config.py

### DIFF
--- a/python/Ganga/GPIDev/Schema/Schema.py
+++ b/python/Ganga/GPIDev/Schema/Schema.py
@@ -243,7 +243,7 @@ class Schema(object):
             # Attempt to get the relevant config section
             config = Config.getConfig(def_name)
 
-            if is_finalized and stored_attr_key in _found_attrs and not config.hasModified():
+            if is_finalized and stored_attr_key in _found_attrs and not config.hasModified:
                 defvalue = _found_attrs[stored_attr_key]
             else:
                 if attr in config.getEffectiveOptions():
@@ -290,7 +290,7 @@ class Schema(object):
                 if isinstance(defvalue, str) or defvalue is None:
                     try:
                         config = Config.getConfig(def_name)
-                        has_modified = config.hasModified()
+                        has_modified = config.hasModified
                     except KeyError:
                         has_modified = False
 

--- a/python/Ganga/GPIDev/Schema/Schema.py
+++ b/python/Ganga/GPIDev/Schema/Schema.py
@@ -241,7 +241,7 @@ class Schema(object):
 
         try:
             # Attempt to get the relevant config section
-            config = Config.getConfig(def_name, create=False)
+            config = Config.getConfig(def_name)
 
             if is_finalized and stored_attr_key in _found_attrs and not config.hasModified():
                 defvalue = _found_attrs[stored_attr_key]
@@ -289,7 +289,7 @@ class Schema(object):
 
                 if isinstance(defvalue, str) or defvalue is None:
                     try:
-                        config = Config.getConfig(def_name, create=False)
+                        config = Config.getConfig(def_name)
                         has_modified = config.hasModified()
                     except KeyError:
                         has_modified = False

--- a/python/Ganga/Utility/Config/Config.py
+++ b/python/Ganga/Utility/Config/Config.py
@@ -115,20 +115,20 @@ class ConfigError(GangaException):
 # for example, do not do here: from Ganga.Utility.logging import logger
 # use getLogger() function defined below:
 
-logger = None
+_logger = None
 
 
 def getLogger():
     import Ganga.Utility.logging
-    global logger
-    if logger is not None:
-        return logger
+    global _logger
+    if _logger is not None:
+        return _logger
 
     # for the configuration of the logging package itself (in the initial
     # phases) the logging may be disabled
     try:
-        logger = Ganga.Utility.logging.getLogger()
-        return logger
+        _logger = Ganga.Utility.logging.getLogger()
+        return _logger
     except AttributeError as err:
         print("AttributeError: %s" % err)
         # in such a case we return a mock proxy object which ignore all calls
@@ -674,15 +674,15 @@ def transform_PATH_option(name, new_value, current_value):
 
     PATH_ITEM = '_PATH'
     if name[-len(PATH_ITEM):] == PATH_ITEM:
-        logger.debug('PATH-like variable: %s %s %s', name, new_value, current_value)
+        getLogger().debug('PATH-like variable: %s %s %s', name, new_value, current_value)
         if current_value is None:
             ret_value = new_value
         elif new_value[:3] != ':::':
-            logger.debug('Prepended %s to PATH-like variable %s', new_value, name)
+            getLogger().debug('Prepended %s to PATH-like variable %s', new_value, name)
             ret_value = new_value + ':' + current_value
             new_value = ""
         else:
-            logger.debug('Resetting PATH-like variable %s to %s', name, new_value)
+            getLogger().debug('Resetting PATH-like variable %s to %s', name, new_value)
             ret_value = new_value  # [3:]
             new_value = ":::"
 
@@ -896,7 +896,7 @@ def setConfigOption(section="", item="", value=""):
             if item in config.getEffectiveOptions():
                 config.setSessionValue(item, value)
         except Exception as err:
-            logger.debug("Error setting Option: %s = %s  :: %s" % (item, value, err))
+            getLogger().debug("Error setting Option: %s = %s  :: %s" % (item, value, err))
 
     return None
 # KH 050725: End of addition

--- a/python/Ganga/Utility/Config/Config.py
+++ b/python/Ganga/Utility/Config/Config.py
@@ -90,6 +90,7 @@ There is a GPI wrapper in Ganga.GPIDev.Lib.Config which:
 
 """
 
+from collections import defaultdict
 from functools import reduce
 
 from Ganga.Core.exceptions import GangaException
@@ -145,7 +146,7 @@ allConfigs = {}
 # configuration session buffer
 # this dictionary contains the value for the options which are defined in the configuration file and which have
 # not yet been defined
-unknownConfigFileValues = {}
+unknownConfigFileValues = defaultdict(dict)
 
 
 def getConfig(name):
@@ -861,7 +862,6 @@ def setSessionValue(config_name, option_name, value):
 
     # put value in the buffer, it will be removed from the buffer when option
     # is added
-    unknownConfigFileValues.setdefault(config_name, {})
     unknownConfigFileValues[config_name][option_name] = value
 
 

--- a/python/Ganga/Utility/Config/Config.py
+++ b/python/Ganga/Utility/Config/Config.py
@@ -98,6 +98,7 @@ from functools import reduce
 
 from Ganga.Core.exceptions import GangaException
 
+
 class ConfigError(GangaException):
 
     """ ConfigError indicates that an option does not exist or it cannot be set.
@@ -115,8 +116,6 @@ class ConfigError(GangaException):
 # use getLogger() function defined below:
 
 logger = None
-
-
 
 
 def getLogger():
@@ -254,13 +253,6 @@ class ConfigOption(object):
 
         if hasattr(self, 'session_value'):
             session_value = self.transform_PATH_option(session_value, self.session_value)
-        else:
-            pass
-
-        if hasattr(self, 'session_value'):
-            old_value = self.session_value
-        else:
-            pass
 
         self.session_value = session_value
         self.convert_type('session_value')
@@ -280,13 +272,9 @@ class ConfigOption(object):
 
         if hasattr(self, 'user_value'):
             user_value = self.transform_PATH_option(user_value, self.user_value)
-        else:
-            pass
 
         if hasattr(self, 'user_value'):
             old_value = self.user_value
-        else:
-            pass
 
         self.user_value = user_value
         try:
@@ -303,8 +291,6 @@ class ConfigOption(object):
         self.setModified(True)
         if hasattr(self, 'default_value'):
             default_value = self.transform_PATH_option(default_value, self.default_value)
-        else:
-            pass
         self.default_value = default_value
         self.convert_type('user_value')
         self.convert_type('session_value')
@@ -318,8 +304,6 @@ class ConfigOption(object):
                 str_val = n+'_value'
                 if hasattr(self, str_val):
                     values.append(getattr(self, str_val))
-                else:
-                    pass
 
             if values != []:
                 returnable = reduce(self.transform_PATH_option, values)
@@ -336,9 +320,9 @@ class ConfigOption(object):
     def __setattr__(self, name, value):
         if name in ['value', 'level']:
             raise AttributeError('Cannot set "%s" attribute of the option object' % name)
-        else:
-            self.__dict__[name] = value
-            self.__dict__['_hasModified'] = True
+
+        self.__dict__[name] = value
+        self.__dict__['_hasModified'] = True
 
     def check_defined(self):
         return hasattr(self, 'default_value')
@@ -507,8 +491,6 @@ class PackageConfig(object):
             msg = "Error getting ConfigFileValue Option: %s" % self.name
             if locals().get('logger') is not None:
                 locals().get('logger').debug("dbg: %s"%msg)
-            else:
-                pass
             conf_value = dict()
 
         if option.name in conf_value:
@@ -520,8 +502,6 @@ class PackageConfig(object):
                 msg = "Error Setting Session Value: %s" % err
                 if locals().get('logger') is not None:
                     locals().get('logger').debug("dbg: %s" % msg)
-                else:
-                    pass
 
     def setSessionValue(self, name, value, raw=0):
         """  Add or  override options  as a  part of  second  phase of
@@ -558,8 +538,6 @@ class PackageConfig(object):
                 logger.error("Name: %s Value: '%s'" % (name, value))
                 logger.error("Err:\n%s" % err)
                 raise err
-            finally:
-                pass
 
     def setUserValue(self, name, value):
         """ Modify option  at runtime. This  method corresponds to  the user
@@ -592,10 +570,6 @@ class PackageConfig(object):
         if name in self.options:
             if hasattr(self.options[name], 'user_value'):
                 del self.options[name].user_value
-            else:
-                pass
-        else:
-            pass
 
     def revertToDefault(self, name):
         self.setModified(True)
@@ -603,10 +577,6 @@ class PackageConfig(object):
         if name in self.options:
             if hasattr(self.options[name], 'session_value'):
                 del self.options[name].session_value
-            else:
-                pass
-        else:
-            pass
 
     def revertToSessionOptions(self):
         self.setModified(True)

--- a/python/Ganga/Utility/Config/Config.py
+++ b/python/Ganga/Utility/Config/Config.py
@@ -474,10 +474,6 @@ class PackageConfig(object):
         # sanity check to force using makeConfig()
         self._config_made = False
 
-        if _configured and self.is_open:
-            logger = getLogger()
-            logger.error('cannot define open configuration section %s after configure() step', self.name)
-
         self._hasModified = False
 
     def setModified(self, val):
@@ -905,9 +901,6 @@ def setSessionValue(config_name, option_name, value):
     unknownConfigFileValues[config_name][option_name] = value
 
 
-_configured = False
-
-
 def setSessionValuesFromFiles(filenames, system_vars):
     """ Sets session values for all options in all configuration units
     defined in the sequence of config files.  Initialize config parser
@@ -935,8 +928,6 @@ def setSessionValuesFromFiles(filenames, system_vars):
                 logger.warning("Can't expand the config file option %s:%s, treating it as raw" % (str(name), str(o)))
                 v = cfg.get(name, o, raw=True)
             setSessionValue(name, o, v)
-
-    _configured = True
 
 
 def load_user_config(filename, system_vars):

--- a/python/Ganga/Utility/Config/Config.py
+++ b/python/Ganga/Utility/Config/Config.py
@@ -217,7 +217,7 @@ class ConfigOption(object):
         self.examples = None
         self.filter = None
         self.typelist = None
-        self._hasModified = False
+        self.hasModified = False
 
     def defineOption(self, default_value, docstring, **meta):
 
@@ -235,18 +235,12 @@ class ConfigOption(object):
         self.convert_type('session_value')
         self.convert_type('user_value')
 
-    def setModified(self, val):
-        self._hasModified = val
-
-    def hasModified(self):
-        return self._hasModified
-
     def setSessionValue(self, session_value):
 
         if not hasattr(self, 'docstring'):
             raise ConfigError('Can\'t set a session value without a docstring!')
 
-        self.setModified(True)
+        self.hasModified = True
 
         # try:
         if self.filter:
@@ -263,7 +257,7 @@ class ConfigOption(object):
         if not hasattr(self, 'docstring'):
             raise ConfigError('Can\'t set a user value without a docstring!')
 
-        self.setModified(True)
+        self.hasModified = True
         try:
             if self.filter:
                 user_value = self.filter(self, user_value)
@@ -289,7 +283,7 @@ class ConfigOption(object):
             raise x
 
     def overrideDefaultValue(self, default_value):
-        self.setModified(True)
+        self.hasModified = True
         if hasattr(self, 'default_value'):
             default_value = self.transform_PATH_option(default_value, self.default_value)
         self.default_value = default_value
@@ -322,8 +316,8 @@ class ConfigOption(object):
         if name in ['value', 'level']:
             raise AttributeError('Cannot set "%s" attribute of the option object' % name)
 
-        self.__dict__[name] = value
-        self.__dict__['_hasModified'] = True
+        super(ConfigOption, self).__setattr__(name, value)
+        super(ConfigOption, self).__setattr__('_hasModified', True)
 
     def check_defined(self):
         return hasattr(self, 'default_value')
@@ -446,13 +440,7 @@ class PackageConfig(object):
         # sanity check to force using makeConfig()
         self._config_made = False
 
-        self._hasModified = False
-
-    def setModified(self, val):
-        self._hasModified = val
-
-    def hasModified(self):
-        return self._hasModified
+        self.hasModified = False
 
     def _addOpenOption(self, name, value):
         self.addOption(name, value, "", override=True)
@@ -508,7 +496,7 @@ class PackageConfig(object):
         default type of the option  is not string, then the expression
         will be evaluated."""
 
-        self.setModified(True)
+        self.hasModified = True
 
         logger = getLogger()
 
@@ -541,7 +529,7 @@ class PackageConfig(object):
         the  default  type  of  the  option  is  not  string,  then  the
         expression will be evaluated. """
 
-        self.setModified(True)
+        self.hasModified = True
 
         logger = getLogger()
 
@@ -558,29 +546,29 @@ class PackageConfig(object):
             handler[1](name, value)
 
     def overrideDefaultValue(self, name, val):
-        self.setModified(True)
+        self.hasModified = True
         self.options[name].overrideDefaultValue(val)
 
     def revertToSession(self, name):
-        self.setModified(True)
+        self.hasModified = True
         if name in self.options:
             if hasattr(self.options[name], 'user_value'):
                 del self.options[name].user_value
 
     def revertToDefault(self, name):
-        self.setModified(True)
+        self.hasModified = True
         self.revertToSession(name)
         if name in self.options:
             if hasattr(self.options[name], 'session_value'):
                 del self.options[name].session_value
 
     def revertToSessionOptions(self):
-        self.setModified(True)
+        self.hasModified = True
         for name in self.options:
             self.revertToSession(name)
 
     def revertToDefaultOptions(self):
-        self.setModified(True)
+        self.hasModified = True
         self.revertToSessionOptions()
         for name in self.options:
             self.revertToDefault(name)

--- a/python/Ganga/Utility/Config/Config.py
+++ b/python/Ganga/Utility/Config/Config.py
@@ -148,35 +148,10 @@ allConfigs = {}
 # not yet been defined
 unknownConfigFileValues = {}
 
-translated_names = {}
-# helper function which helps migrating the names from old naming convention
-# to the stricter new one: spaces are removed, colons replaced by underscored
-# returns a valid name or raises a ValueError
-
-
-def _migrate_name(name):
-    import Ganga.Utility.strings as strings
-
-    if (name not in translated_names) and (not strings.is_identifier(name)):
-        name2 = strings.drop_spaces(name)
-        name3 = name2.replace(':', '_')
-
-        if not strings.is_identifier(name3):
-            raise ValueError('config name %s is not a valid python identifier' % name)
-        else:
-            logger = getLogger()
-            logger.warning('obsolete config name found: replaced "%s" -> "%s"' % (name, name3))
-            logger.warning('config names must be python identifiers, please correct your usage in the future ')
-            translated_names[name] = name3
-    elif name not in translated_names:
-        translated_names[name] = name
-
-    return translated_names[name]
 
 def getConfig(name):
     """
     Get an existing PackageConfig.
-    Temporary name migration conversion applies -- see _migrate_name().
     Principle is the same as for getLogger() -- the config instances may
     be easily shared between different parts of the program.
 
@@ -190,7 +165,6 @@ def getConfig(name):
         KeyError: if the config is not found
     """
 
-    name = _migrate_name(name)
     try:
         return allConfigs[name]
     except KeyError:
@@ -208,7 +182,6 @@ def makeConfig(name, docstring, **kwds):
         raise ConfigError(
             'attempt to create a configuration section [%s] after bootstrap' % name)
 
-    name = _migrate_name(name)
     try:
         c = allConfigs[name]
         c.docstring = docstring
@@ -479,12 +452,11 @@ class PackageConfig(object):
     def __init__(self, name, docstring, **meta):
         """ Arguments:
          - name may not contain blanks and should be a valid python identifier otherwise ValueError is raised
-         - temporary name migration conversion applies -- see _migrate_name()
          meta args have the same meaning as for the ConfigOption:
           - hidden
           - cfile
         """
-        self.name = _migrate_name(name)
+        self.name = name
         self.options = {}  # {'name':Option('name',default_value,docstring)}
         self.docstring = docstring
         self.hidden = False

--- a/python/Ganga/Utility/Config/Config.py
+++ b/python/Ganga/Utility/Config/Config.py
@@ -90,6 +90,9 @@ There is a GPI wrapper in Ganga.GPIDev.Lib.Config which:
 
 """
 
+import os
+import re
+import traceback
 from collections import defaultdict
 from functools import reduce
 
@@ -549,7 +552,6 @@ class PackageConfig(object):
             try:
                 h[1](name, value)
             except Exception as err:
-                import traceback
                 traceback.print_stack()
                 logger.error("h[1]: %s" % h[1])
                 logger.error("Error in Setting Session Value!")
@@ -742,8 +744,6 @@ def read_ini_files(filenames, system_vars):
     sequence of files (which are parsed from left-to-right).
     Apply special rules for PATH-like variables - see transform_PATH_option() """
 
-    import re
-    import os
     import Ganga.Utility.logging
 
     logger = getLogger()
@@ -895,7 +895,6 @@ def setSessionValuesFromFiles(filenames, system_vars):
 
 
 def load_user_config(filename, system_vars):
-    import os
     logger = getLogger()
     if not os.path.exists(filename):
         return
@@ -954,7 +953,6 @@ def expandConfigPath(path, top):
     """ Split the path and return a list, where all relative path components will have top prepended.
         Example: 'A:/B/C::D/E' -> ['top/A','/B/C','top/D/E']
     """
-    import os.path
     l = []
     for p in path.split(':'):
         if p:

--- a/python/Ganga/Utility/Config/Config.py
+++ b/python/Ganga/Utility/Config/Config.py
@@ -955,30 +955,3 @@ def sanityCheck():
             for o, v in zip(opts.keys(), opts.values()):
                 cfg._addOpenOption(o, v)
                 cfg.setSessionValue(o, v)
-
-
-def getFlavour():
-
-    runtimepath = getConfig('Configuration')['RUNTIME_PATH']
-
-    if 'GangaLHCb' in runtimepath:
-        lhcb = True
-    else:
-        lhcb = False
-
-    if 'GangaAtlas' in runtimepath:
-        atlas = True
-    else:
-        atlas = False
-
-    if lhcb and atlas:
-        raise ConfigError('Atlas and LHCb conflict')
-
-    if lhcb:
-        return 'LHCb'
-
-    if atlas:
-        return 'Atlas'
-
-    return ''
-

--- a/python/Ganga/Utility/Config/Config.py
+++ b/python/Ganga/Utility/Config/Config.py
@@ -146,7 +146,7 @@ allConfigs = {}
 # configuration session buffer
 # this dictionary contains the value for the options which are defined in the configuration file and which have
 # not yet been defined
-allConfigFileValues = {}
+unknownConfigFileValues = {}
 
 translated_names = {}
 # helper function which helps migrating the names from old naming convention
@@ -544,8 +544,8 @@ class PackageConfig(object):
         option.defineOption(default_value, docstring, **meta)
         self.options[option.name] = option
 
-        if self.name in allConfigFileValues:
-            conf_value = allConfigFileValues[self.name]
+        if self.name in unknownConfigFileValues:
+            conf_value = unknownConfigFileValues[self.name]
         else:
             msg = "Error getting ConfigFileValue Option: %s" % str(self.name)
             if 'logger' in locals() and logger is not None:
@@ -929,8 +929,8 @@ def setSessionValue(config_name, option_name, value):
 
     # put value in the buffer, it will be removed from the buffer when option
     # is added
-    allConfigFileValues.setdefault(config_name, {})
-    allConfigFileValues[config_name][option_name] = value
+    unknownConfigFileValues.setdefault(config_name, {})
+    unknownConfigFileValues[config_name][option_name] = value
 
 
 _configured = False
@@ -1045,8 +1045,8 @@ def sanityCheck():
         if not c._config_made:
             logger.error("sanity check failed: %s: no makeConfig() found in the code", c.name)
 
-    for name in allConfigFileValues:
-        opts = allConfigFileValues[name]
+    for name in unknownConfigFileValues:
+        opts = unknownConfigFileValues[name]
         if name in allConfigs:
             cfg = allConfigs[name]
         else:

--- a/python/Ganga/Utility/Config/Config.py
+++ b/python/Ganga/Utility/Config/Config.py
@@ -173,36 +173,28 @@ def _migrate_name(name):
 
     return translated_names[name]
 
-
-def getConfig(name, create=True):
+def getConfig(name):
     """
-    Get an exisiting PackageConfig or create a new one if needed.
+    Get an existing PackageConfig.
     Temporary name migration conversion applies -- see _migrate_name().
     Principle is the same as for getLogger() -- the config instances may
     be easily shared between different parts of the program.
 
     Args:
         name: the name of the config section
-        create (bool): should the section be created if it does not yet exist
 
     Returns:
         PackageConfig:
 
     Raises:
-        KeyError: if the config is not found and ``create`` was False
+        KeyError: if the config is not found
     """
-    # FIXME: In future ``create`` should always be False and the function should be simplified to return ``return allConfigs[name]``
 
     name = _migrate_name(name)
-    if name in allConfigs:
+    try:
         return allConfigs[name]
-    else:
-        if create:
-            logger.debug('Creating "%s" config in getConfig', name)
-            allConfigs[name] = PackageConfig(name, 'Documentation not available')
-            return allConfigs[name]
-        else:
-            raise KeyError('Config section "{0}" not found'.format(name))
+    except KeyError:
+        raise KeyError('Config section "[{0}]" not found'.format(name))
 
 
 def makeConfig(name, docstring, **kwds):

--- a/python/Ganga/Utility/Config/Config.py
+++ b/python/Ganga/Utility/Config/Config.py
@@ -109,7 +109,7 @@ class ConfigError(GangaException):
         self.what = what
 
     def __str__(self):
-        return "ConfigError: %s " % (self.what)
+        return "ConfigError: %s " % self.what
 
 # WARNING: avoid importing logging at the module level in this file
 # for example, do not do here: from Ganga.Utility.logging import logger
@@ -133,6 +133,7 @@ def getLogger():
         print("AttributeError: %s" % err)
         # in such a case we return a mock proxy object which ignore all calls
         # such as logger.info()...
+
         class X(object):
 
             def __getattr__(self, name):
@@ -305,7 +306,7 @@ class ConfigOption(object):
                 if hasattr(self, str_val):
                     values.append(getattr(self, str_val))
 
-            if values != []:
+            if values:
                 returnable = reduce(self.transform_PATH_option, values)
                 return returnable
 
@@ -331,10 +332,10 @@ class ConfigOption(object):
         return transform_PATH_option(self.name, new_value, current_value)
 
     def convert_type(self, x_name):
-        ''' Convert the type of session_value or user_value (referred to by x_name) according to the types defined by the self.
+        """ Convert the type of session_value or user_value (referred to by x_name) according to the types defined by the self.
         If the option has not been defined or the x_name in question is not defined, then this method is no-op.
         If conversion cannot be performed (type mismatch) then raise ConfigError.
-        '''
+        """
 
         try:
             value = getattr(self, x_name)
@@ -373,8 +374,6 @@ class ConfigOption(object):
 
         def check_type(x, t):
             return isinstance(x, t) or x is t
-
-        type_matched = False
 
         # first we check using the same rules for typelist as for the GPI proxy
         # objects
@@ -451,7 +450,7 @@ class PackageConfig(object):
 
     def setModified(self, val):
         self._hasModified = val
-                               
+
     def hasModified(self):
         return self._hasModified
 
@@ -490,7 +489,7 @@ class PackageConfig(object):
         else:
             msg = "Error getting ConfigFileValue Option: %s" % self.name
             if locals().get('logger') is not None:
-                locals().get('logger').debug("dbg: %s"%msg)
+                locals().get('logger').debug("dbg: %s" % msg)
             conf_value = dict()
 
         if option.name in conf_value:
@@ -503,14 +502,11 @@ class PackageConfig(object):
                 if locals().get('logger') is not None:
                     locals().get('logger').debug("dbg: %s" % msg)
 
-    def setSessionValue(self, name, value, raw=0):
+    def setSessionValue(self, name, value):
         """  Add or  override options  as a  part of  second  phase of
         initialization of  this configuration module (PHASE  2) If the
         default type of the option  is not string, then the expression
-        will be evaluated. Optional  argument raw indicates if special
-        treatment  of  PATH-like  variables  is disabled  (enabled  by
-        default).  The special treatment  applies to the session level
-        values only (and not the default one!).  """
+        will be evaluated."""
 
         self.setModified(True)
 
@@ -792,7 +788,6 @@ def read_ini_files(filenames, system_vars):
                     envvarclean = envvar.strip('$')
 
                     # is env variable
-                    envval = ''
                     logger.debug('looking for ' + str(envvarclean) + ' in the shell environment')
                     if envvarclean in os.environ:
                         envval = os.environ[envvarclean]

--- a/python/Ganga/Utility/Config/__init__.py
+++ b/python/Ganga/Utility/Config/__init__.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-from .Config import getConfig, makeConfig, ConfigError, setSessionValuesFromFiles, allConfigs, setConfigOption, expandConfigPath, config_scope, setSessionValue, getFlavour
+from .Config import getConfig, makeConfig, ConfigError, setSessionValuesFromFiles, allConfigs, setConfigOption, expandConfigPath, config_scope, setSessionValue
 import os.path
 
 ## from Config import getConfigDict


### PR DESCRIPTION
This removes a bunch of unused and unnecessary code from Config as a first step towards making it more easily loadable and un-loadable.

The biggest change in here is that `getConfig()` will no longer *create* a config section if it doesn't find one. This is possible since we are now explicit about using `makeConfig()` in our `__init__.py` files.