### PR TITLE
Make test external

### DIFF
--- a/python/Ganga/Utility/Config/Config.py
+++ b/python/Ganga/Utility/Config/Config.py
@@ -198,7 +198,7 @@ def getConfig(name, create=True):
         return allConfigs[name]
     else:
         if create:
-            logger.warning('Creating "%s" config in getConfig', name)
+            logger.debug('Creating "%s" config in getConfig', name)
             allConfigs[name] = PackageConfig(name, 'Documentation not available')
             return allConfigs[name]
         else:

--- a/python/GangaLHCb/test/GPI/TestSubmitLocal.py
+++ b/python/GangaLHCb/test/GPI/TestSubmitLocal.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from Ganga.testlib.mark import external
 import pytest
 
 from Ganga.testlib.GangaUnitTest import GangaUnitTest

--- a/python/GangaLHCb/test/GPI/TestSubmitLocal.py
+++ b/python/GangaLHCb/test/GPI/TestSubmitLocal.py
@@ -6,6 +6,9 @@ from Ganga.testlib.GangaUnitTest import GangaUnitTest
 
 class TestJob(GangaUnitTest):
 
+    # Adding this locally puts us in a state where we're vulnerable to LHCb projects having problems
+    # This is not good from a test perspective! making it external for now until we sort out what's going on
+    @external
     def testSubmitLocal(self):
         from Ganga.GPI import DaVinci, Job, TestSubmitter, JobError
         from GangaLHCb.testlib import addLocalTestSubmitter


### PR DESCRIPTION
Making LHCb test external as it's vulnerable to `SetupProject DaVinci` failing. We cannot demand this tests pass in this case.