### PR TITLE
Add mocked tests for LCG and Grid submission

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "2.7"
 #  - "3.4"
 #  - "3.5"
-install: pip install -r requirements.txt
+install: pip install --upgrade -r requirements.txt
 script: python setup.py tests --type=unit --coverage
 before_install:
   - pip install codecov

--- a/python/Ganga/test/GPI/LCG/TestLCG.py
+++ b/python/Ganga/test/GPI/LCG/TestLCG.py
@@ -30,6 +30,10 @@ def test_job_kill(gpi):
 
 
 def test_submit_kill_resubmit(gpi):
+    """
+    Test that a simple submit-kill-resubmit-kill cycle works
+    """
+
     from Ganga.GPI import Job, LCG
     j = Job()
     j.backend = LCG()
@@ -54,6 +58,10 @@ def test_submit_kill_resubmit(gpi):
 
 
 def test_submit_monitor(gpi):
+    """
+    Test that an LCG job can be monitored
+    """
+
     from Ganga.GPI import Job, LCG
     j = Job()
     j.backend = LCG()

--- a/python/Ganga/test/GPI/LCG/TestLCG.py
+++ b/python/Ganga/test/GPI/LCG/TestLCG.py
@@ -1,3 +1,8 @@
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
+
 from Ganga.testlib.mark import external
 from Ganga.testlib.monitoring import run_until_completed
 
@@ -20,3 +25,24 @@ def test_job_kill(gpi):
     j.backend = LCG()
     j.submit()
     j.kill()
+
+
+def test_submit_kill_resubmit(gpi):
+    from Ganga.GPI import Job, LCG
+    j = Job()
+    j.backend = LCG()
+
+    with patch('Ganga.Lib.LCG.Grid.submit', return_value=42) as submit:
+        j.submit()
+        submit.assert_called_once()
+        assert j.backend.id == 42
+
+    with patch('Ganga.Lib.LCG.Grid.cancel', return_value=True) as cancel:
+        j.kill()
+        cancel.assert_called_once()
+        assert j.status == 'killed'
+
+    with patch('Ganga.Lib.LCG.Grid.submit', return_value=43) as submit:
+        j.resubmit()
+        submit.assert_called_once()
+        assert j.backend.id == 43

--- a/python/Ganga/test/GPI/LCG/TestLCG.py
+++ b/python/Ganga/test/GPI/LCG/TestLCG.py
@@ -49,6 +49,9 @@ def test_submit_kill_resubmit(gpi):
         submit.assert_called_once()
         assert j.backend.id == 'https://example.com:9000/43'
 
+    with patch('Ganga.Lib.LCG.Grid.cancel', return_value=True):
+        j.kill()
+
 
 def test_submit_monitor(gpi):
     from Ganga.GPI import Job, LCG
@@ -80,3 +83,6 @@ def test_submit_monitor(gpi):
     with patch('Ganga.Lib.LCG.Grid.status', side_effect=status_results) as status:
         stripProxy(j).backend.master_updateMonitoringInformation([stripProxy(j)])
         assert status.call_count == 2
+
+    with patch('Ganga.Lib.LCG.Grid.cancel', return_value=True):
+        j.kill()

--- a/python/Ganga/test/GPI/LCG/TestLCG.py
+++ b/python/Ganga/test/GPI/LCG/TestLCG.py
@@ -32,17 +32,17 @@ def test_submit_kill_resubmit(gpi):
     j = Job()
     j.backend = LCG()
 
-    with patch('Ganga.Lib.LCG.Grid.submit', return_value=42) as submit:
+    with patch('Ganga.Lib.LCG.Grid.submit', return_value='https://example.com:9000/42') as submit:
         j.submit()
         submit.assert_called_once()
-        assert j.backend.id == 42
+        assert j.backend.id == 'https://example.com:9000/42'
 
     with patch('Ganga.Lib.LCG.Grid.cancel', return_value=True) as cancel:
         j.kill()
         cancel.assert_called_once()
         assert j.status == 'killed'
 
-    with patch('Ganga.Lib.LCG.Grid.submit', return_value=43) as submit:
+    with patch('Ganga.Lib.LCG.Grid.submit', return_value='https://example.com:9000/43') as submit:
         j.resubmit()
         submit.assert_called_once()
-        assert j.backend.id == 43
+        assert j.backend.id == 'https://example.com:9000/43'

--- a/python/Ganga/test/Unit/LCG/TestGrid.py
+++ b/python/Ganga/test/Unit/LCG/TestGrid.py
@@ -1,0 +1,72 @@
+def test_submit_no_proxy(mocker):
+    """
+    Test that the lack of a proxy object causes the submit to fail
+    """
+    check_proxy = mocker.patch('Ganga.Lib.LCG.Grid.check_proxy', return_value=False)
+
+    from Ganga.Lib.LCG import Grid
+    job_url = Grid.submit('/some/path')
+
+    assert check_proxy.call_count == 1
+
+    assert job_url is None
+
+
+def test_submit_expired_proxy(mocker):
+    """
+    Test that an invalid proxy object causes the submit to fail
+    """
+    check_proxy = mocker.patch('Ganga.Lib.LCG.Grid.check_proxy', return_value=True)
+    credential = mocker.patch('Ganga.Lib.LCG.Grid.credential', return_value=mocker.MagicMock())
+    credential.return_value.isValid.return_value = False
+
+    from Ganga.Lib.LCG import Grid
+    job_url = Grid.submit('/some/path')
+
+    assert check_proxy.call_count == 1
+    assert credential.call_count == 1
+
+    assert job_url is None
+
+
+def test_submit_bad_output(mocker):
+    """
+    Test that the external command returning bad data causes the job to fail
+    """
+    check_proxy = mocker.patch('Ganga.Lib.LCG.Grid.check_proxy', return_value=True)
+    credential = mocker.patch('Ganga.Lib.LCG.Grid.credential', return_value=mocker.MagicMock())
+    credential.return_value.isValid.return_value = True
+    __set_submit_option__ = mocker.patch('Ganga.Lib.LCG.Grid.__set_submit_option__', return_value='  ')
+    cmd1 = mocker.patch('Ganga.Utility.GridShell.Shell.cmd1', return_value=(0, 'some bad output', False))
+
+    from Ganga.Lib.LCG import Grid
+    job_url = Grid.submit('/some/path')
+
+    assert check_proxy.call_count == 1
+    assert credential.call_count == 1
+    assert __set_submit_option__.call_count == 1
+    assert cmd1.call_count == 1
+
+    assert job_url is None
+
+
+def test_submit(mocker):
+    """
+    Test that a job submit succeeds with valid input
+    """
+    check_proxy = mocker.patch('Ganga.Lib.LCG.Grid.check_proxy', return_value=True)
+    credential = mocker.patch('Ganga.Lib.LCG.Grid.credential', return_value=mocker.MagicMock())
+    credential.return_value.isValid.return_value = True
+    __set_submit_option__ = mocker.patch('Ganga.Lib.LCG.Grid.__set_submit_option__', return_value='  ')
+    cmd1 = mocker.patch('Ganga.Utility.GridShell.Shell.cmd1', return_value=(0, 'https://example.com:9000/some_url', False))
+
+    from Ganga.Lib.LCG import Grid
+    job_url = Grid.submit('/some/path')
+
+    assert check_proxy.call_count == 1
+    assert credential.call_count == 1
+    assert __set_submit_option__.call_count == 1
+    assert cmd1.call_count == 1
+
+    assert '/some/path' in cmd1.call_args[0][0], 'JDL path was not passed correctly'
+    assert job_url == 'https://example.com:9000/some_url'

--- a/python/Ganga/test/Unit/LCG/TestGrid.py
+++ b/python/Ganga/test/Unit/LCG/TestGrid.py
@@ -1,3 +1,6 @@
+from Ganga.Utility.GridShell import Shell
+
+
 def test_submit_no_proxy(mocker):
     """
     Test that the lack of a proxy object causes the submit to fail
@@ -37,6 +40,7 @@ def test_submit_bad_output(mocker):
     credential = mocker.patch('Ganga.Lib.LCG.Grid.credential', return_value=mocker.MagicMock())
     credential.return_value.isValid.return_value = True
     __set_submit_option__ = mocker.patch('Ganga.Lib.LCG.Grid.__set_submit_option__', return_value='  ')
+    mocker.patch('Ganga.Lib.LCG.Grid.getShell', return_value=Shell)
     cmd1 = mocker.patch('Ganga.Utility.GridShell.Shell.cmd1', return_value=(0, 'some bad output', False))
 
     from Ganga.Lib.LCG import Grid
@@ -58,6 +62,7 @@ def test_submit(mocker):
     credential = mocker.patch('Ganga.Lib.LCG.Grid.credential', return_value=mocker.MagicMock())
     credential.return_value.isValid.return_value = True
     __set_submit_option__ = mocker.patch('Ganga.Lib.LCG.Grid.__set_submit_option__', return_value='  ')
+    mocker.patch('Ganga.Lib.LCG.Grid.getShell', return_value=Shell)
     cmd1 = mocker.patch('Ganga.Utility.GridShell.Shell.cmd1', return_value=(0, 'https://example.com:9000/some_url', False))
 
     from Ganga.Lib.LCG import Grid

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@
 
 pytest
 pytest-cov
+pytest-mock
 unittest2
 coverage
 pygments


### PR DESCRIPTION
This adds a number of tests for the LCG and Grid systems using the mock module to avoid communicating with any external systems. 

This builds on #619.