### PR TITLE
Unicode proxystrip

### DIFF
--- a/python/Ganga/GPIDev/Base/Proxy.py
+++ b/python/Ganga/GPIDev/Base/Proxy.py
@@ -13,6 +13,7 @@ from Ganga.GPIDev.Schema import ComponentItem
 from Ganga.GPIDev.Base.Objects import Node, GangaObject, ObjectMetaclass, _getName
 from Ganga.Core import GangaAttributeError, ProtectedAttributeError, ReadOnlyObjectError, TypeMismatchError
 
+import collections
 import functools
 import os
 
@@ -528,8 +529,7 @@ class ProxyDataDescriptor(object):
     def __recursive_strip(_val):
         ## Strip the proxies recursively for things like nested lists
         raw_val = stripProxy(_val)
-        if not isinstance(_val, basestring) and (isType(_val, getKnownLists()) or\
-                (hasattr(raw_val, '__len__') and hasattr(raw_val, '__getitem__'))):
+        if isinstance(_val, collections.Sequence) and not isinstance(_val, basestring):
             val = raw_val.__class__()
             if isinstance(val, dict):
                 for _key, elem in _val.iteritems():

--- a/python/Ganga/GPIDev/Base/Proxy.py
+++ b/python/Ganga/GPIDev/Base/Proxy.py
@@ -528,7 +528,7 @@ class ProxyDataDescriptor(object):
     def __recursive_strip(_val):
         ## Strip the proxies recursively for things like nested lists
         raw_val = stripProxy(_val)
-        if not isinstance(_val, str) and (isType(_val, getKnownLists()) or\
+        if not isinstance(_val, basestring) and (isType(_val, getKnownLists()) or\
                 (hasattr(raw_val, '__len__') and hasattr(raw_val, '__getitem__'))):
             val = raw_val.__class__()
             if isinstance(val, dict):


### PR DESCRIPTION
This PR resolves https://github.com/ganga-devs/ganga/issues/692. Essentially checking for base type `basestring` rather than `str` such that unicode objects are also caught. It also includes some code clean up as mentioned in the above issue.