### PR TITLE
GaudiRun adding read input data

### DIFF
--- a/python/GangaDirac/Lib/Splitters/OfflineGangaDiracSplitter.py
+++ b/python/GangaDirac/Lib/Splitters/OfflineGangaDiracSplitter.py
@@ -174,10 +174,9 @@ def calculateSiteSEMapping(file_replicas, wanted_common_site, uniqueSE, site_to_
 
 def lookUpLFNReplicas(inputs, allLFNData):
     # Build a useful dictionary and list
-    allLFNs = []
-    LFNdict = {}
+    allLFNs = [_lfn.lfn for _lfn in inputs]
+    LFNdict = dict().fromkeys(allLFNs)
     for _lfn in inputs:
-        allLFNs.append(_lfn.lfn)
         LFNdict[_lfn.lfn] = _lfn
 
     # Request the replicas for all LFN 'LFN_parallel_limit' at a time to not overload the

--- a/python/GangaLHCb/Lib/Applications/PythonOptionsParser.py
+++ b/python/GangaLHCb/Lib/Applications/PythonOptionsParser.py
@@ -22,7 +22,7 @@ logger = Ganga.Utility.logging.getLogger()
 ## Due to a bug in Gaudi at some point we need this equivalenc here: see #204
 DataObjectDescriptorCollection = str
 
-class PythonOptionsParser:
+class PythonOptionsParser(object):
 
 
     """ Parses job options file(s) w/ gaudirun.py to extract user's files"""
@@ -132,7 +132,8 @@ class PythonOptionsParser:
 
         from Ganga.GPIDev.Base.Filters import allComponentFilters
         file_filter = allComponentFilters['gangafiles']
-        ds = LHCbDataset()
+
+        all_files = []
         for d in data:
             p1 = d.find('DATAFILE=') + len('DATAFILE=')
             quote = d[p1]
@@ -141,7 +142,9 @@ class PythonOptionsParser:
             this_file = file_filter(f, None)
             if this_file is None:
                 this_file = LocalFile(name=f)
-            ds.files.append(this_file)
+            all_files.append(this_file)
+
+        ds = LHCbDataset(files=all_files, fromRef=True)
         return ds
 
     def get_output_files(self):

--- a/python/GangaLHCb/Lib/GaudiRunApp/GaudiRunApp.py
+++ b/python/GangaLHCb/Lib/GaudiRunApp/GaudiRunApp.py
@@ -9,7 +9,6 @@ from Ganga.GPIDev.Base.Proxy import getName
 from Ganga.GPIDev.Lib.File.File import ShareDir
 from Ganga.GPIDev.Lib.File.LocalFile import LocalFile
 from Ganga.GPIDev.Schema import Schema, Version, SimpleItem, GangaFileItem
-from Ganga.Runtime.GPIexport import exportToGPI
 from Ganga.Utility.logging import getLogger
 from Ganga.Utility.files import expandfilename
 
@@ -73,7 +72,7 @@ class GaudiRun(IPrepareApp):
         })
     _category = 'applications'
     _name = 'GaudiRun'
-    _exportmethods = ['prepare', 'unprepare', 'exec_cmd', 'getDir']
+    _exportmethods = ['prepare', 'unprepare', 'exec_cmd', 'getDir', 'readInputData']
 
     cmake_sandbox_name = 'cmake-input-sandbox.tgz'
     build_target = 'ganga-input-sandbox'
@@ -204,6 +203,8 @@ class GaudiRun(IPrepareApp):
             logger.error("StdErr: %s" % str(stderr))
             raise GangaException("Failed to Execute command")
 
+        return rc, stdout, stderr
+
     def buildGangaTarget(self):
         """
         This builds the ganga target 'ganga-input-sandbox' for the project defined by self.directory
@@ -239,7 +240,7 @@ class GaudiRun(IPrepareApp):
         except:
             raise GangaException("This makes no sense without first belonging to a job object as I can't assign input data!")
 
-        if job.inputdata:
+        if job.inputdata is not None and len(job.inputdata) > 0:
             logger.warning("Warning Job %s already contained inputdata, overwriting" % job.fqid)
 
         job.inputdata = input_dataset

--- a/python/GangaLHCb/Lib/GaudiRunApp/GaudiRunAppUtils.py
+++ b/python/GangaLHCb/Lib/GaudiRunApp/GaudiRunAppUtils.py
@@ -1,0 +1,73 @@
+import subprocess
+import time
+from Ganga.Core.exceptions import GangaException
+from GangaLHCb.Lib.Applications import PythonOptionsParser
+
+def readInputData(optsfiles, app):
+    '''Returns a LHCbDataSet object from a list of options files. The
+       optional argument extraopts will decide if the extraopts string inside
+       the application is considered or not.
+
+    Usage example:
+    # Get the data from an options file and assign it to the jobs inputdata field
+    j.inputdata = readInputData([\"~/cmtuser/DaVinci_v22r0p2/Tutorial/Analysis/options/Bs2JpsiPhi2008.py\"], j.application)
+
+    This is also called behind the scenes for j.readInputData([\"~/cmtuser/DaVinci_v22r0p2/Tutorial/Analysis/options/Bs2JpsiPhi2008.py\"])
+
+    '''
+    if not isinstance(optsfiles, []):
+        optsfiles = [optsfiles]
+
+    # use a dummy file to keep the parser happy
+    if len(optsfiles) == 0:
+        raise GangaException("Need a file to parse to call this method")
+
+    try:
+        parser = PythonOptsCmakeParser(optsfiles, app)
+    except Exception as err:
+        msg = 'Unable to parse the job options. Please check options files and extraopts.'
+        logger.error("PythonOptionsParserError:\n%s" % str(err))
+        raise ApplicationConfigurationError(None, msg)
+
+    return parser.get_input_data()
+
+exportToGPI('GetGaudiRunInputData', readInputData, 'Functions')
+
+def prepare_cmake_app(myApp, myVer, myPath='$HOME/cmtuser', myGetpack=None):
+    """
+        Short helper function for setting up minimal application environments on disk for job submission
+        Args:
+            myApp (str): This is the name of the app to pass to lb-dev
+            myVer (str): This is the version of 'myApp' to pass tp lb-dev
+            myPath (str): This is where lb-dev will be run
+            myGepPack (str): This is a getpack which will be run once the lb-dev has executed
+    """
+    full_path = expandfilename(myPath, True)
+    if not path.exists(full_path):
+        makedirs(full_path)
+        chdir(full_path)
+    _exec_cmd('lb-dev %s %s' % (myApp, myVer), full_path)
+    logger.info("Set up App Env at: %s" % full_path)
+    if myGetpack:
+        dev_dir = path.join(full_path, myApp + 'Dev_' + myVer)
+        _exec_cmd('getpack %s' % myGetpack, dev_dir)
+        logger.info("Ran Getpack: %s" % myGetpack)
+
+exportToGPI('prepare_cmake_app', prepare_cmake_app, 'Functions')
+
+def _exec_cmd(cmd, cwdir):
+    """
+        This is taken from the code which runs SetupProject
+        TODO: Replace me with a correct call to execute once the return code is known to work
+
+        Args:
+            cmd (str): This is the full command which is to be executed
+            cwdir (str): The folder the command is to be run in
+    """
+    pipe = subprocess.Popen(cmd, shell=True, env=None, cwd=cwdir,
+                            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout, stderr = pipe.communicate()
+    while pipe.poll() is None:
+        time.sleep(0.5)
+    return pipe.returncode, stdout, stderr
+

--- a/python/GangaLHCb/Lib/GaudiRunApp/GaudiRunAppUtils.py
+++ b/python/GangaLHCb/Lib/GaudiRunApp/GaudiRunAppUtils.py
@@ -1,7 +1,12 @@
 import subprocess
 import time
 from Ganga.Core.exceptions import GangaException
-from GangaLHCb.Lib.Applications import PythonOptionsParser
+from Ganga.Runtime.GPIexport import exportToGPI
+from Ganga.Utility.logging import getLogger
+from Ganga.Core.exceptions import ApplicationConfigurationError
+from .PythonOptsCmakeParser import PythonOptsCmakeParser
+
+logger = getLogger()
 
 def readInputData(optsfiles, app):
     '''Returns a LHCbDataSet object from a list of options files. The
@@ -15,7 +20,7 @@ def readInputData(optsfiles, app):
     This is also called behind the scenes for j.readInputData([\"~/cmtuser/DaVinci_v22r0p2/Tutorial/Analysis/options/Bs2JpsiPhi2008.py\"])
 
     '''
-    if not isinstance(optsfiles, []):
+    if not isinstance(optsfiles, list):
         optsfiles = [optsfiles]
 
     # use a dummy file to keep the parser happy
@@ -26,7 +31,7 @@ def readInputData(optsfiles, app):
         parser = PythonOptsCmakeParser(optsfiles, app)
     except Exception as err:
         msg = 'Unable to parse the job options. Please check options files and extraopts.'
-        logger.error("PythonOptionsParserError:\n%s" % str(err))
+        logger.error("PythonOptsCmakeParserError:\n%s" % str(err))
         raise ApplicationConfigurationError(None, msg)
 
     return parser.get_input_data()

--- a/python/GangaLHCb/Lib/GaudiRunApp/PythonOptsCmakeParser.py
+++ b/python/GangaLHCb/Lib/GaudiRunApp/PythonOptsCmakeParser.py
@@ -4,6 +4,7 @@ from Ganga.GPIDev.Lib.File import LocalFile
 import Ganga.Utility.logging
 from GangaLHCb.Lib.LHCbDataset import LHCbDataset
 from Ganga.Core import ApplicationConfigurationError
+from Ganga.Utility.files import expandfilename
 logger = Ganga.Utility.logging.getLogger()
 
 def readInputData(optsfiles, app):
@@ -27,9 +28,10 @@ def readInputData(optsfiles, app):
     try:
         parser = PythonOptsCmakeParser(optsfiles, app)
     except Exception as err:
-         msg = 'Unable to parse the job options. Please check options files and extraopts.'
+        msg = 'Unable to parse the job options. Please check options files and extraopts.'
         logger.error("PythonOptionsParserError:\n%s" % str(err))
-        raise ApplicationConfigurationError(None, msg)
+        #raise ApplicationConfigurationError(None, msg)
+        raise
 
     return parser.get_input_data()
 
@@ -121,8 +123,8 @@ class PythonOptsCmakeParser(object):
             opts_input = self.opts_dict['EventSelector']['Input']
             data = [f for f in opts_input]
         except KeyError as err:
-            logger.debug('No inputdata has been defined in the options file.')
-            logger.debug("%s" % str(err))
+            logger.error('No inputdata has been defined in the options file.')
+            logger.error("%s" % str(err))
 
         from Ganga.GPIDev.Base.Filters import allComponentFilters
         file_filter = allComponentFilters['gangafiles']

--- a/python/GangaLHCb/Lib/GaudiRunApp/PythonOptsCmakeParser.py
+++ b/python/GangaLHCb/Lib/GaudiRunApp/PythonOptsCmakeParser.py
@@ -1,0 +1,151 @@
+import os.path
+import tempfile
+from Ganga.GPIDev.Lib.File import LocalFile
+import Ganga.Utility.logging
+from GangaLHCb.Lib.LHCbDataset import LHCbDataset
+from Ganga.Core import ApplicationConfigurationError
+logger = Ganga.Utility.logging.getLogger()
+
+def readInputData(optsfiles, app):
+    '''Returns a LHCbDataSet object from a list of options files. The
+       optional argument extraopts will decide if the extraopts string inside
+       the application is considered or not.
+
+       Usage examples:
+       # Create an LHCbDataset object with the data found in the optionsfile
+       l=DaVinci(version='v22r0p2').readInputData([\"~/cmtuser/DaVinci_v22r0p2/Tutorial/Analysis/options/Bs2JpsiPhi2008.py\"])
+       # Get the data from an options file and assign it to the jobs inputdata field
+       j.inputdata = j.application.readInputData([\"~/cmtuser/DaVinci_v22r0p2/Tutorial/Analysis/options/Bs2JpsiPhi2008.py\"])
+
+    '''
+    if not isinstance(optsfiles, []):
+        optsfiles = [optsfiles]
+
+    if len(optsfiles) == 0:
+        raise ApplicationConfigurationError(None, "Need a file to parse to call this method")
+
+    try:
+        parser = PythonOptsCmakeParser(optsfiles, app)
+    except Exception as err:
+         msg = 'Unable to parse the job options. Please check options files and extraopts.'
+        logger.error("PythonOptionsParserError:\n%s" % str(err))
+        raise ApplicationConfigurationError(None, msg)
+
+    return parser.get_input_data()
+
+## Due to a bug in Gaudi at some point we need this equivalence here: see #204
+DataObjectDescriptorCollection = str
+
+class PythonOptsCmakeParser(object):
+
+    """ Parses job options file(s) w/ gaudirun.py to extract user's files
+    Uses gaudirun.py to parse the job options file to allow for easy extraction
+    of inputdata, outputdata and output files."""
+
+    def __init__(self, optsfiles, app):
+        self.optsfiles = optsfiles
+        self.app = app
+        self.opts_dict, self.opts_pkl_str = self._get_opts_dict_and_pkl_string()
+
+    def _get_opts_dict_and_pkl_string(self):
+        '''Parse the options using gaudirun.py and create a dictionary of the
+        configuration and pickle the options. The app handler will make a copy
+        of the .pkl file for each job.'''
+
+        logger.info("Started parsing input Data file")
+
+        tmp_pkl = tempfile.NamedTemporaryFile(suffix='.pkl')
+        tmp_py = tempfile.NamedTemporaryFile(suffix='.py')
+        py_opts = tempfile.NamedTemporaryFile(suffix='.py')
+        py_opts.write(self._join_opts_files())
+        py_opts.flush()
+
+        gaudirun = 'gaudirun.py -n -v -o %s %s' % (tmp_py.name, py_opts.name)
+        opts_str = ''
+        err_msg = ''
+        options = {}
+
+        rc, stdout, m = self.app.exec_cmd(gaudirun)
+
+        if stdout.find('Gaudi.py') >= 0:
+            msg = 'The version of gaudirun.py required for your application is not supported.'
+            raise ValueError(None, msg)
+
+        elif stdout.find('no such option: -o') >= 0:
+            gaudirun = 'gaudirun.py -n -v -p %s %s' % (tmp_pkl.name, py_opts.name)
+            rc, stdout, m = self.app.exec_cmd(gaudirun)
+            rc = 0
+
+            if stdout and rc == 0:
+                opts_str = stdout
+                err_msg = 'Please check %s -v %s' % (cmdbase, py_opts.name)
+                err_msg += ' returns valid python syntax'
+
+        else:
+            cmd = 'gaudirun.py -n -p %s %s' % (tmp_pkl.name, py_opts.name)
+            rc, stdout, m = self.app.exec_cmd(cmd)
+            if rc == 0 and stdout:
+                opts_str = tmp_py.read()
+                err_msg = 'Please check gaudirun.py -o file.py produces a valid python file.'
+
+        if stdout and rc == 0:
+            try:
+                options = eval(opts_str)
+            except Exception as err:
+                logger.error('Cannot eval() the options file. Exception: %s', err)
+                from traceback import print_exc
+                logger.error(' ', print_exc())
+                raise ApplicationConfigurationError(None, stdout + '###SPLIT###' + m)
+            try:
+                opts_pkl_string = tmp_pkl.read()
+            except IOError as err:
+                logger.error('Cannot read() the temporary pickle file: %s', tmp_pkl.name)
+                raise err
+
+        if not rc == 0:
+            logger.debug('Failed to run: %s', gaudirun)
+            raise ApplicationConfigurationError(None, stdout + '###SPLIT###' + m)
+
+        tmp_pkl.close()
+        py_opts.close()
+        tmp_py.close()
+
+        logger.info("Finished parsing input Data file")
+
+        return (options, opts_pkl_string)
+
+    def get_input_data(self):
+        '''Collects the user specified input data that the job will process'''
+        data = []
+        try:
+            opts_input = self.opts_dict['EventSelector']['Input']
+            data = [f for f in opts_input]
+        except KeyError as err:
+            logger.debug('No inputdata has been defined in the options file.')
+            logger.debug("%s" % str(err))
+
+        from Ganga.GPIDev.Base.Filters import allComponentFilters
+        file_filter = allComponentFilters['gangafiles']
+
+        all_files = []
+        for d in data:
+            p1 = d.find('DATAFILE=') + len('DATAFILE=')
+            quote = d[p1]
+            p2 = d.find(quote, p1 + 1)
+            f = d[p1 + 1:p2]
+            this_file = file_filter(f, None)
+            if this_file is None:
+                this_file = LocalFile(name=f)
+            all_files.append(this_file)
+
+        ds = LHCbDataset(files=all_files, fromRef=True)
+        return ds
+
+    def _join_opts_files(self):
+        '''Create a single options file from all supplied options.'''
+        joined_py_opts = ''
+        for name in self.optsfiles:
+            with open(expandfilename(name), 'r') as this_file:
+                joined_py_opts += this_file.read()
+        return joined_py_opts
+


### PR DESCRIPTION
This PR adds the readInputData functionality into the GaudiRun app...

I was a little surprised at first but this appears to be a very quick thing to do so I think I see some appeal in addition to the LHCb users getting their datasets from bookkeeping this way.

I based this heavily on the equivalent code in the old-style LHCb apps but added some changes to make this more 'cmake'-like. This still uses gaudirun to pickle a file and such as before.

Once the test here passes I'll merge this PR and do some additional testing before looking into making a beta release to LHCb.
(I think I've spotted a bug in LHCbDataset I'd like to make 100% sure doesn't go out into testing as it would be quite annoying)