### PR TITLE
Removing __construct__ instances and fixing code

### DIFF
--- a/python/Ganga/Core/GangaRepository/SubJobXMLList.py
+++ b/python/Ganga/Core/GangaRepository/SubJobXMLList.py
@@ -84,20 +84,6 @@ class SubJobXMLList(GangaObject):
         # Lock to ensure only one load at a time
         self._load_lock = threading.Lock()
 
-    def __construct__(self, args):
-        """ CONSTUCT method... TODO remove me in time """
-        super(SubJobXMLList, self).__construct__(args)
-        self._definedParent = None
-
-        self._subjobIndexData = {}
-        self._subjob_master_index_name = "subjobs.idx"
-        self._jobDirectory = None
-        self._registry = None
-        self._dataFileName = None
-        self._load_backup = None
-        self._cachedJobs = {}
-        self._cached_filenames = {}
-        self._stored_len =[]
 
     ## THIS CLASS MAKES USE OF THE INTERNAL CLASS DICTIONARY ONLY!!!
     ## THIS CLASS DOES NOT MAKE USE OF THE SCHEMA TO STORE INFORMATION AS TRANSIENT OR UNCOPYABLE

--- a/python/Ganga/GPIDev/Adapters/IPostProcessor.py
+++ b/python/Ganga/GPIDev/Adapters/IPostProcessor.py
@@ -55,10 +55,9 @@ class MultiPostProcessor(IPostProcessor):
         'process_objects': ComponentItem('postprocessor', defvalue=[], hidden=1, doc='A list of Processors to run', sequence=1)
     })
 
-    def __init__(self):
+    def __init__(self, *args):
         super(MultiPostProcessor, self).__init__()
 
-    def __construct__(self, args):
         if len(args) == 1 or len(args) > 1 and isType(args, (GangaList, list)):
             if isinstance(args, list) or isType(args, GangaList):
                 for process in args:

--- a/python/Ganga/GPIDev/Base/Objects.py
+++ b/python/Ganga/GPIDev/Base/Objects.py
@@ -726,8 +726,6 @@ class GangaObject(Node):
         elif len(args) == 1:
             if not isinstance(args[0], type(self)):
                 logger.warning("Performing a copyFrom from: %s to: %s" % (type(args[0]), type(self)))
-                import traceback
-                traceback.print_stack()
             self.copyFrom(args[0])
         else:
             from Ganga.GPIDev.Base.Proxy import TypeMismatchError

--- a/python/Ganga/GPIDev/Base/Objects.py
+++ b/python/Ganga/GPIDev/Base/Objects.py
@@ -726,6 +726,8 @@ class GangaObject(Node):
         elif len(args) == 1:
             if not isinstance(args[0], type(self)):
                 logger.warning("Performing a copyFrom from: %s to: %s" % (type(args[0]), type(self)))
+                import traceback
+                traceback.print_stack()
             self.copyFrom(args[0])
         else:
             from Ganga.GPIDev.Base.Proxy import TypeMismatchError

--- a/python/Ganga/GPIDev/Lib/File/File.py
+++ b/python/Ganga/GPIDev/Lib/File/File.py
@@ -64,21 +64,11 @@ class File(GangaObject):
         if not subdir is None:
             self.subdir = subdir
 
-    def __construct__(self, args):
-        if len(args) == 1 and isinstance(args[0], str):
-            v = args[0]
-            import os.path
-            expanded = expandfilename(v)
-            # if it is not already an absolute filename
-            if not urlprefix.match(expanded):
-                if os.path.exists(os.path.abspath(expanded)):
-                    self.name = os.path.abspath(expanded)
-                else:
-                    self.name = v
-            else:  # bugfix #20545
-                self.name = expanded
-        else:
-            super(File, self).__construct__(args)
+    def __setattr__(self, attr, value):
+        actual_value = value
+        if attr == "name":
+            actual_value = expandfilename(value)
+        super(File, self).__setattr__(attr, value)
 
     def _attribute_filter__set__(self, attribName, attribValue):
         if attribName is 'name':
@@ -126,7 +116,7 @@ def string_file_shortcut_file(v, item):
     if isinstance(v, str):
         # use proxy class to enable all user conversions on the value itself
         # but return the implementation object (not proxy)
-        return stripProxy(File._proxyClass(v))
+        return File(v)
     return None
 
 allComponentFilters['files'] = string_file_shortcut_file
@@ -255,7 +245,7 @@ def string_sharedfile_shortcut(v, item):
     if isinstance(v, str):
         # use proxy class to enable all user conversions on the value itself
         # but return the implementation object (not proxy)
-        return stripProxy(ShareDir._proxyClass(v))
+        return ShareDir(v)
     return None
 
 allComponentFilters['shareddirs'] = string_sharedfile_shortcut

--- a/python/Ganga/GPIDev/Lib/File/MassStorageFile.py
+++ b/python/Ganga/GPIDev/Lib/File/MassStorageFile.py
@@ -4,6 +4,11 @@ from __future__ import absolute_import
 #
 # $Id: MassStorageFile.py,v 0.1 2011-11-09 15:40:00 idzhunov Exp $
 ##########################################################################
+import errno
+import re
+import os
+import copy
+
 from Ganga.GPIDev.Schema import Schema, Version, SimpleItem, ComponentItem
 
 from Ganga.Utility.Config import getConfig
@@ -13,11 +18,8 @@ from Ganga.Utility import Shell
 from Ganga.Utility.logging import getLogger
 from Ganga.GPIDev.Adapters.IGangaFile import IGangaFile
 from Ganga.GPIDev.Base.Proxy import getName
+from Ganga.Utility.files import expandfilename
 
-import errno
-import re
-import os
-import copy
 import Ganga.Utility.Config
 
 regex = re.compile('[*?\[\]]')
@@ -54,13 +56,17 @@ class MassStorageFile(IGangaFile):
 
         self.shell = Shell.Shell()
 
-    def __construct__(self, args):
-        if len(args) == 1 and isinstance(args[0], str):
-            self._setNamePath(args[0], '')
-        elif len(args) == 2 and isinstance(args[0], str) and isinstance(args[1], str):
-            self._setNamePath(args[0], args[1])
-        self.locations = []
-        self.shell = Shell.Shell()
+    def __setattr__(self, attr, value):
+
+        actual_value = value
+        if attr == "namePattern":
+            actual_value = os.path.basename(value)
+            this_localDir = os.path.dirname(value)
+            super(MassStorageFile, self).__setattr__('localDir', this_localDir)
+        if attr == "localDir":
+            actual_value = os.path.abspath(expandfilename(value))
+
+        super(MassStorageFile, self).__setattr__(attr, actual_value)
 
     def _setNamePath(self, _namePattern='', _localDir=''):
         if _namePattern != '' and _localDir == '':
@@ -71,7 +77,9 @@ class MassStorageFile(IGangaFile):
             self.namePattern = _namePattern
             self.localDir = _localDir
 
+
     def _on_attribute__set__(self, obj_type, attrib_name):
+        # This is defining the object as uncopyable from outputfiles... do we want this mechanism still?
         r = copy.deepcopy(self)
         if getName(obj_type) == 'Job' and attrib_name == 'outputfiles':
             r.locations = []

--- a/python/Ganga/GPIDev/Lib/GangaList/GangaList.py
+++ b/python/Ganga/GPIDev/Lib/GangaList/GangaList.py
@@ -123,23 +123,6 @@ class GangaList(GangaObject):
         self._is_a_ref = False
         super(GangaList, self).__init__()
 
-    def __construct__(self, args):
-
-        #super(GangaList, self).__construct__(args)
-
-        if len(args) == 1:
-            if isType(args[0], (len, GangaList, tuple)):
-                for elem in args[0]:
-                    self._list.expand(self.strip_proxy(elem))
-            elif args[0] is None:
-                self._list = None
-            else:
-                raise GangaException("Construct: Attempting to assign a non list item: %s to a GangaList._list!" % str(args[0]))
-        else:
-            super(GangaList, self).__construct__(args)
-
-        return
-
     # convenience methods
     @staticmethod
     def is_list(obj):

--- a/python/Ganga/GPIDev/Lib/Job/Job.py
+++ b/python/Ganga/GPIDev/Lib/Job/Job.py
@@ -258,57 +258,6 @@ class Job(GangaObject):
             parent = self._getParent()
         return parent
 
-    def __construct__(self, args):
-
-        self.status = "new"
-        logger.debug("Intercepting __construct__")
-
-        #super(Job, self).__construct__(args)
-
-        # Not correctly calling Copy Constructor as in
-        # Ganga/test/GPI/TestJobProperties:test008_CopyConstructor
-        #super(Job, self).__construct__( args )
-
-        logger.debug("Job args: %s" % args)
-
-        if len(args) == 1:
-
-            if isType(args[0], Job):
-
-                self._unsetSubmitTransients()
-                super(Job, self).__construct__( args )
-
-                original_job = args[0]
-
-                self.copyFrom(original_job)
-
-                if original_job.master is not None:
-
-                    if getConfig('Output')['ForbidLegacyInput']:
-
-                        if original_job.inputfiles == []:
-                            self.inputfiles = copy.copy(original_job.master.inputfiles)
-                        else:
-                            self.inputfiles = copy.copy(original_job.inputfiles)
-                        self.inputsandbox = []
-                    else:
-
-                        if original_job.inputsandbox == []:
-                            self.inputsandbox = original_job.master.inputsandbox
-                        else:
-                            self.inputsandbox = original_job.inputsandbox
-                        self.inputfiles = []
-                if getConfig('Preparable')['unprepare_on_copy'] is True:
-                    self.unprepare()
-
-            else:
-                # Fix for Ganga/test/GPI/TestJobProperties:test008_CopyConstructor
-                super(Job, self).__construct__( args )
-                #raise ValueError("Object %s is NOT of type Job" % args[0])
-        else:
-            # Fix for Ganga/test/GPI/TestJobProperties:test008_CopyConstructor
-            super(Job, self).__construct__(args)
-
     def _readonly(self):
         return self.status != 'new'
 
@@ -2232,10 +2181,6 @@ class JobTemplate(Job):
 
     def __init__(self):
         super(JobTemplate, self).__init__()
-        self.status = "template"
-
-    def __construct__(self, args):
-        super(JobTemplate, self).__construct__(args)
         self.status = "template"
 
     def _readonly(self):

--- a/python/Ganga/GPIDev/Lib/Registry/PrepRegistry.py
+++ b/python/Ganga/GPIDev/Lib/Registry/PrepRegistry.py
@@ -105,11 +105,12 @@ class ShareRef(GangaObject):
         self.name = {}
         #self._setRegistry(None)
 
-    def __construct__(self, args):
-        super(ShareRef, self).__construct__(args)
-        if self.name is None:
-            self.name = {}
-        #self._setRegistry(None)
+    def __setattr__(self, attr, value):
+        actual_value = value
+        if attr == "name":
+            if not actual_value:
+                actual_value = {}
+        super(ShareRef, self).__setattr__(attr, actual_value)
 
     def __getName(self):
         if not hasattr(self, 'name') or self.name is None:

--- a/python/Ganga/GPIDev/Schema/Schema.py
+++ b/python/Ganga/GPIDev/Schema/Schema.py
@@ -515,7 +515,9 @@ class Item(object):
                             if not valueTypeAllowed(dKey, validTypes) or not valueTypeAllowed(dVal, validTypes):
                                 raise TypeMismatchError('Dictionary entry %s:%s for attribute %s is invalid. Valid types for key/value pairs: %s' % (dKey, dVal, name, validTypes))
                     else:  # new value is not a dict
-                        raise TypeMismatchError('Attribute "%s" expects a dictionary.' % name)
+                        if val == []:
+                            return
+                        raise TypeMismatchError('Attribute "%s" expects a dictionary. Found: "%s".' % (name, found))
                     return
                 else:  # a 'simple' (i.e. non-dictionary) non-sequence value
                     self.__check(valueTypeAllowed(val, validTypes), name, validTypes, val)

--- a/python/Ganga/test/GPI/GangaList/TestMutableMethods.py
+++ b/python/Ganga/test/GPI/GangaList/TestMutableMethods.py
@@ -295,8 +295,8 @@ class TestMutableMethods(GangaUnitTest):
         else:
             def testList(_list):
                 for l in _list:
-                    assert isType(
-                        l, IGangaFile), "All entries must be of type IGangaFile"
+                    print("Testing: '%s' type: '%s'" % (l, type(l)))
+                    assert isType(l, IGangaFile), "All entries must be of type IGangaFile"
 
             list_one = [LocalFile(self._makeRandomString()) for _ in range(10)]
             j.inputfiles = list_one

--- a/python/GangaDirac/Lib/Files/DiracFile.py
+++ b/python/GangaDirac/Lib/Files/DiracFile.py
@@ -75,24 +75,6 @@ class DiracFile(IGangaFile):
         if remoteDir is not None:
             self.remoteDir = remoteDir
 
-    def __construct__(self, args):
-
-        self.locations = []
-
-        if len(args) == 1 and isType(args[0], DiracFile):
-            self.lfn = args[0].lfn
-            self.namePattern = args[0].namePattern
-            self.remoteDir = args[0].remoteDir
-            self.localDir = args[0].localDir
-            self.guid = args[0].guid
-            self.compressed = args[0].compressed
-            self._storedReplicas = args[0]._storedReplicas
-            self._remoteURLs = args[0]._remoteURLs
-            self.failureReason = args[0].failureReason
-            self._have_copied = True
-            self.subfiles = copy.deepcopy(args[0].subfiles)
-            return
-
         # LFN ONLY
         if len(args) == 1 and type(args[0]) == type(''):
             if str(str(args[0]).upper()[0:4]) == str("LFN:"):
@@ -127,6 +109,24 @@ class DiracFile(IGangaFile):
             super(DiracFile, self).__construct__(args)
 
         return
+
+    def __setattr__(self, attr, value):
+
+        actual_value = value
+        if attr == "namePattern":
+            actual_value = os.path.basename(value)
+            this_dir = os.path.dirname(value)
+            super(DiracFile, self).__setattr__('localDir', this_dir)
+        elif attr == 'localDir':
+            actual_value = os.path.abspath(expandfilename(value))
+        elif attr == 'lfn':
+            this_name = os.path.basename(value)
+            super(DiracFile, self).__setattr__('namePattern', this_name)
+        elif attr == 'remoteDir':
+            this_lfn = os.path.join(value, self.lfn)
+            super(DiracFile, self).__setattr__('lfn', this_lfn)
+
+        super(DiracFile, self).__setattr__(attr, actual_value)
 
     def _attribute_filter__set__(self, name, value):
 


### PR DESCRIPTION
Here I have removed the `__construct__` functions in the classes that use them and have defined some sensible `__setattr__` functions which are now correctly called from the ProxyDescriptor.

The advantage of this is 3 fold.

 1. Classes stop calling `__construct__` when being constructed from the proxy. We'd much rather have all proxy-specific changes to an object in `_auto__init__`
 2. `__setattr__` is much nicer and cleaner than the construct list. It means that we know exactly what we're setting when and can adjust the values.
 3. The `localDir` is now always set to be `cwd` from when the class has been constructed or the dirname from a full/relative file path (if no path it's the cwd where the file is expected to be). No more guessing about what the `localDir` (although you can set it independently).

This PR has passed a large(ish) subset of the test suite locally but I'm expecting 1 or 2 corner cases I've not considered yet to come up in testing.

The Proxy `__init__` (`_init`) function is now much cleaner and the export and load of jobs still works correctly.

I'm mainly uploading this for testing (for now) but would like to see it go into 6.1.22 if possible.
There is known missing documentation on this which I'll get back to before committing it.