### PR TITLE
Bugfix/fixing config bug

### DIFF
--- a/python/Ganga/Utility/Config/Config.py
+++ b/python/Ganga/Utility/Config/Config.py
@@ -198,7 +198,7 @@ def getConfig(name, create=True):
         return allConfigs[name]
     else:
         if create:
-            logger.debug('Creating "%s" config in getConfig', name)
+            logger.warning('Creating "%s" config in getConfig', name)
             allConfigs[name] = PackageConfig(name, 'Documentation not available')
             return allConfigs[name]
         else:
@@ -283,6 +283,9 @@ class ConfigOption(object):
 
     def setSessionValue(self, session_value):
 
+        if not hasattr(self, 'docstring'):
+            raise ConfigError('Can\'t set a session value without a docstring!')
+
         self.setModified(True)
 
         # try:
@@ -307,6 +310,9 @@ class ConfigOption(object):
         self.convert_type('session_value')
 
     def setUserValue(self, user_value):
+
+        if not hasattr(self, 'docstring'):
+            raise ConfigError('Can\'t set a user value without a docstring!')
 
         self.setModified(True)
         try:

--- a/python/GangaLHCb/__init__.py
+++ b/python/GangaLHCb/__init__.py
@@ -134,7 +134,7 @@ def loadPlugins(config=None):
 def postBootstrapHook():
     configDirac = Ganga.Utility.Config.getConfig('DIRAC')
     configOutput = Ganga.Utility.Config.getConfig('Output')
-    configPoll = Ganga.Utility.Config.getConfig('Poll')
+    configPoll = Ganga.Utility.Config.getConfig('PollThread')
     
     configDirac.setSessionValue('DiracEnvJSON', os.environ['GANGADIRACENVIRONMENT'])
     configDirac.setSessionValue('userVO', 'lhcb')


### PR DESCRIPTION
There is an annoying bug in the Config system which allows for a config item to be initialized and edited before it's defined. This _will_ and does cause strange errors elsewhere and needs to be fixed.

There was a bug in the LHCb config which causes this to occur but it should be handled better in the Config system rather than causing strange crashes elsewhere.