### PR TITLE
Fixing GangaTest Runtime env modification

### DIFF
--- a/python/Ganga/Runtime/bootstrap.py
+++ b/python/Ganga/Runtime/bootstrap.py
@@ -791,7 +791,9 @@ under certain conditions; type license() for details.
         if self.options.TEST:
             # FIXME: CONFIG CHECK
             # ?? config['RUNTIME_PATH'] = ''
-            config.setSessionValue('RUNTIME_PATH', 'GangaTest')
+            config = getConfig('Configuration')
+            exiting = config['RUNTIME_PATH']
+            config.setSessionValue('RUNTIME_PATH', exiting + ':GangaTest')
 
         # ensure we're not interactive if daemonised
         if self.options.daemon and self.interactive:


### PR DESCRIPTION
Fixing a bug in how the GangaTest adds itself to the RUNTIME_PATH. This fixes it so that it works for my LHCb environment which has additional plugins for testing.