### PR TITLE
Fixing bug in old_tests

### DIFF
--- a/python/GangaLHCb/Lib/LHCbDataset/LHCbDataset.py
+++ b/python/GangaLHCb/Lib/LHCbDataset/LHCbDataset.py
@@ -71,7 +71,7 @@ class LHCbDataset(GangaDataset):
                 return isinstance(_file, IGangaFile)
             areFiles = all([isFileTest(f) for f in files._list])
             if areFiles:
-                self.file._list.extend(files._list)
+                self.files._list.extend(files._list)
                 process_files = False
         elif isinstance(files, LHCbDataset):
             self.files._list.extend(files.files._list)


### PR DESCRIPTION
This bug was highlighted by looking through the old_tests that were run against 6.1.21.

At what point in the release process are these tests run? Was there an email saying where the test results are located? I think I may have missed that email as I can't find one in my inbox.

As it stands this looks like a bug against LHCb Tasks so I'll try and see if I can run some simple task examples for LHCb and if not I'll push out the release with a caveat for tasks users. (I'm hoping to avoid this)