### PR TITLE
removing bad option on lhcb-prepare (docs)

### DIFF
--- a/doc/UserGuide/InstallAndBasicUsage.rst
+++ b/doc/UserGuide/InstallAndBasicUsage.rst
@@ -77,17 +77,17 @@ To install locally run one of the following:
 * For the official Ganga releases:
 .. code-block:: bash
 
-        ./lhcb-prepare -v v601r14
+        ./lhcb-prepare v601r14
 
 * For an 'in development' release:
 .. code-block:: bash
 
-        ./lhcb-prepare -v -p v601r15
+        ./lhcb-prepare -p v601r15
 
 * To keep the git history of the project so that you can develop patches and branches etc:
 .. code-block:: bash
 
-        ./lhcb-prepare -k -t -v v601r15
+        ./lhcb-prepare -k -t v601r15
 
 You now have Ganga installed in ``$HOME/cmtuser/GANGA/GANGA_v601r15``
 


### PR DESCRIPTION
removing the -v lines on lhcb-prepare

Waiting on the test to  finish which gets in the way of editing docs on the fly

Should we consider putting the docs in a second repo so that people can contribute to them in a much more informal way because collecting things for a PR and then re-testing Ganga is a bit overkill for submitting changes at the level of typos to the docs. This is the advantages of wiki's etc...