### PR TITLE
Getting rid of bad warning when it's simply not needed

### DIFF
--- a/python/Ganga/Utility/GridShell.py
+++ b/python/Ganga/Utility/GridShell.py
@@ -65,6 +65,9 @@ def getShell(force=False):
         logger.warning('[LCG] configuration section not found. Cannot set up a proper grid shell.')
         return None
 
+    if not config['GLITE_ENABLE']:
+        return None
+
     s = None
 
     # 1. check if the GLITE_SETUP is changed by user -> take the user's value as session value


### PR DESCRIPTION
After or if the `GLITE_ENABLED` is set to false in the config there is no need to warn the user about missing files which will/should never be used.
Goes from:
```
INFO     LCG config is not set. Please set [LCG]VirtualOrganisation to your VO (e.g. "gridpp") or disable LCG with [LCG]GLITE_ENABLE=False
WARNING  Configuration of GLITE for LCG:
WARNING  File not found: /afs/cern.ch/sw/ganga/install/config/grid_env_auto.sh
```

```
INFO     LCG config is not set. Please set [LCG]VirtualOrganisation to your VO (e.g. "gridpp") or disable LCG with [LCG]GLITE_ENABLE=False
```

As long as we're not creating a proxy on systems when they start by default just because the tools are there I'm happy to wait until 6.1.22 for this to go in.