### PR TITLE
Moving to use ._inMemory everywhere for tracking object loaded state

### DIFF
--- a/python/Ganga/Core/GangaRepository/GangaRepository.py
+++ b/python/Ganga/Core/GangaRepository/GangaRepository.py
@@ -134,14 +134,6 @@ class GangaRepository(object):
         """
         pass
 
-    def isObjectLoaded(self, obj):
-        """
-        Returns if an object is loaded into memory
-        Args:
-            obj (GangaObject): object we want to know if it's in memory or not
-        """
-        raise NotImplementedError
-
 
 # Optional but suggested functions
     def get_lock_session(self, id):
@@ -301,12 +293,4 @@ class GangaRepositoryTransient(object):
             ids (list): The object keys which we want to iterate over from the objects dict
         """
         pass
-
-    def isObjectLoaded(self, obj):
-        """
-        Returns if an object is loaded into memory
-        Args:
-            obj (GangaObject): object we want to know if it's in memory or not
-        """
-        return True
 

--- a/python/Ganga/Core/GangaRepository/GangaRepositorySQLite.py
+++ b/python/Ganga/Core/GangaRepository/GangaRepositorySQLite.py
@@ -27,7 +27,6 @@ class GangaRepositorySQLite(GangaRepository):
         """ Starts an repository and reads in a directory structure."""
         self._load_timestamp = {}
         self._cache_load_timestamp = {}
-        self._fully_loaded = {}
         self.known_bad_ids = []
         self.root = os.path.join(
             self.registry.location, "0.1", self.registry.name)
@@ -131,11 +130,11 @@ class GangaRepositorySQLite(GangaRepository):
                 obj = self._make_empty_object_(_id, e[2], e[1])
             else:
                 obj = self.objects[_id]
-            if _id not in self._fully_loaded:
+            if not self.objects[_id]._inMemory:
                 new_data = pickle.loads(e[3])
                 for k, v in new_data:
                     setattr(obj, k, v)
-            self._fully_loaded[_id] = obj
+            self.objects[_id]._inMemory = True
             ids.remove(_id)
         if len(ids) > 0:
             raise KeyError(ids[0])

--- a/python/Ganga/Core/GangaRepository/GangaRepositoryXML.py
+++ b/python/Ganga/Core/GangaRepository/GangaRepositoryXML.py
@@ -202,7 +202,6 @@ class GangaRepositoryLocal(GangaRepository):
         self.saved_idxpaths = {}
         self._cache_load_timestamp = {}
         self.printed_explanation = False
-        self._fully_loaded = {}
 
     def startup(self):
         """ Starts a repository and reads in a directory structure.
@@ -239,8 +238,9 @@ class GangaRepositoryLocal(GangaRepository):
         from Ganga.Utility.logging import getLogger
         logger = getLogger()
         logger.debug("Shutting Down GangaRepositoryLocal: %s" % self.registry.name)
-        for k in self._fully_loaded:
-            self.index_write(k, shutdown=True)
+        for k in self.objects:
+            if self.objects[k]._inMemory:
+                self.index_write(k, shutdown=True)
         self._write_master_cache(True)
         self.sessionlock.shutdown()
 
@@ -431,7 +431,7 @@ class GangaRepositoryLocal(GangaRepository):
                 if k in self.incomplete_objects:
                     continue
                 try:
-                    if k in self._fully_loaded:
+                    if v._inMemory:
                         # Check and write index first
                         obj = v#self.objects[k]
                         new_index = None
@@ -563,7 +563,7 @@ class GangaRepositoryLocal(GangaRepository):
                         if this_id not in self.incomplete_objects:
                             # If object is loaded mark it dirty so next flush will regenerate XML,
                             # otherwise just go about fixing it
-                            if not self.isObjectLoaded(self.objects[this_id]):
+                            if this_id not in self.objects or not self.objects[this_id]._inMemory:
                                 self.index_write(this_id)
                             else:
                                 self.objects[this_id]._setDirty()
@@ -645,7 +645,6 @@ class GangaRepositoryLocal(GangaRepository):
                     raise RepositoryError( self, "OSError on mkdir: %s" % (e))
 
             self._internal_setitem__(ids[i], objs[i])
-            self._fully_loaded[ids[i]] = objs[i]
             objs[i]._inMemory = True
 
             # Set subjobs dirty - they will not be flushed if they are not.
@@ -738,14 +737,13 @@ class GangaRepositoryLocal(GangaRepository):
         else:
             raise RepositoryError(self, "Cannot flush an Empty object for ID: %s" % this_id)
 
-        if this_id not in self._fully_loaded:
-            self._fully_loaded[this_id] = obj
+        if not obj._inMemory:
             obj._inMemory = True
 
     def flush(self, ids):
         """
         flush the set of "ids" to disk and write the XML representing said objects in self.objects
-        NB: This adds the given objects corresponding to ids to the _fully_loaded dict
+        NB: This sets the _inMemory attribute to GangaObjects
         Args:
             ids (list): List of integers, used as keys to objects in the self.objects dict
         """
@@ -772,8 +770,7 @@ class GangaRepositoryLocal(GangaRepository):
                     logger.debug("Index write failed")
                     pass
 
-                if this_id not in self._fully_loaded:
-                    self._fully_loaded[this_id] = self.objects[this_id]
+                if not self.objects[this_id]._inMemory:
                     self.objects[this_id]._inMemory = True
 
                 subobj_attr = getattr(self.objects[this_id], self.sub_split, None)
@@ -824,7 +821,7 @@ class GangaRepositoryLocal(GangaRepository):
             if len(self.lock([this_id])) != 0:
                 if this_id not in self.incomplete_objects:
                     # Mark as dirty if loaded, otherwise load and fix
-                    if not self.isObjectLoaded(self.objects[this_id]):
+                    if not self.objects[this_id]._inMemory:
                         self.index_write(this_id)
                     else:
                         self.objects[this_id]._setDirty()
@@ -899,8 +896,7 @@ class GangaRepositoryLocal(GangaRepository):
 
         obj._index_cache = {}
 
-        if this_id not in self._fully_loaded:
-            self._fully_loaded[this_id] = obj
+        if not obj._inMemory:
             obj._inMemory = True
 
     def _actually_load_xml(self, fobj, fn, this_id, load_backup):
@@ -1125,10 +1121,9 @@ class GangaRepositoryLocal(GangaRepository):
                 logger.debug("Delete Error: %s" % err)
             self._internal_del__(this_id)
             rmrf(os.path.dirname(fn))
-            if this_id in self._fully_loaded:
-                self._fully_loaded[this_id]._inMemory = False
-                del self._fully_loaded[this_id]
             if this_id in self.objects:
+                if self.objects[this_id]._inMemory:
+                    self.objects[this_id]._inMemory = False
                 del self.objects[this_id]
 
     def lock(self, ids):
@@ -1179,15 +1174,4 @@ class GangaRepositoryLocal(GangaRepository):
         rmrf(self.root)
         self.startup()
 
-    def isObjectLoaded(self, obj):
-        """
-        This will return a true false if an object has been fully loaded into memory
-        Args:
-            obj (GangaObject): The object we want to know if it was loaded into memory
-        """
-        try:
-            _id = next(id_ for id_, o in self._fully_loaded.items() if o is obj)
-            return True
-        except StopIteration:
-            return False
 

--- a/python/Ganga/Core/GangaRepository/Registry.py
+++ b/python/Ganga/Core/GangaRepository/Registry.py
@@ -886,6 +886,7 @@ class Registry(object):
         self.changed_ids[name] = set()
         return res
 
+    @synchronised
     def getIndexCache(self, obj):
         """Returns a dictionary to be put into obj._index_cache (is this valid)
         This can and should be overwritten by derived Registries to provide more index values."""

--- a/python/Ganga/Core/GangaRepository/Registry.py
+++ b/python/Ganga/Core/GangaRepository/Registry.py
@@ -305,11 +305,11 @@ class Registry(object):
         while this_id in self._inprogressDict:
             logger.debug("Getting item being operated on: %s" % this_id)
             logger.debug("Currently in state: %s" % self._inprogressDict[this_id])
-            import traceback
-            traceback.print_stack()
-            import sys
-            sys.exit(-1)
-            #time.sleep(0.05)
+            #import traceback
+            #traceback.print_stack()
+            #import sys
+            #sys.exit(-1)
+            time.sleep(0.1)
         self._inprogressDict[this_id] = action
         if this_id not in self.hard_lock:
             self.hard_lock[this_id] = threading.Lock()

--- a/python/Ganga/Core/GangaRepository/SubJobXMLList.py
+++ b/python/Ganga/Core/GangaRepository/SubJobXMLList.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from Ganga.GPIDev.Schema.Schema import Schema, SimpleItem, Version
 from Ganga.GPIDev.Base.Objects import GangaObject
 from Ganga.Utility.logging import getLogger
@@ -337,12 +338,12 @@ class SubJobXMLList(GangaObject):
         #print("\n\n\n")
         #import sys
         #sys.exit(-1)
-        job_obj = self.getSafeJob()
-        if job_obj is not None:
-            fqid = self.getMasterID()
-            logger.debug( "Loading subjob at: %s for job %s" % (subjob_data, fqid) )
-        else:
-            logger.debug( "Loading subjob at: %s" % subjob_data )
+        #job_obj = self.getSafeJob()
+        #if job_obj is not None:
+        #    fqid = self.getMasterID()
+        #    logger.debug( "Loading subjob at: %s for job %s" % (subjob_data, fqid) )
+        #else:
+        #    logger.debug( "Loading subjob at: %s" % subjob_data )
         sj_file = open(subjob_data, "r")
         return sj_file
 

--- a/python/Ganga/GPIDev/Base/Objects.py
+++ b/python/Ganga/GPIDev/Base/Objects.py
@@ -260,8 +260,8 @@ def synchronised_set_descriptor(set_function):
         if obj is None:
             return set_function(self, obj, type_or_value)
 
-        with obj.const_lock:
-            with obj._read_lock:
+        with obj._read_lock:
+            with obj.const_lock:
                 return set_function(self, obj, type_or_value)
     return decorated
 
@@ -348,10 +348,9 @@ class Descriptor(object):
         # Since we couldn't find the information in the cache, we will need to fully load the object
 
         # Guarantee that the object is now loaded from disk
-        if not self._inMemory:
-            reg = obj._getRegistry()
-            if reg:
-                reg._load([self.id])
+        reg = obj._getRegistry()
+        if reg:
+            reg._load([obj._id])
 
         # If we've loaded from disk then the data dict has changed. If we're constructing an object
         # then we need to rely on the factory

--- a/python/Ganga/GPIDev/Base/Objects.py
+++ b/python/Ganga/GPIDev/Base/Objects.py
@@ -1114,7 +1114,7 @@ class GangaObject(Node):
     @synchronised
     def _setFlushed(self):
         """Un-Set the dirty flag all of the way down the schema."""
-        for k in self._data.keys():
+        for k in self._schema.allItemNames():
             ## Avoid attributes the likes of job.master which crawl back up the tree
             properties = self._schema[k].getProperties()
             if not properties['visitable'] or properties['transient']:

--- a/python/Ganga/GPIDev/Base/Objects.py
+++ b/python/Ganga/GPIDev/Base/Objects.py
@@ -112,13 +112,15 @@ class Node(object):
         # type: () -> Node
         return self._parent
 
-    @synchronised  # This will lock the _current_ (soon to be _old_) root object
+    #@synchronised  # This will lock the _current_ (soon to be _old_) root object
     def _setParent(self, parent):
         """
         This sets the parent of this Node to be a new object
         Args:
             parent (GangaObject): This is the GangaObject to be taken as the objects new parent
         """
+        setattr(self, '_parent', parent)
+        return
         # type: (Node) -> None
         if parent is None:
             setattr(self, '_parent', parent)

--- a/python/Ganga/GPIDev/Base/Objects.py
+++ b/python/Ganga/GPIDev/Base/Objects.py
@@ -47,7 +47,7 @@ logger = getLogger(modulename=1)
 
 _imported_GangaList = None
 
-do_not_copy = ['_index_cache_dict', '_parent', '_registry', '_data', '_read_lock', '_write_lock', '_proxyObject']
+do_not_copy = ['_index_cache_dict', '_parent', '_registry', '_data', '_const_lock', '_proxyObject']
 
 def _getGangaList():
     """
@@ -84,13 +84,12 @@ class Node(object):
     thread-safe usage.
     """
     __metaclass__ = abc.ABCMeta
-    __slots__ = ('_parent', '_read_lock', '_write_lock', '_dirty')
+    __slots__ = ('_parent', '_const_lock', '_dirty')
 
     def __init__(self, parent=None):
         super(Node, self).__init__()
         self._parent = parent
-        self._read_lock = threading.RLock()  # Don't read out of thread whilst we're making a change
-        self._write_lock = threading.RLock()  # Don't write from out of thread when modifying an object
+        self._const_lock = threading.RLock()  # Don't write from out of thread when modifying an object
         self._dirty = False  # dirty flag is true if the object has been modified locally and its contents is out-of-sync with its repository
 
     def __deepcopy__(self, memo=None):
@@ -112,15 +111,13 @@ class Node(object):
         # type: () -> Node
         return self._parent
 
-    #@synchronised  # This will lock the _current_ (soon to be _old_) root object
+    @synchronised  # This will lock the _current_ (soon to be _old_) root object
     def _setParent(self, parent):
         """
         This sets the parent of this Node to be a new object
         Args:
             parent (GangaObject): This is the GangaObject to be taken as the objects new parent
         """
-        setattr(self, '_parent', parent)
-        return
         # type: (Node) -> None
         if parent is None:
             setattr(self, '_parent', parent)
@@ -141,14 +138,11 @@ class Node(object):
         but changing them is not. Only one thread can hold this lock at once.
         """
         root = self._getRoot()
-        reg = root._getRegistry()
-        root._read_lock.acquire()
-        root._write_lock.acquire()
+        root._const_lock.acquire()
         try:
             yield
         finally:
-            root._write_lock.release()
-            root._read_lock.release()
+            root._const_lock.release()
 
     def _getRoot(self, cond=None):
         # type: () -> Node
@@ -235,24 +229,7 @@ class Node(object):
 ##########################################################################
 
 
-def synchronised_get_descriptor(get_function):
-    """
-    This decorator should only be used on ``__get__`` method of the ``Descriptor``.
-    Args:
-        get_function (function): Function we intend to wrap with the soft/read lock
-    """
-    @functools.wraps(get_function)
-    def decorated(self, obj, type_or_value):
-        if obj is None:
-            return get_function(self, obj, type_or_value)
-
-        with obj._read_lock:
-            return get_function(self, obj, type_or_value)
-
-    return decorated
-
-
-def synchronised_set_descriptor(set_function):
+def synchronised_descriptor(set_function):
     """
     This decorator should only be used on ``__set__`` method of the ``Descriptor``.
     Args:
@@ -262,9 +239,8 @@ def synchronised_set_descriptor(set_function):
         if obj is None:
             return set_function(self, obj, type_or_value)
 
-        with obj._read_lock:
-            with obj.const_lock:
-                return set_function(self, obj, type_or_value)
+        with obj.const_lock:
+            return set_function(self, obj, type_or_value)
     return decorated
 
 
@@ -310,7 +286,7 @@ class Descriptor(object):
         if self._getter_name:
             raise AttributeError('cannot modify or delete "%s" property (declared as "getter")' % _getName(self))
 
-    @synchronised_get_descriptor
+    @synchronised_descriptor
     def __get__(self, obj, cls):
         """
         Get method of Descriptor
@@ -465,7 +441,7 @@ class Descriptor(object):
 
         return v_copy
 
-    @synchronised_set_descriptor
+    @synchronised_descriptor
     def __set__(self, obj, val):
         """
         Set method

--- a/python/Ganga/GPIDev/Lib/Job/Job.py
+++ b/python/Ganga/GPIDev/Lib/Job/Job.py
@@ -58,9 +58,8 @@ def lazyLoadJobObject(raw_job, this_attr, do_eval=True):
 
     this_job = stripProxy(raw_job)
 
-    if this_job._getRegistry() is not None:
-        if this_job._getRegistry().has_loaded(this_job):
-            return getattr(this_job, this_attr)
+    if this_job._inMemory:
+        return getattr(this_job, this_attr)
 
     lzy_loading_str = 'display:'+ this_attr
     job_index_cache = this_job._index_cache

--- a/python/Ganga/GPIDev/Lib/Registry/JobRegistry.py
+++ b/python/Ganga/GPIDev/Lib/Registry/JobRegistry.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import
 from Ganga.Utility.external.OrderedDict import OrderedDict as oDict
 
 from Ganga.Core.exceptions import GangaException
-from Ganga.Core.GangaRepository.Registry import Registry, RegistryKeyError, RegistryAccessError, RegistryFlusher
+from Ganga.Core.GangaRepository.Registry import Registry, RegistryKeyError, RegistryAccessError, RegistryFlusher, synchronised
 
 from Ganga.GPIDev.Base.Proxy import stripProxy, isType, addProxy
 
@@ -41,6 +41,7 @@ class JobRegistry(Registry):
     def getProxy(self):
         return self.stored_proxy
 
+    @synchronised
     def getIndexCache(self, obj):
 
         cached_values = ['status', 'id', 'name']

--- a/python/Ganga/test/GPI/Internals/TestRepo.py
+++ b/python/Ganga/test/GPI/Internals/TestRepo.py
@@ -25,9 +25,6 @@ class FakeRegistry(object):
     def _dirty(self, obj):
         self.repo.flush([obj._registry_id])
 
-    def has_loaded(self, obj):
-        return True
-
 # def _dirty(self,obj):
 #        pass
 

--- a/python/Ganga/test/GPI/Loading/TestLazyLoading.py
+++ b/python/Ganga/test/GPI/Loading/TestLazyLoading.py
@@ -33,7 +33,7 @@ class TestLazyLoading(object):
 
         raw_j = stripProxy(j)
 
-        has_loaded_job = raw_j._getRegistry().has_loaded(raw_j)
+        has_loaded_job = raw_j._inMemory
 
         assert not has_loaded_job
 
@@ -51,7 +51,7 @@ class TestLazyLoading(object):
         # Any command to load a job can be used here
         raw_j.printSummaryTree()
 
-        has_loaded_job = raw_j._getRegistry().has_loaded(raw_j)
+        has_loaded_job = raw_j._inMemory
 
         assert has_loaded_job
 
@@ -62,19 +62,19 @@ class TestLazyLoading(object):
 
         raw_j = stripProxy(jobs(0))
 
-        assert not raw_j._getRegistry().has_loaded(raw_j)
+        assert not raw_j._inMemory
 
         dirty_status = raw_j._dirty
 
         assert not dirty_status
 
-        assert not raw_j._getRegistry().has_loaded(raw_j)
+        assert not raw_j._inMemory
 
         with pytest.raises(AttributeError):
             _ = jobs(0)._dirty
 
-        assert not raw_j._getRegistry().has_loaded(raw_j)
+        assert not raw_j._inMemory
 
         raw_j.printSummaryTree()
 
-        assert raw_j._getRegistry().has_loaded(raw_j)
+        assert raw_j._inMemory

--- a/python/Ganga/test/GPI/Loading/TestLazyLoadingManyJobs.py
+++ b/python/Ganga/test/GPI/Loading/TestLazyLoadingManyJobs.py
@@ -41,7 +41,7 @@ class TestLazyLoadingManyJobs(GangaUnitTest):
             if j.id != 9:
                 raw_j = stripProxy(j)
 
-                has_loaded_job = raw_j._getRegistry().has_loaded(raw_j)
+                has_loaded_job = raw_j._inMemory
 
                 self.assertFalse(has_loaded_job)
 
@@ -57,7 +57,7 @@ class TestLazyLoadingManyJobs(GangaUnitTest):
                 stat = lazyLoadJobStatus(raw_j)
                 fq = lazyLoadJobFQID(raw_j)
 
-                has_loaded_job = raw_j._getRegistry().has_loaded(raw_j)
+                has_loaded_job = raw_j._inMemory
 
                 self.assertFalse(has_loaded_job)
 
@@ -75,7 +75,7 @@ class TestLazyLoadingManyJobs(GangaUnitTest):
         ## ANY COMMAND TO LOAD A JOB CAN BE USED HERE
         raw_j.printSummaryTree()
 
-        has_loaded_job = raw_j._getRegistry().has_loaded(raw_j)
+        has_loaded_job = raw_j._inMemory
 
         self.assertTrue(has_loaded_job)
 

--- a/python/Ganga/test/GPI/Loading/TestLazyLoadingSubjobs.py
+++ b/python/Ganga/test/GPI/Loading/TestLazyLoadingSubjobs.py
@@ -44,7 +44,7 @@ class TestLazyLoadingSubjobs(GangaUnitTest):
         from Ganga.GPIDev.Base.Proxy import stripProxy
         raw_j = stripProxy(j)
 
-        has_loaded_job = raw_j._getRegistry().has_loaded(raw_j)
+        has_loaded_job = raw_j._inMemory
 
         self.assertFalse(has_loaded_job)
 
@@ -62,7 +62,7 @@ class TestLazyLoadingSubjobs(GangaUnitTest):
         ## ANY COMMAND TO LOAD A JOB CAN BE USED HERE
         raw_j.printSummaryTree()
 
-        has_loaded_job = raw_j._getRegistry().has_loaded(raw_j)
+        has_loaded_job = raw_j._inMemory
 
         for i in range(len(j.subjobs)):
             self.assertFalse(raw_j.subjobs.isLoaded(i))

--- a/python/Ganga/test/GPI/newXMLTest/TestNestedXMLWorking.py
+++ b/python/Ganga/test/GPI/newXMLTest/TestNestedXMLWorking.py
@@ -51,7 +51,7 @@ class TestNestedXMLWorking(GangaUnitTest):
         from Ganga.GPIDev.Base.Proxy import stripProxy
         raw_j = stripProxy(j)
 
-        has_loaded_job = raw_j._getRegistry().has_loaded(raw_j)
+        has_loaded_job = raw_j._inMemory
 
         assert not has_loaded_job
 
@@ -69,7 +69,7 @@ class TestNestedXMLWorking(GangaUnitTest):
         ## ANY COMMAND TO LOAD A JOB CAN BE USED HERE
         raw_j.printSummaryTree()
 
-        has_loaded_job = raw_j._getRegistry().has_loaded(raw_j)
+        has_loaded_job = raw_j._inMemory
 
         assert has_loaded_job
 


### PR DESCRIPTION
This is an extension of #584 which moves to make use of the `GangaObject._inMemory` boolean for tracking an objects loaded state (introduced in the former #PR)

This touches quite a few files so once I'm certain this works I can look at merging this into #584 ahead of merging that into develop.