### PR TITLE
Reverting to debug

### DIFF
--- a/python/Ganga/Utility/Config/Config.py
+++ b/python/Ganga/Utility/Config/Config.py
@@ -198,7 +198,7 @@ def getConfig(name, create=True):
         return allConfigs[name]
     else:
         if create:
-            logger.warning('Creating "%s" config in getConfig', name)
+            logger.debug('Creating "%s" config in getConfig', name)
             allConfigs[name] = PackageConfig(name, 'Documentation not available')
             return allConfigs[name]
         else:


### PR DESCRIPTION
Reverting a warning to debug as it spams LHCb users a bit on opening a new repo with warnings which don't effect the use of Ganga