### PR TITLE
Fixing logger on shutdown in tests

### DIFF
--- a/python/Ganga/Utility/logging/__init__.py
+++ b/python/Ganga/Utility/logging/__init__.py
@@ -498,8 +498,12 @@ def bootstrap(internal=False, handler=None):
 
 def final_shutdown():
     """ Shutdown the logging system via a call here as we don't want to do this in the wrong place in the shutdown method """
+
     private_logger.debug('shutting down logsystem')
     logging.shutdown()
+    for handler in main_logger.handlers:
+        main_logger.removeHandler(handler)
+    main_logger.addHandler(default_handler)
 
 
 # do the initial bootstrap automatically at import -> this will bootstrap


### PR DESCRIPTION
This is a bug which only really effects the tests, however it does mean that there are some few 100 Handles left associated with the logging system when running all of the tests back to back.

I'll merge this once the tests complete