### PR TITLE
Change PYTHONPATH to syspath for rucio import

### DIFF
--- a/python/GangaAtlas/PACKAGE.py
+++ b/python/GangaAtlas/PACKAGE.py
@@ -61,9 +61,9 @@ if sys.hexversion < 0x2050000:
 # use appropriate RUCIO Client version
 _external_packages['rucio-clients']['RUCIO_HOME'] = os.path.join(getExternalHome(), 'rucio-clients', _external_packages['rucio-clients']['version'], 'noarch')
 if 'CMTCONFIG' in os.environ and 'slc5' in os.environ['CMTCONFIG'] and 'i686' in os.environ['CMTCONFIG']:
-    _external_packages['rucio-clients']['PYTHONPATH'] = [ 'externals/kerberos/lib.slc6-i686-2.6', 'externals/kerberos/lib.slc6-x86_64-2.6', 'lib/python2.6/site-packages' ]
+    _external_packages['rucio-clients']['syspath'] = [ 'externals/kerberos/lib.slc6-i686-2.6', 'externals/kerberos/lib.slc6-x86_64-2.6', 'lib/python2.6/site-packages' ]
 elif 'CMTCONFIG' in os.environ and 'slc5' in os.environ['CMTCONFIG']:
-    _external_packages['rucio-clients']['PYTHONPATH'] = [ 'externals/kerberos/lib.slc6-x86_64-2.6', 'externals/kerberos/lib.slc6-i686-2.6', 'lib/python2.6/site-packages' ]
+    _external_packages['rucio-clients']['syspath'] = [ 'externals/kerberos/lib.slc6-x86_64-2.6', 'externals/kerberos/lib.slc6-i686-2.6', 'lib/python2.6/site-packages' ]
 
 setup = PackageSetup(_external_packages)
 


### PR DESCRIPTION
In the recent changes to the plugin setup and removal of REEXEC I missed a change to the rucio client import that was needed for (very) old Athena releases. This fixes that.