### PR TITLE
Stopping filenames getting excessively long

### DIFF
--- a/python/Ganga/Core/GangaRepository/GangaRepositoryXML.py
+++ b/python/Ganga/Core/GangaRepository/GangaRepositoryXML.py
@@ -129,9 +129,12 @@ def rmrf(name, count=0):
     if os.path.isdir(name):
 
         try:
-            remove_name = name + "_" + str(time.time()) + '__to_be_deleted_'
-            os.rename(name, remove_name)
-            #logger.debug("Move completed")
+            if not remove_name.endswith('__to_be_deleted'):
+                remove_name = name + "_" + str(time.time()) + '__to_be_deleted_'
+                os.rename(name, remove_name)
+                #logger.debug("Move completed")
+            else:
+                remove_name = name
         except OSError as err:
             if err.errno != errno.ENOENT:
                 logger.debug("rmrf Err: %s" % err)

--- a/python/Ganga/Core/GangaRepository/GangaRepositoryXML.py
+++ b/python/Ganga/Core/GangaRepository/GangaRepositoryXML.py
@@ -129,12 +129,11 @@ def rmrf(name, count=0):
     if os.path.isdir(name):
 
         try:
+            remove_name = name
             if not remove_name.endswith('__to_be_deleted'):
                 remove_name = name + "_" + str(time.time()) + '__to_be_deleted_'
                 os.rename(name, remove_name)
                 #logger.debug("Move completed")
-            else:
-                remove_name = name
         except OSError as err:
             if err.errno != errno.ENOENT:
                 logger.debug("rmrf Err: %s" % err)


### PR DESCRIPTION
This PR just stops the rmrf method from renaming a file which is to be deleted too many times.

Files here are moved and then deleted due to some problems with AFS lockfiles so that any folders which can't be deleted due to a stray lock file won't get in the way in the XML repo in the future.