### PR TITLE
Fix GaudiExec prep

### DIFF
--- a/python/GangaLHCb/Lib/Applications/GaudiExec.py
+++ b/python/GangaLHCb/Lib/Applications/GaudiExec.py
@@ -7,6 +7,7 @@ import shutil
 import tarfile
 import threading
 import stat
+import uuid
 from StringIO import StringIO
 
 from Ganga.Core import ApplicationConfigurationError, ApplicationPrepareError, GangaException
@@ -93,8 +94,7 @@ class GaudiExec(IPrepareApp):
         'directory':    SimpleItem(defvalue=None, typelist=[None, str], comparable=1, doc='A path to the project that you\'re wanting to run.'),
         'options':       GangaFileItem(defvalue=None, doc='File which contains the options I want to pass to gaudirun.py'),
         'uploadedInput': GangaFileItem(defvalue=None, hidden=1, doc='This stores the input for the job which has been pre-uploaded so that it gets to the WN'),
-        'uploadedScripts': GangaFileItem(defvalue=None, hidden=1, doc='This file stores the uploaded scripts which are generated fron this app to run on the WN'),
-        'sharedOptsInput': GangaFileItem(defvalue=None, hidden=1, doc='This stores the extra-opts for all (sub)jobs which are uploaded as 1 archive'),
+        'jobScriptArchive': GangaFileItem(defvalue=None, hidden=1, copyable=0, doc='This file stores the uploaded scripts which are generated fron this app to run on the WN'),
         'useGaudiRun':  SimpleItem(defvalue=True, doc='Should \'options\' be run as "python options.py data.py" rather than "gaudirun.py options.py data.py"'),
         'platform' :    SimpleItem(defvalue='x86_64-slc6-gcc49-opt', typelist=[str], doc='Platform the application was built for'),
         'extraOpts':    SimpleItem(defvalue='', typelist=[str], doc='An additional string which is to be added to \'options\' when submitting the job'),
@@ -112,7 +112,7 @@ class GaudiExec(IPrepareApp):
     cmake_sandbox_name = 'cmake-input-sandbox.tgz'
     build_target = 'ganga-input-sandbox'
     build_dest = 'input-sandbox.tgz'
-    sharedOptsFile_name = 'sharedExtraOpts.tar'
+    sharedOptsFile_baseName = 'jobScripts-%s.tar'
 
     def __setattr__(self, attr, value):
         """
@@ -149,7 +149,7 @@ class GaudiExec(IPrepareApp):
             self.is_prepared = None
         self.hash = None
         self.uploadedInput = None
-        self.sharedOptsInput = None
+        self.jobScriptArchive = None
 
 
     def prepare(self, force=False):
@@ -222,13 +222,15 @@ class GaudiExec(IPrepareApp):
 
         master_job = job.master or job
 
-        df = master_job.application.sharedOptsInput
+        df = master_job.application.jobScriptArchive
 
         folder_dir = master_job.getInputWorkspace(create=True).getPath()
 
+        unique_name = GaudiExec.sharedOptsFile_baseName % uuid.uuid4()
+
         if not df or df.namePattern == '':
-            master_job.application.sharedOptsInput = LocalFile(namePattern=GaudiExec.sharedOptsFile_name, localDir=folder_dir)
-            tar_filename = path.join(folder_dir, GaudiExec.sharedOptsFile_name)
+            master_job.application.jobScriptArchive = LocalFile(namePattern=unique_name, localDir=folder_dir)
+            tar_filename = path.join(folder_dir, unique_name)
             if not path.isfile(tar_filename):
                 with tarfile.open(tar_filename, "w"):
                     pass
@@ -242,12 +244,12 @@ class GaudiExec(IPrepareApp):
         extra_opts_file = self.getOptsFileName()
 
         # First construct if needed
-        if not path.isfile(path.join(folder_dir, GaudiExec.sharedOptsFile_name)):
-            with tarfile.open(path.join(folder_dir, GaudiExec.sharedOptsFile_name), "w"):
+        if not path.isfile(path.join(folder_dir, unique_name)):
+            with tarfile.open(path.join(folder_dir, unique_name), "w"):
                 pass
 
         # Now append the extra_opts file here when needed
-        with tarfile.open(path.join(folder_dir, GaudiExec.sharedOptsFile_name), "a") as tar_file:
+        with tarfile.open(path.join(folder_dir, unique_name), "a") as tar_file:
             # Add the extra opts file to the job
             tinfo = tarfile.TarInfo(extra_opts_file)
             tinfo.mtime = time.time()

--- a/python/GangaLHCb/Lib/Applications/GaudiExec.py
+++ b/python/GangaLHCb/Lib/Applications/GaudiExec.py
@@ -148,11 +148,9 @@ class GaudiExec(IPrepareApp):
             self.decrementShareCounter(self.is_prepared.name)
             self.is_prepared = None
         self.hash = None
-        ## FIXME Add some configurable object which controls whether a file should be removed from storage
-        ## Here if the is_prepared count reaches zero
-        if self.uploadedInput:
-            self.uploadedInput.remove()
         self.uploadedInput = None
+        self.sharedOptsInput = None
+
 
     def prepare(self, force=False):
         """

--- a/python/GangaLHCb/Lib/RTHandlers/GaudiExecRTHandlers.py
+++ b/python/GangaLHCb/Lib/RTHandlers/GaudiExecRTHandlers.py
@@ -191,7 +191,7 @@ class GaudiExecRTHandler(IRuntimeHandler):
 
         job_command = prepareCommand(app)
 
-         # Generate the script which is to be executed for us on the WN
+        # Generate the script which is to be executed for us on the WN
         scriptToRun = generateWNScript(job_command, app)
         input_sand.append(scriptToRun)
 
@@ -259,9 +259,7 @@ def generateJobScripts(app, appendJobScripts):
     job = app.getJobObject()
 
     if not job.master:
-        rjobs = job.subjobs
-        if not rjobs:
-            rjobs = [job]
+        rjobs = job.subjobs or [job]
     else:
         rjobs = [job]
 

--- a/python/GangaLHCb/Lib/RTHandlers/GaudiExecRTHandlers.py
+++ b/python/GangaLHCb/Lib/RTHandlers/GaudiExecRTHandlers.py
@@ -145,14 +145,6 @@ def prepareCommand(app):
     return full_cmd
 
 
-def WarnUsers():
-    """ A quick method for warning users about the in-development status of the app """
-    print("\n\n")
-    logger.warning("This GaudiExec Application is still in the testing phase.")
-    logger.warning("There is no guarantee that any jobs submitted with it wil remain compatible with the next release of Ganga")
-    raw_input("Please Hit the return key to continue with your Job submission\n")
-
-
 class GaudiExecRTHandler(IRuntimeHandler):
 
     """The runtime handler to run plain executables on the Local backend"""
@@ -165,28 +157,16 @@ class GaudiExecRTHandler(IRuntimeHandler):
             appmasterconfig (unknown): Output passed from the application master configuration call
         """
 
-        WarnUsers()
-
         inputsandbox, outputsandbox = master_sandbox_prepare(app, appmasterconfig)
 
-        if isinstance(app.sharedOptsInput, LocalFile):
-            app.sharedOptsInput = None
+        if isinstance(app.jobScriptArchive, LocalFile):
+            app.jobScriptArchive = None
 
-        job = app.getJobObject()
-        if job.subjobs:
-            rjobs = job.subjobs
-        else:
-            rjobs = [job]
-        for this_job in rjobs:
-            logger.debug("RTHandler Preparing: %s" % this_job.fqid)
-            this_job.application.constructExtraFiles(this_job)
+        generateJobScripts(app, appendJobScripts=False)
 
-        optsArchive = os.path.join(app.sharedOptsInput.localDir, app.sharedOptsInput.namePattern)
-        gzipFile(optsArchive, optsArchive+'.gz', True)
-        app.sharedOptsInput.namePattern = app.sharedOptsInput.namePattern + '.gz'
-        optsArchive = os.path.join(app.sharedOptsInput.localDir, app.sharedOptsInput.namePattern)
+        scriptArchive = os.path.join(app.jobScriptArchive.localDir, app.jobScriptArchive.namePattern)
 
-        inputsandbox.append(File(name=optsArchive))
+        inputsandbox.append(File(name=scriptArchive))
         return StandardJobConfig(inputbox=unique(inputsandbox), outputbox=unique(outputsandbox))
 
     def prepare(self, app, appconfig, appmasterconfig, jobmasterconfig):
@@ -211,7 +191,7 @@ class GaudiExecRTHandler(IRuntimeHandler):
 
         job_command = prepareCommand(app)
 
-        # Generate the script which is to be executed for us on the WN
+         # Generate the script which is to be executed for us on the WN
         scriptToRun = generateWNScript(job_command, app)
         input_sand.append(scriptToRun)
 
@@ -232,7 +212,7 @@ allHandlers.add('GaudiExec', 'LSF', GaudiExecRTHandler)
 
 def generateDiracInput(app):
     """
-    Construct a DIRAC input which must be unique to each job to have unique checksum.
+    Construct a DIRAC input which does not need to be unique to each job but is required to have a unique checksum.
     This generates a unique file, uploads it to DRIAC and then stores the LFN in app.uploadedInput
     Args:
         app (GaudiExec): This expects a GaudiExec app to be passed so that the constructed
@@ -256,28 +236,78 @@ def generateDiracInput(app):
         else:
             rjobs = [job]
 
-        script_names = []
-
-        for this_job in rjobs:
-            this_app = this_job.application
-            wnScript = generateWNScript(prepareCommand(this_app), this_app)
-            this_script = os.path.join(tmp_dir, wnScript.name)
-            script_names.append(wnScript)
-            wnScript.create(this_script)
-
         with tarfile.open(compressed_file, "w:gz") as tar_file:
             for name in input_files:
                 # FIXME Add support for subfiles here once it's working across multiple IGangaFile objects in a consistent way
                 # Not hacking this in for now just in-case we end up with a mess as a result
                 tar_file.add(name, arcname=os.path.basename(name))
-            for thisScript in script_names:
-                this_file = os.path.join(tmp_dir, thisScript.name)
-                logger.debug("Adding: '%s' as: '%s'" % (this_file, os.path.join(thisScript.subdir, thisScript.name)))
-                tar_file.add(this_file, arcname=os.path.join(thisScript.subdir, thisScript.name))
 
     new_df = uploadLocalFile(job, os.path.basename(compressed_file), tmp_dir)
 
     app.uploadedInput = new_df
+
+
+def generateJobScripts(app, appendJobScripts):
+    """
+    Construct a DIRAC scripts which must be unique to each job to have unique checksum.
+    This generates a unique file, uploads it to DRIAC and then stores the LFN in app.uploadedInput
+    Args:
+        app (GaudiExec): This expects a GaudiExec app to be passed so that the constructed
+        appendJobScripts (bool): Should we add the job scripts to the script archive? (Only makes sense on backends which auto-extact tarballs before running)
+    """
+
+    job = app.getJobObject()
+
+    if not job.master:
+        rjobs = job.subjobs
+        if not rjobs:
+            rjobs = [job]
+    else:
+        rjobs = [job]
+
+    tmp_dir = tempfile.gettempdir()
+
+    # First create the extraOpts files needed 1 per subjob
+    for this_job in rjobs:
+        logger.debug("RTHandler Making Scripts: %s" % this_job.fqid)
+        this_job.application.constructExtraFiles(this_job)
+
+    if not job.master and job.subjobs:
+        for sj in rjobs:
+            sj.application.jobScriptArchive = sj.master.application.jobScriptArchive
+
+    master_job = job.master or job
+
+    # Now lets get the name of this tar file
+    scriptArchive = os.path.join(master_job.application.jobScriptArchive.localDir, master_job.application.jobScriptArchive.namePattern)
+
+    if appendJobScripts:
+        # Now lets add the Job scripts to this archive
+        with tarfile.open(scriptArchive, 'a') as tar_file:
+            for this_job in rjobs:
+                this_app = this_job.application
+                wnScript = generateWNScript(prepareCommand(this_app), this_app)
+                this_script = os.path.join(tmp_dir, wnScript.name)
+                wnScript.create(this_script)
+                tar_file.add(this_script, arcname=os.path.join(wnScript.subdir, wnScript.name))
+
+    gzipFile(scriptArchive, scriptArchive+'.gz', True)
+    app.jobScriptArchive.namePattern = app.jobScriptArchive.namePattern + '.gz'
+
+def generateDiracScripts(app):
+    """
+    Construct a DIRAC scripts which must be unique to each job to have unique checksum.
+    This generates a unique file, uploads it to DRIAC and then stores the LFN in app.uploadedInput
+    Args:
+        app (GaudiExec): This expects a GaudiExec app to be passed so that the constructed
+    """
+    generateJobScripts(app, appendJobScripts=True)
+
+    job = app.getJobObject()
+
+    new_df = uploadLocalFile(job, app.jobScriptArchive.namePattern, app.jobScriptArchive.localDir)
+
+    app.jobScriptArchive = new_df
 
 
 def uploadLocalFile(job, namePattern, localDir, should_del=True):
@@ -324,15 +354,10 @@ class GaudiExecDiracRTHandler(IRuntimeHandler):
             appmasterconfig (unknown): Output passed from the application master configuration call
         """
 
-        WarnUsers()
-
         inputsandbox, outputsandbox = master_sandbox_prepare(app, appmasterconfig)
 
 
         if not isinstance(app.uploadedInput, DiracFile):
-            logger.info("Using DiracFile: '%s' as prepared state." % app.uploadedInput.lfn)
-            logger.info("Run job.application.reset()")
-        else:
             generateDiracInput(app)
             assert isinstance(app.uploadedInput, DiracFile), "Failed to upload needed file, aborting submit"
         
@@ -340,34 +365,14 @@ class GaudiExecDiracRTHandler(IRuntimeHandler):
         assert rep_data != {}, "Failed to find a replica, aborting submit"
 
 
-        if isinstance(app.sharedOptsInput, DiracFile):
-            app.sharedOptsInput = None
+        if isinstance(app.jobScriptArchive, (DiracFile, LocalFile)):
+            app.jobScriptArchive = None
 
-        job = app.getJobObject()
-        if job.subjobs:
-            rjobs = job.subjobs
-        else:
-            rjobs = [job]
-        for this_job in rjobs:
-            logger.debug("RTHandler Preparing: %s" % this_job.fqid)
-            this_job.application.constructExtraFiles(this_job)
+        generateDiracScripts(app)
 
-        optsArchive = os.path.join(app.sharedOptsInput.localDir, app.sharedOptsInput.namePattern[:-3] + '-'+str(uuid.uuid4())+'.tar')
-        gzipFile(optsArchive, optsArchive+'.gz', True)
-
-        new_df = DiracFile()
-        new_df.namePattern = app.sharedOptsInput.namePattern + '.gz'
-        new_df.localDir = app.sharedOptsInput.localDir
-        new_df.remoteDir = getInputFileDir(app.getJobObject())
-        new_df = new_df.put(force=True)[0]
-        app.sharedOptsInput = new_df
-
-        assert isinstance(app.sharedOptsInput, DiracFile), "Failed to upload needed file, aborting submit"
-
-        rep_data = app.sharedOptsInput.getReplicas()
+        assert isinstance(app.jobScriptArchive, DiracFile), "Failed to upload needed file, aborting submit"
+        rep_data = app.jobScriptArchive.getReplicas()
         assert rep_data != {}, "Failed to find a replica, aborting submit"
-
-        os.unlink(optsArchive+'.gz')
 
         return StandardJobConfig(inputbox=unique(inputsandbox), outputbox=unique(outputsandbox))
 
@@ -410,8 +415,10 @@ class GaudiExecDiracRTHandler(IRuntimeHandler):
                 logger.error("Filetype: %s nor currently supported, please contact Ganga Devs if you require support for this with the DIRAC backend" % getName(file_))
                 raise ApplicationConfigurationError(None, "Unsupported filetype: %s with DIRAC backend" % getName(file_))
 
-        app.uploadedInput = job.master.application.uploadedInput
-        app.sharedOptsInput = job.master.application.sharedOptsInput
+        master_job = job.master or job
+
+        app.uploadedInput = master_job.application.uploadedInput
+        app.jobScriptArchive = master_job.application.jobScriptArchive
 
         logger.debug("uploadedInput: %s" % app.uploadedInput)
 
@@ -420,7 +427,7 @@ class GaudiExecDiracRTHandler(IRuntimeHandler):
         logger.debug("Replica info: %s" % rep_data)
 
         inputsandbox += ['LFN:'+app.uploadedInput.lfn]
-        inputsandbox += ['LFN:'+app.sharedOptsInput.lfn]
+        inputsandbox += ['LFN:'+app.jobScriptArchive.lfn]
 
         logger.debug("Input Sand: %s" % inputsandbox)
 


### PR DESCRIPTION
I've refactored some of the code to fix a few minor bugs in how the jobs work when a new job is copied.

Now every new job regenerates all of the script files from scratch. However the prepared state of the application remains the same.

I have tried copying a Local job, modifying it's backend to Dirac and resubmitting it and everything now works as expected.

This also makes the code in the master_prepare methods a bit easier to read.

I've also cleaned up the schema slightly so that all of the generated scripts are stored in 1 LFN and all of the scripts for the application prepared state are stored in another.

Now when unpreparing an application the reference to the LFN is set to None and there is no way to automatically remove these files which may be on external storage (this is potentially annoying but not the end of the world).


(aside and looking at 6.1.24/6.2.0)
I've a small additional PR incoming which I'd like to propose which fixes this which I'd like to see in 6.2.0 so we don't have lost files and LFN everywhere. I think I can do this in a fully backwards compatible way so that only future jobs store the information this way. I propose we keep the current system for removing the shared dir, and just add a step to remove additional files not in the sharedDir on disk but are registered with the sharedDir.
(The problem comes in fixing a long standing bug in how we handle these sharedDir objects in XML which will hold the PR up a bit).