### PR TITLE
Fixing bug to stop status always being evalled

### DIFF
--- a/python/Ganga/GPIDev/Lib/Job/Job.py
+++ b/python/Ganga/GPIDev/Lib/Job/Job.py
@@ -39,7 +39,7 @@ def lazyLoadJobFQID(this_job):
 
 
 def lazyLoadJobStatus(this_job):
-    return lazyLoadJobObject(this_job, 'status', do_eval=True)
+    return lazyLoadJobObject(this_job, 'status', do_eval=False)
 
 
 def lazyLoadJobBackend(this_job):


### PR DESCRIPTION
Just a quick PR for a 1 line fix. I'll merge after the tests have passed.

This fixes a bug where in a lot of cases the job status wasn't being loaded correctly from the lazy loading index. This is a quick 1 line fix to make sure that it is indeed loaded from the index and not from the actual underlying object which hasn't been loaded.