### PR TITLE
Nicely disable LCG

### DIFF
--- a/python/Ganga/Lib/LCG/LCG.py
+++ b/python/Ganga/Lib/LCG/LCG.py
@@ -2120,6 +2120,10 @@ class LCGJobConfig(StandardJobConfig):
 
 logger.debug('LCG module initialization: begin')
 
+if config['GLITE_ENABLE'] and not config['VirtualOrganisation']:
+    logger.info('LCG config is not set. Please set [LCG]VirtualOrganisation to your VO (e.g. "gridpp") or disable LCG with [LCG]GLITE_ENABLE=False')
+    config.setSessionValue('GLITE_ENABLE', False)
+
 if config['GLITE_ENABLE']:
     active = Grid.check_proxy()
     config.setSessionValue('GLITE_ENABLE', active)

--- a/python/Ganga/__init__.py
+++ b/python/Ganga/__init__.py
@@ -314,7 +314,7 @@ lcg_config.addOption('GLITE_SETUP', '/afs/cern.ch/sw/ganga/install/config/grid_e
                  'sets the LCG-UI environment setup script for the GLITE middleware',
                  filter=Ganga.Utility.Config.expandvars)
 
-lcg_config.addOption('VirtualOrganisation', 'dteam',
+lcg_config.addOption('VirtualOrganisation', '',
                  'sets the name of the grid virtual organisation')
 
 lcg_config.addOption('ConfigVO', '', 'DEPRECATED sets the VO-specific LCG-UI configuration script for the EDG resource broker',


### PR DESCRIPTION
As we have discussed in the past, we want to be able to disable the LCG system by default without affecting anyone who is currently using it. This PR achieves this by changing the default `[LCG]VirtualOrganisation` to `''` and adding a check to only enable the LCG system if the VO has been set to *something*.

In any case, a default VO of `dteam` made little sense anyway.

I've labelled this for 6.1.22 but it could be brought forward to 6.1.21 if people wanted.