### PR TITLE
Fixes for DIRACserver job kill problem and DiracFile used as Batch/Local outputfile

### DIFF
--- a/python/GangaDirac/Lib/Backends/DiracBase.py
+++ b/python/GangaDirac/Lib/Backends/DiracBase.py
@@ -736,7 +736,7 @@ class DiracBase(IBackend):
             if configDirac['failed_sandbox_download']:
                 execute("getOutputSandbox(%d,'%s')" % (job.backend.id, job.getOutputWorkspace().getPath()))
         else:
-            logger.error("Unexpected dirac status '%s' encountered" % updated_dirac_status)
+            logger.error("Job #%s Unexpected dirac status '%s' encountered" % (job.getFQID('.'), updated_dirac_status))
 
     @staticmethod
     def job_finalisation(job, updated_dirac_status):

--- a/python/GangaDirac/Lib/Files/DiracFile.py
+++ b/python/GangaDirac/Lib/Files/DiracFile.py
@@ -667,14 +667,11 @@ class DiracFile(IGangaFile):
                 logger.warning("LFN will be generated automatically")
                 self.lfn = ""
 
-        if self.remoteDir == '':
+        if not self.remoteDir:
             try:
                 job = self.getJobObject()
-            except AssertionError:
-                job = None
-            if job:
                 lfn_folder = os.path.join("GangaUploadedFiles", "GangaJob_%s" % job.getFQID('.'))
-            else:
+            except AssertionError:
                 t = datetime.datetime.now()
                 this_date = t.strftime("%H.%M_%A_%d_%B_%Y")
                 lfn_folder = os.path.join("GangaUploadedFiles", 'GangaFiles_%s' % this_date)
@@ -838,14 +835,11 @@ for f in glob.glob('###NAME_PATTERN###'):
         WNscript_location = os.path.join( script_path, 'WNInjectTemplate.py' )
         script = FileUtils.loadScript(WNscript_location, '')
 
-        if self.remoteDir == '':
+        if not self.remoteDir:
             try:
                 job = self.getJobObject()
-            except AssertionError:
-                job = None
-            if job:
                 lfn_folder = os.path.join("GangaUploadedFiles", "GangaJob_%s" % job.getFQID('.'))
-            else:
+            except AssertionError:
                 t = datetime.datetime.now()
                 this_date = t.strftime("%H.%M_%A_%d_%B_%Y")
                 lfn_folder = os.path.join("GangaUploadedFiles", 'GangaFiles_%s' % this_date)

--- a/python/GangaDirac/Lib/Files/DiracFile.py
+++ b/python/GangaDirac/Lib/Files/DiracFile.py
@@ -1,10 +1,12 @@
 import copy
 import os
 import datetime
+import inspect
 import hashlib
 import re
 import os.path
 import random
+import glob
 from Ganga.GPIDev.Base.Proxy import stripProxy, GPIProxyObjectFactory, isType, getName
 from Ganga.GPIDev.Lib.GangaList.GangaList import GangaList
 from Ganga.GPIDev.Schema import Schema, Version, SimpleItem, ComponentItem
@@ -98,9 +100,10 @@ class DiracFile(IGangaFile):
             if value:
                 this_name = os.path.basename(value)
                 super(DiracFile, self).__setattr__('namePattern', this_name)
+                super(DiracFile, self).__setattr__('remoteDir', os.path.dirname(value))
         elif attr == 'remoteDir':
             if value:
-                this_lfn = os.path.join(value, self.lfn)
+                this_lfn = os.path.join(value, self.namePattern)
                 super(DiracFile, self).__setattr__('lfn', this_lfn)
 
         super(DiracFile, self).__setattr__(attr, actual_value)
@@ -633,7 +636,10 @@ class DiracFile(IGangaFile):
             else:
                 return
 
-        if lfn != '':
+        if lfn and os.path.basename(lfn) != self.namePattern:
+            logger.warning("Changing namePattern from: '%s' to '%s' during put operation" % (self.namePattern, os.path.basename(lfn)))
+
+        if lfn:
             self.lfn = lfn
 
         # looks like will only need this for the interactive uploading of jobs.
@@ -661,15 +667,18 @@ class DiracFile(IGangaFile):
                 logger.warning("LFN will be generated automatically")
                 self.lfn = ""
 
-        selfConstructedLFN = False
-
-        import glob
-        if self.remoteDir == '' and self.lfn == '':
-            import datetime
-            t = datetime.datetime.now()
-            this_date = t.strftime("%H.%M_%A_%d_%B_%Y")
-            self.lfn = os.path.join(DiracFile.diracLFNBase(), 'GangaFiles_%s' % this_date)
-            selfConstructedLFN = True
+        if self.remoteDir == '':
+            try:
+                job = self.getJobObject()
+            except AssertionError:
+                job = None
+            if job:
+                lfn_folder = os.path.join("GangaUploadedFiles", "GangaJob_%s" % job.getFQID('.'))
+            else:
+                t = datetime.datetime.now()
+                this_date = t.strftime("%H.%M_%A_%d_%B_%Y")
+                lfn_folder = os.path.join("GangaUploadedFiles", 'GangaFiles_%s' % this_date)
+            self.lfn = os.path.join(DiracFile.diracLFNBase(), lfn_folder, self.namePattern)
 
         if self.remoteDir[:4] == 'LFN:':
             lfn_base = self.remoteDir[4:]
@@ -690,11 +699,8 @@ class DiracFile(IGangaFile):
             storage_elements = [uploadSE]
 
         outputFiles = GangaList()
-        backup_lfn = self.lfn
         for this_file in glob.glob(os.path.join(sourceDir, self.namePattern)):
             name = this_file
-
-            self.lfn = backup_lfn
 
             if not os.path.exists(name):
                 if not self.compressed:
@@ -712,10 +718,7 @@ class DiracFile(IGangaFile):
             if lfn == "":
                 lfn = os.path.join(lfn_base, os.path.basename(name))
 
-            if selfConstructedLFN is True:
-                self.lfn = os.path.join(self.lfn, os.path.basename(name))
-
-            lfn = self.lfn
+            #lfn = os.path.join(os.path.dirname(self.lfn), this_file)
 
             d = DiracFile()
             d.namePattern = os.path.basename(name)
@@ -723,7 +726,8 @@ class DiracFile(IGangaFile):
             d.localDir = sourceDir
             stderr = ''
             stdout = ''
-            logger.info('Uploading file \'%s\' to \'%s\' as \'%s\'' % (name, storage_elements[0], lfn))
+            logger.debug('Uploading file \'%s\' to \'%s\' as \'%s\'' % (name, storage_elements[0], lfn))
+            logger.debug('execute: uploadFile("%s", "%s", %s)' % (lfn, name, str([storage_elements[0]])))
             stdout = execute('uploadFile("%s", "%s", %s)' % (lfn, name, str([storage_elements[0]])))
             if type(stdout) == str:
                 logger.warning("Couldn't upload file '%s': \'%s\'" % (os.path.basename(name), stdout))
@@ -770,14 +774,13 @@ class DiracFile(IGangaFile):
                         this_file.replicate(se)
 
         if len(outputFiles) > 0:
-            return GPIProxyObjectFactory(outputFiles)
+            return outputFiles
         else:
             outputFiles.append(self)
-            return GPIProxyObjectFactory(outputFiles)
+            return outputFiles
 
     def getWNScriptDownloadCommand(self, indent):
 
-        import inspect
         script_location = os.path.join(os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe()))), 'downloadScript.py')
 
         from Ganga.GPIDev.Lib.File import FileUtils
@@ -801,13 +804,11 @@ subprocess.Popen('''python -c "import sys\nexec(sys.stdin.read())"''', shell=Tru
         return script
 
     def _getDiracEnvStr(self):
-        from GangaDirac.Lib.Utilities.DiracUtilities import getDiracEnv
         diracEnv = str(getDiracEnv())
         return diracEnv
 
     def _WN_wildcard_script(self, namePattern, lfnBase, compressed):
         wildcard_str =  """
-import glob, hashlib
 for f in glob.glob('###NAME_PATTERN###'):
     processes.append(uploadFile(os.path.basename(f), '###LFN_BASE###', ###COMPRESSED###, '###NAME_PATTERN###'))
 """
@@ -828,7 +829,6 @@ for f in glob.glob('###NAME_PATTERN###'):
         Returns script that have to be injected in the jobscript for postprocessing on the WN
         """
 
-        import inspect
         script_path = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
         script_location = os.path.join( script_path, 'uploadScript.py')
 
@@ -838,23 +838,26 @@ for f in glob.glob('###NAME_PATTERN###'):
         WNscript_location = os.path.join( script_path, 'WNInjectTemplate.py' )
         script = FileUtils.loadScript(WNscript_location, '')
 
-        selfConstructedLFNs = False
+        if self.remoteDir == '':
+            try:
+                job = self.getJobObject()
+            except AssertionError:
+                job = None
+            if job:
+                lfn_folder = os.path.join("GangaUploadedFiles", "GangaJob_%s" % job.getFQID('.'))
+            else:
+                t = datetime.datetime.now()
+                this_date = t.strftime("%H.%M_%A_%d_%B_%Y")
+                lfn_folder = os.path.join("GangaUploadedFiles", 'GangaFiles_%s' % this_date)
+            self.lfn = os.path.join(DiracFile.diracLFNBase(), lfn_folder, self.namePattern)
 
-        if self.remoteDir == '' and self.lfn == '':
-            import datetime
-            t = datetime.datetime.now()
-            this_date = t.strftime("%H.%M_%A_%d_%B_%Y")
-            self.lfn = os.path.join(DiracFile.diracLFNBase(), 'GangaFiles_%s' % this_date)
-            selfConstructedLFNs = True
-
-        if self.remoteDir == '' and self.lfn != '':
+        if self.remoteDir == '':
             self.remoteDir = DiracFile.diracLFNBase()
 
         if self.remoteDir[:4] == 'LFN:':
             lfn_base = self.remoteDir[4:]
         else:
             lfn_base = self.remoteDir
-
 
         for this_file in outputFiles:
             isCompressed = this_file.namePattern in patternsToZip

--- a/python/GangaDirac/Lib/Files/WNInjectTemplate.py
+++ b/python/GangaDirac/Lib/Files/WNInjectTemplate.py
@@ -1,5 +1,5 @@
 
-import os, sys
+import os, sys, datetime, subprocess
 dirac_env=###DIRAC_ENV###
 processes=[]
 storage_elements = ###STORAGE_ELEMENTS###
@@ -8,9 +8,8 @@ def uploadFile(file_name, lfn_base, compress=False, wildcard=''):
 
     upload_script = '''\n###UPLOAD_SCRIPT###'''
 
-    import sys, os, datetime, subprocess
     if not os.path.exists(os.path.join(os.getcwd(),file_name)):
-        ###LOCATIONSFILE###.write("DiracFile:::%s&&%s->###FAILED###:::File '%s' didn't exist:::NotAvailable\n" % (wildcard, file_label, file_name))
+        ###LOCATIONSFILE###.write("DiracFile:::%s&&%s->###FAILED###:::File '%s' didn't exist:::NotAvailable\n" % (wildcard, file_name, file_name))
         return
 
     replace_dict = {

--- a/python/GangaDirac/Lib/Files/downloadScript.py
+++ b/python/GangaDirac/Lib/Files/downloadScript.py
@@ -1,7 +1,7 @@
 import os
 ## NB parseCommandLine first then import Dirac!!
 from DIRAC.Core.Base.Script import parseCommandLine
-parseCommandLine()
 from DIRAC.Interfaces.API.Dirac import Dirac
+parseCommandLine()
 dirac=Dirac()
 dirac.getFile('###LFN###', os.getcwd())

--- a/python/GangaDirac/Lib/Files/uploadScript.py
+++ b/python/GangaDirac/Lib/Files/uploadScript.py
@@ -1,9 +1,13 @@
 
 import os
 ## NB parseCommandLine first then import Dirac!!
+import datetime
+import gzip
+import sys
+from contextlib import closing
 from DIRAC.Core.Base.Script import parseCommandLine
-parseCommandLine()
 from DIRAC.Interfaces.API.Dirac import Dirac
+parseCommandLine()
 dirac=Dirac()
 errmsg=''
 file_name='###UPLOAD_FILE###'
@@ -11,7 +15,6 @@ file_label=file_name
 
 compressed = ###COMPRESSED###
 if compressed:
-    import gzip
     file_name += '.gz'
     f_in = open(file_label, 'rb')
     f_out = gzip.open(file_name, 'wb')
@@ -19,21 +22,19 @@ if compressed:
     f_out.close()
     f_in.close()
 
-lfn= os.path.join('###LFN_BASE###', file_name)
+lfn=os.path.join('###LFN_BASE###', file_name)
 wildcard='###WILDCARD###'
 storage_elements=###SEs###
 
-from contextlib import closing
 with closing(open('###LOCATIONSFILE_NAME###','ab')) as locationsfile:
     for se in storage_elements:
+        sys.stdout.write('\nUploading file: \"%s\" as \"%s\" at \"%s\"\n' % (file_name, lfn, se))
         try:
             result = dirac.addFile(lfn, file_name, se)
         except Exception as x:
-            import sys
             sys.stdout.write('Exception running dirac.addFile command: %s' % str(x))
             break
         if result.get('OK',False) and lfn in result.get('Value',{'Successful':{}})['Successful']:
-            import datetime
             guid = dirac.getMetadata(lfn)['Value']['Successful'][lfn]['GUID']
             locationsfile.write("DiracFile:::%s&&%s->%s:::['%s']:::%s\\n" % (wildcard, file_label, lfn, se, guid))
             locationsfile.flush()
@@ -42,6 +43,5 @@ with closing(open('###LOCATIONSFILE_NAME###','ab')) as locationsfile:
         errmsg+="(%s, %s), " % (se, result)
     else:
         locationsfile.write("DiracFile:::%s&&%s->###FAILED###:::File '%s' could not be uploaded to any SE (%s):::NotAvailable\\n" % (wildcard, file_label, file_name, errmsg))
-        import sys
         sys.stdout.write('Could not upload file %s' % file_name)
 

--- a/python/GangaDirac/__init__.py
+++ b/python/GangaDirac/__init__.py
@@ -66,7 +66,7 @@ if not _after_bootstrap:
                                             'Deleted': 'failed',
                                             'Done': 'completed',
                                             'Failed': 'failed',
-                                            'Killed': 'killed',
+                                            'Killed': 'failed',
                                             'Matched': 'submitted',
                                             'Received': 'submitted',
                                             'Running': 'running',
@@ -77,7 +77,7 @@ if not _after_bootstrap:
     configDirac.addOption('finalised_statuses',
                                                 {'Done': 'completed',
                                                  'Failed': 'failed',
-                                                 'Killed': 'killed',
+                                                 'Killed': 'failed',
                                                  'Deleted': 'failed',
                                                  'Unknown: No status for Job': 'failed'},
                                                 "Mapping of Dirac to Ganga Job statuses used to construct a queue to finalize a given job, i.e. final statues in 'statusmapping'")


### PR DESCRIPTION
These are some changes broken out from #691

I've confirmed the changes in `GangaDirac/__init__.py` Fix #685 

I've also made several small changes to the DiracFile and it's scripts which are inserted into jobs. This fixes the DiracFile so that it works correctly as an outputfile for Local jobs.

In addition I've fixed some minor bugs where the DiracFile wasn't uploaded to the correct LFN.

I think this needs to be merged given the DiracFile is currently broken (I suspect a lot of changes due to the `__construct__` changes).