### PR TITLE
Migrating is_prepared to ComponentItem and cleaning up Schema

### DIFF
--- a/python/Ganga/Core/GangaRepository/VStreamer.py
+++ b/python/Ganga/Core/GangaRepository/VStreamer.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, absolute_import
 from Ganga.Core.exceptions import GangaException
 from Ganga.Utility.logging import getLogger
-from Ganga.GPIDev.Base.Proxy import stripProxy, isType, getName
+from Ganga.GPIDev.Base.Objects import _getName
 
 from Ganga.GPIDev.Lib.GangaList.GangaList import GangaList, makeGangaListByRef
 
@@ -50,7 +50,7 @@ class XMLFileError(GangaException):
 def _raw_to_file(j, fobj=None, ignore_subs=[]):
     vstreamer = VStreamer(out=fobj, selection=ignore_subs)
     vstreamer.begin_root()
-    stripProxy(j).accept(vstreamer)
+    j.accept(vstreamer)
     vstreamer.end_root()
 
 def to_file(j, fobj=None, ignore_subs=[]):
@@ -122,7 +122,7 @@ def fastXML(obj, indent='', ignore_subs=''):
         return sl
     elif hasattr(obj, '_data'):
         v = obj._schema.version
-        sl = ['\n', indent, '<class name="%s" version="%i.%i" category="%s">\n' % (getName(obj), v.major, v.minor, obj._category)]
+        sl = ['\n', indent, '<class name="%s" version="%i.%i" category="%s">\n' % (_getName(obj), v.major, v.minor, obj._category)]
         for attr_name in obj._schema.allItemNames():
             k = attr_name
             o = getattr(obj, k)
@@ -140,7 +140,7 @@ def fastXML(obj, indent='', ignore_subs=''):
         sl.append('</class>')
         return sl
     else:
-        return ["<value>", escape(repr(stripProxy(obj))), "</value>"]
+        return ["<value>", escape(repr(obj)), "</value>"]
 
 ##########################################################################
 # A visitor to print the object tree into XML.
@@ -182,7 +182,7 @@ class VStreamer(object):
         return
 
     def print_value(self, x):
-        print('\n', self.indent(), '<value>%s</value>' % escape(repr(stripProxy(x))), file=self.out)
+        print('\n', self.indent(), '<value>%s</value>' % escape(repr(x)), file=self.out)
 
     def showAttribute(self, node, name):
         return not node._schema.getItem(name)['transient'] and (self.level > 1 or name not in self.selection)
@@ -203,6 +203,8 @@ class VStreamer(object):
                 print(self.indent(), '</attribute>', file=self.out)
             else:
                 self.level += 1
+                if hasattr(value, 'accept'):
+                    raise GangaException("Trying to store a GangaObject using a repr, rather than storing it correctly as XML")
                 self.print_value(value)
                 self.level -= 1
                 print(self.indent(), end=' ', file=self.out)
@@ -217,17 +219,17 @@ class VStreamer(object):
         if s is None:
             print(self.indent(), '<value>None</value>', file=self.out)
         else:
-            if isType(s, str):
+            if isinstance(s, str):
                 print(self.indent(), '<value>%s</value>' % escape(repr(s)), file=self.out)
-            elif hasattr(stripProxy(s), 'accept'):
-                stripProxy(s).accept(self)
-            elif isType(s, (list, tuple, GangaList)):
+            elif hasattr(s, 'accept'):
+                s.accept(self)
+            elif isinstance(s, (list, tuple, GangaList)):
                 print(self.indent(), '<sequence>', file=self.out)
                 for sub_s in s:
                     self.acceptOptional(sub_s)
                 print(self.indent(), '</sequence>', file=self.out)
             else:
-                self.print_value(stripProxy(s))
+                self.print_value(s)
         self.level -= 1
 
     def componentAttribute(self, node, name, subnode, sequence):

--- a/python/Ganga/Lib/Executable/Executable.py
+++ b/python/Ganga/Lib/Executable/Executable.py
@@ -6,7 +6,7 @@
 
 from Ganga.GPIDev.Adapters.IPrepareApp import IPrepareApp
 from Ganga.GPIDev.Adapters.IRuntimeHandler import IRuntimeHandler
-from Ganga.GPIDev.Schema import Schema, Version, SimpleItem
+from Ganga.GPIDev.Schema import Schema, Version, SimpleItem, ComponentItem
 
 from Ganga.Utility.Config import getConfig
 
@@ -55,8 +55,8 @@ class Executable(IPrepareApp):
         'exe': SimpleItem(preparable=1, defvalue='echo', typelist=[str, File], comparable=1, doc='A path (string) or a File object specifying an executable.'),
         'args': SimpleItem(defvalue=["Hello World"], typelist=[str, File, int], sequence=1, strict_sequence=0, doc="List of arguments for the executable. Arguments may be strings, numerics or File objects."),
         'env': SimpleItem(defvalue={}, typelist=[str], doc='Dictionary of environment variables that will be replaced in the running environment.'),
-       'is_prepared': SimpleItem(defvalue=None, strict_sequence=0, visitable=1, copyable=1, hidden=0, typelist=[None, ShareDir], protected=0, comparable=1, doc='Location of shared resources. Presence of this attribute implies the application has been prepared.'),
-        'hash': SimpleItem(defvalue=None, typelist=[None, str], hidden=0, doc='MD5 hash of the string representation of applications preparable attributes')
+       'is_prepared': ComponentItem('shareddirs', strict_sequence=0, visitable=1, copyable=1, hidden=0, typelist=[None, ShareDir], protected=0, comparable=1, doc='Location of shared resources. Presence of this attribute implies the application has been prepared.'),
+        'hash': SimpleItem(defvalue=None, typelist=[None, str], hidden=1, doc='MD5 hash of the string representation of applications preparable attributes')
     })
     _category = 'applications'
     _name = 'Executable'

--- a/python/Ganga/Lib/LCG/CREAM.py
+++ b/python/Ganga/Lib/LCG/CREAM.py
@@ -68,7 +68,7 @@ class CREAM(IBackend):
         'workernode': SimpleItem(defvalue='', protected=1, copyable=0, doc='The worker node on which the job actually runs.'),
         'isbURI': SimpleItem(defvalue='', protected=1, copyable=0, doc='The input sandbox URI on CREAM CE'),
         'osbURI': SimpleItem(defvalue='', protected=1, copyable=0, doc='The output sandbox URI on CREAM CE'),
-        'delegation_id': SimpleItem(defvalue='', typelist=['str'], hidden=True),
+        'delegation_id': SimpleItem(defvalue='', typelist=[str], hidden=True),
     })
 
     _category = 'backends'

--- a/python/Ganga/Lib/Root/Root.py
+++ b/python/Ganga/Lib/Root/Root.py
@@ -8,7 +8,7 @@ from __future__ import print_function
 
 from Ganga.GPIDev.Adapters.IPrepareApp import IPrepareApp
 from Ganga.GPIDev.Adapters.IRuntimeHandler import IRuntimeHandler
-from Ganga.GPIDev.Schema import Schema, Version, SimpleItem, FileItem
+from Ganga.GPIDev.Schema import Schema, Version, SimpleItem, FileItem, ComponentItem
 from Ganga.GPIDev.Lib.File import File, ShareDir
 
 from Ganga.Utility.Config import getConfig, ConfigError
@@ -206,7 +206,7 @@ class Root(IPrepareApp):
         'args': SimpleItem(defvalue=[], typelist=[str, int], sequence=1, doc="List of arguments for the script. Accepted types are numerics and strings"),
         'version': SimpleItem(defvalue='6.04.02', doc="The version of Root to run"),
         'usepython': SimpleItem(defvalue=False, doc="Execute 'script' using Python. The PyRoot libraries are added to the PYTHONPATH."),
-        'is_prepared': SimpleItem(defvalue=None, strict_sequence=0, visitable=1, copyable=1, typelist=[None, bool], protected=1, hidden=0, comparable=1, doc='Location of shared resources. Presence of this attribute implies the application has been prepared.'),
+        'is_prepared': ComponentItem('shareddirs', strict_sequence=0, visitable=1, copyable=1, typelist=[None, bool, ShareDir], protected=1, hidden=0, comparable=1, doc='Location of shared resources. Presence of this attribute implies the application has been prepared.'),
         'hash': SimpleItem(defvalue=None, typelist=[None, str], hidden=1, doc='MD5 hash of the string representation of applications preparable attributes')
     })
     _category = 'applications'

--- a/python/GangaDirac/Lib/Backends/DiracBase.py
+++ b/python/GangaDirac/Lib/Backends/DiracBase.py
@@ -62,26 +62,26 @@ class DiracBase(IBackend):
 
     _schema = Schema(Version(3, 2), {
         'id': SimpleItem(defvalue=None, protected=1, copyable=0,
-                         typelist=['int', 'type(None)'],
+                         typelist=[int, None],
                          doc='The id number assigned to the job by the DIRAC WMS. If seeking help'
                          ' on jobs with the Dirac backend, please always report this id '
                          'number in addition to a full description of your problem. The id '
                          'can also be used to further inspect the job at '
                          'https://lhcbweb.pic.es/DIRAC/info/general/diracOverview'),
         'status': SimpleItem(defvalue=None, protected=1, copyable=0,
-                             typelist=['str', 'type(None)'],
+                             typelist=[str, None],
                              doc='The detailed status as reported by the DIRAC WMS'),
         'actualCE': SimpleItem(defvalue=None, protected=1, copyable=0,
-                               typelist=['str', 'type(None)'],
+                               typelist=[str, None],
                                doc='The location where the job ran'),
         'normCPUTime': SimpleItem(defvalue=None, protected=1, copyable=0,
-                                  typelist=['str', 'type(None)'],
+                                  typelist=[str, None],
                                   doc='The normalized CPU time reported by the DIRAC WMS'),
         'statusInfo': SimpleItem(defvalue='', protected=1, copyable=0,
-                                 typelist=['str', 'type(None)'],
+                                 typelist=[str, None],
                                  doc='Minor status information from Dirac'),
         'extraInfo': SimpleItem(defvalue='', protected=1, copyable=0,
-                                typelist=['str', 'type(None)'],
+                                typelist=[str, None],
                                 doc='Application status information from Dirac'),
         'diracOpts': SimpleItem(defvalue='',
                                 doc='DIRAC API commands to add the job definition script. Only edit '

--- a/python/GangaDirac/Lib/Files/DiracFile.py
+++ b/python/GangaDirac/Lib/Files/DiracFile.py
@@ -32,18 +32,18 @@ class DiracFile(IGangaFile):
     File stored on a DIRAC storage element
     """
     _schema = Schema(Version(1, 1), {'namePattern': SimpleItem(defvalue="", doc='pattern of the file name'),
-                                     'localDir': SimpleItem(defvalue=None, copyable=1, typelist=['str', 'type(None)'],
+                                     'localDir': SimpleItem(defvalue=None, copyable=1, typelist=[str, None],
                                                             doc='local dir where the file is stored, used from get and put methods'),
-                                     'locations': SimpleItem(defvalue=[], copyable=1, typelist=['str'], sequence=1,
+                                     'locations': SimpleItem(defvalue=[], copyable=1, typelist=[str], sequence=1,
                                                              doc="list of SE locations where the outputfiles are uploaded"),
                                      'compressed': SimpleItem(defvalue=False, typelist=['bool'], protected=0,
                                                               doc='wheather the output file should be compressed before sending somewhere'),
-                                     'lfn': SimpleItem(defvalue='', copyable=1, typelist=['str'],
+                                     'lfn': SimpleItem(defvalue='', copyable=1, typelist=[str],
                                                        doc='return the logical file name/set the logical file name to use if not '
                                                        'using wildcards in namePattern'),
                                      'remoteDir': SimpleItem(defvalue="", doc='remote directory where the LFN is to be placed within '
                                                              'the dirac base directory by the put method.'),
-                                     'guid': SimpleItem(defvalue='', copyable=1, typelist=['str'],
+                                     'guid': SimpleItem(defvalue='', copyable=1, typelist=[str],
                                                         doc='return the GUID/set the GUID to use if not using wildcards in the namePattern.'),
                                      'subfiles': ComponentItem(category='gangafiles', defvalue=[], sequence=1, copyable=0,  # hidden=1,
                                                                typelist=['GangaDirac.Lib.Files.DiracFile'], doc="collected files from the wildcard namePattern"),

--- a/python/GangaGaudi/Lib/Applications/Gaudi.py
+++ b/python/GangaGaudi/Lib/Applications/Gaudi.py
@@ -72,7 +72,7 @@ class Gaudi(GaudiBase):
 
     docstr = 'The gaudirun.py cli args that will be passed at run-time'
     _schema.datadict['args'] = SimpleItem(defvalue=['-T'], sequence=1, strict_sequence=0,
-                                          typelist=['str', 'type(None)'], doc=docstr)
+                                          typelist=[str, None], doc=docstr)
     docstr = 'The name of the optionsfile. Import statements in the file ' \
              'will be expanded at submission time and a full copy made'
     _schema.datadict['optsfile'] = FileItem(preparable=1, sequence=1, strict_sequence=0, defvalue=[],
@@ -83,7 +83,7 @@ class Gaudi(GaudiBase):
              '\"myPlots.root"\\nEventSelector().PrintFreq = 100\n or by '  \
              'using triple quotes around a multiline string.'
     _schema.datadict['extraopts'] = SimpleItem(preparable=1, defvalue=None,
-                                               typelist=['str', 'type(None)'], doc=docstr)
+                                               typelist=[str, None], doc=docstr)
 
     _schema.version.major += 0
     _schema.version.minor += 0

--- a/python/GangaGaudi/Lib/Applications/GaudiBase.py
+++ b/python/GangaGaudi/Lib/Applications/GaudiBase.py
@@ -6,7 +6,7 @@ import tempfile
 import gzip
 import shutil
 from Ganga.GPIDev.Base.Proxy import stripProxy
-from Ganga.GPIDev.Schema import SimpleItem, Schema, Version
+from Ganga.GPIDev.Schema import SimpleItem, Schema, Version, ComponentItem
 from Ganga.GPIDev.Adapters.IPrepareApp import IPrepareApp
 import Ganga.Utility.logging
 from Ganga.Utility.files import expandfilename, fullpath
@@ -30,39 +30,40 @@ class GaudiBase(IPrepareApp):
     schema = {}
     docstr = 'The version of the application (like "v19r2")'
     schema['version'] = SimpleItem(preparable=1, defvalue=None,
-                                   typelist=['str', 'type(None)'], doc=docstr)
+                                   typelist=[str, None], doc=docstr)
     docstr = 'The platform the application is configured for (e.g. ' \
              '"slc4_ia32_gcc34")'
     schema['platform'] = SimpleItem(preparable=1, defvalue=None,
-                                    typelist=['str', 'type(None)'], doc=docstr)
+                                    typelist=[str, None], doc=docstr)
     docstr = 'The user path to be used. After assigning this'  \
              ' you can do j.application.getpack(\'Phys DaVinci v19r2\') to'  \
              ' check out into the new location. This variable is used to '  \
              'identify private user DLLs by parsing the output of "cmt '  \
              'show projects".'
     schema['user_release_area'] = SimpleItem(preparable=1, defvalue=None,
-                                             typelist=['str', 'type(None)'],
+                                             typelist=[str, None],
                                              doc=docstr)
     docstr = 'The name of the Gaudi application (e.g. "DaVinci", "Gauss"...)'
-    schema['appname'] = SimpleItem(preparable=1, defvalue=None, typelist=['str', 'type(None)'],
+    schema['appname'] = SimpleItem(preparable=1, defvalue=None, typelist=[str, None],
                                    hidden=1, doc=docstr)
     docstr = 'Location of shared resources. Presence of this attribute implies'\
              'the application has been prepared.'
-    schema['is_prepared'] = SimpleItem(defvalue=None,
+    schema['is_prepared'] = ComponentItem('shareddirs',
+                                       defvalue=None,
                                        strict_sequence=0,
                                        visitable=1,
                                        copyable=1,
-                                       typelist=['type(None)', 'str', ShareDir],
+                                       typelist=[None, str, ShareDir],
                                        hidden=0,
                                        protected=1,
                                        doc=docstr)
     docstr = 'The env'
     schema['env'] = SimpleItem(preparable=1, transient=1, defvalue=None,
-                               hidden=1, doc=docstr, typelist=['type(None)', 'dict'])
+                               hidden=1, doc=docstr, typelist=[None, dict])
     docstr = 'MD5 hash of the string representation of applications preparable attributes'
-    schema['hash'] = SimpleItem(defvalue=None, typelist=['type(None)', 'str'], hidden=1)
+    schema['hash'] = SimpleItem(defvalue=None, typelist=[None, str], hidden=1)
 
-    schema['newStyleApp'] = SimpleItem(defvalue=False, typelist=['bool'], doc="Is this app a 'new Style' CMake app?")
+    schema['newStyleApp'] = SimpleItem(defvalue=False, typelist=[bool], doc="Is this app a 'new Style' CMake app?")
 
     _name = 'GaudiBase'
     _exportmethods = ['getenv', 'getpack', 'make', 'projectCMD', 'cmt']

--- a/python/GangaGaudi/Lib/Datasets/GaudiDataset.py
+++ b/python/GangaGaudi/Lib/Datasets/GaudiDataset.py
@@ -21,7 +21,7 @@ class GaudiDataset(Dataset):
     '''
     schema = {}
     docstr = 'List of PhysicalFile and DiracFile objects'
-    schema['files'] = SimpleItem(defvalue=[], typelist=['str', 'type(None)'],
+    schema['files'] = SimpleItem(defvalue=[], typelist=[str, None],
                                  sequence=1, doc=docstr)
 
     _schema = Schema(Version(3, 0), schema)

--- a/python/GangaGaudi/Lib/Splitters/GaudiInputDataSplitter.py
+++ b/python/GangaGaudi/Lib/Splitters/GaudiInputDataSplitter.py
@@ -20,10 +20,10 @@ class GaudiInputDataSplitter(ISplitter):
     _schema = Schema(Version(1, 0), {
         'filesPerJob': SimpleItem(defvalue=10,
                                   doc='Number of files per subjob',
-                                  typelist=['int']),
+                                  typelist=[int]),
         'maxFiles': SimpleItem(defvalue=None,
                                doc='Maximum number of files to use in a masterjob (None = all files)',
-                               typelist=['int', 'type(None)'])
+                               typelist=[int, None])
     })
 
     # returns splitter generator can be overridden for modified behaviour

--- a/python/GangaLHCb/Lib/Applications/AppsBase.py
+++ b/python/GangaLHCb/Lib/Applications/AppsBase.py
@@ -60,7 +60,7 @@ class AppName(Gaudi):
     _schema = Gaudi._schema.inherit_copy()
     docstr = 'The package the application belongs to (e.g. "Sim", "Phys")'
     _schema.datadict['package'] = SimpleItem(defvalue=None,
-                                             typelist=['str', 'type(None)'],
+                                             typelist=[str, None],
                                              doc=docstr)
     docstr = 'The package where your top level requirements file is read '  \
              'from. Can be written either as a path '  \
@@ -68,7 +68,7 @@ class AppName(Gaudi):
              '\"Analysis v6r0 Tutorial\"'
     _schema.datadict['masterpackage'] = SimpleItem(defvalue=None,
                                                    typelist=[
-                                                       'str', 'type(None)'],
+                                                       str, None],
                                                    doc=docstr)
     docstr = 'Extra options to be passed onto the SetupProject command '\
              'used for configuring the environment. As an example '\
@@ -77,7 +77,7 @@ class AppName(Gaudi):
              'https://twiki.cern.ch/twiki/bin/view/LHCb/SetupProject'
     _schema.datadict['setupProjectOptions'] = SimpleItem(defvalue='',
                                                          typelist=[
-                                                             'str', 'type(None)'],
+                                                             str, None],
                                                          doc=docstr)
 
     _schema.version.major += 2

--- a/python/GangaLHCb/Lib/Applications/Bender.py
+++ b/python/GangaLHCb/Lib/Applications/Bender.py
@@ -53,7 +53,7 @@ class Bender(GaudiBase):
     _schema = GaudiBase._schema.inherit_copy()
     docstr = 'The package the application belongs to (e.g. "Sim", "Phys")'
     _schema.datadict['package'] = SimpleItem(defvalue=None,
-                                             typelist=['str', 'type(None)'],
+                                             typelist=[str, None],
                                              doc=docstr)
     docstr = 'The package where your top level requirements file is read '  \
              'from. Can be written either as a path '  \
@@ -61,7 +61,7 @@ class Bender(GaudiBase):
              '\"Analysis v6r0 Tutorial\"'
     _schema.datadict['masterpackage'] = SimpleItem(defvalue=None,
                                                    typelist=[
-                                                       'str', 'type(None)'],
+                                                       str, None],
                                                    doc=docstr)
     docstr = 'Extra options to be passed onto the SetupProject command '\
              'used for configuring the environment. As an example '\
@@ -70,20 +70,20 @@ class Bender(GaudiBase):
              'https://twiki.cern.ch/twiki/bin/view/LHCb/SetupProject'
     _schema.datadict['setupProjectOptions'] = SimpleItem(defvalue='',
                                                          typelist=[
-                                                             'str', 'type(None)'],
+                                                             str, None],
                                                          doc=docstr)
     docstr = 'The name of the module to import. A copy will be made ' \
              'at submission time'
     _schema.datadict['module'] = FileItem(preparable=1, defvalue=File(), doc=docstr)
     docstr = 'The name of the Gaudi application (Bender)'
     _schema.datadict['project'] = SimpleItem(preparable=1, defvalue='Bender', hidden=1, protected=1,
-                                             typelist=['str'], doc=docstr)
+                                             typelist=[str], doc=docstr)
     docstr = 'The number of events '
     _schema.datadict['events'] = SimpleItem(
-        defvalue=-1, typelist=['int'], doc=docstr)
+        defvalue=-1, typelist=[int], doc=docstr)
     docstr = 'Parameres for module '
     _schema.datadict['params'] = SimpleItem(
-        defvalue={}, typelist=['dict', 'str', 'int', 'bool', 'float'], doc=docstr)
+        defvalue={}, typelist=[dict, str, int, bool, float], doc=docstr)
     _schema.version.major += 2
     _schema.version.minor += 0
 

--- a/python/GangaLHCb/Lib/Applications/BenderScript.py
+++ b/python/GangaLHCb/Lib/Applications/BenderScript.py
@@ -191,13 +191,13 @@ class BenderScript(GaudiBase):
     
     _schema.datadict['package'] = SimpleItem(
         defvalue = None,
-        typelist = ['str', 'type(None)'],
+        typelist = [str, None],
         doc      = """The package the application belongs to (e.g. 'Sim', 'Phys')
         """
         )
     _schema.datadict['masterpackage'] = SimpleItem (
         defvalue = None,
-        typelist = [ 'str', 'type(None)' ],
+        typelist = [str, None],
         doc      = """The package where your top level requirements file is read from.
         Can be written either as a path 'Tutorial/Analysis/v6r0' or in traditional notation 
         'Analysis v6r0 Tutorial'
@@ -206,7 +206,7 @@ class BenderScript(GaudiBase):
     
     _schema.datadict['setupProjectOptions'] = SimpleItem(
         defvalue = ''     ,
-        typelist = [ 'str', 'type(None)'],
+        typelist = [str, None],
         doc      = """Extra options to be passed onto the SetupProject command
         used for configuring the environment. As an example 
         setting it to '--dev' will give access to the DEV area. 
@@ -237,7 +237,7 @@ class BenderScript(GaudiBase):
     
     _schema.datadict['commands'] = SimpleItem(
         defvalue = []      ,
-        typelist = ['str'] ,
+        typelist = [str] ,
         sequence =  1      ,
         doc      = """The commands to be executed,
         e.g. [ 'run(10)' , 'print ls()' , 'print dir()' ]
@@ -246,7 +246,7 @@ class BenderScript(GaudiBase):
     
     _schema.datadict['arguments'] = SimpleItem(
         defvalue = []      ,
-        typelist = ['str'] ,
+        typelist = [str] ,
         sequence =  1      ,
         doc      = """List of command-line arguments for bender script,
         e.g. ['-w','-p5'], etc.

--- a/python/GangaLHCb/Lib/Applications/GaudiExec.py
+++ b/python/GangaLHCb/Lib/Applications/GaudiExec.py
@@ -16,7 +16,7 @@ from Ganga.GPIDev.Base.Filters import allComponentFilters
 from Ganga.GPIDev.Base.Proxy import getName
 from Ganga.GPIDev.Lib.File.File import ShareDir
 from Ganga.GPIDev.Lib.File.LocalFile import LocalFile
-from Ganga.GPIDev.Schema import Schema, Version, SimpleItem, GangaFileItem
+from Ganga.GPIDev.Schema import Schema, Version, SimpleItem, GangaFileItem, ComponentItem
 from Ganga.Utility.logging import getLogger
 from Ganga.Utility.files import expandfilename, fullpath
 
@@ -101,7 +101,7 @@ class GaudiExec(IPrepareApp):
         'extraArgs':    SimpleItem(defvalue=[], typelist=[list], sequence=1, doc='Extra runtime arguments which are passed to the code running on the WN'),
 
         # Prepared job object
-        'is_prepared':  SimpleItem(defvalue=None, strict_sequence=0, visitable=1, copyable=1, hidden=0, typelist=[None, ShareDir], protected=0, comparable=1,
+        'is_prepared':  ComponentItem('shareddirs', strict_sequence=0, visitable=1, copyable=1, hidden=0, typelist=[None, ShareDir], protected=0, comparable=1,
             doc='Location of shared resources. Presence of this attribute implies the application has been prepared.'),
         'hash':         SimpleItem(defvalue=None, typelist=[None, str], hidden=1, doc='MD5 hash of the string representation of applications preparable attributes'),
         })

--- a/python/GangaLHCb/Lib/Applications/GaudiPython.py
+++ b/python/GangaLHCb/Lib/Applications/GaudiPython.py
@@ -69,7 +69,7 @@ class GaudiPython(GaudiBase):
     _schema = GaudiBase._schema.inherit_copy()
     docstr = 'The package the application belongs to (e.g. "Sim", "Phys")'
     _schema.datadict['package'] = SimpleItem(defvalue=None,
-                                             typelist=['str', 'type(None)'],
+                                             typelist=[str, None],
                                              doc=docstr)
     docstr = 'The package where your top level requirements file is read '  \
              'from. Can be written either as a path '  \
@@ -77,7 +77,7 @@ class GaudiPython(GaudiBase):
              '\"Analysis v6r0 Tutorial\"'
     _schema.datadict['masterpackage'] = SimpleItem(defvalue=None,
                                                    typelist=[
-                                                       'str', 'type(None)'],
+                                                       str, None],
                                                    doc=docstr)
     docstr = 'Extra options to be passed onto the SetupProject command '\
              'used for configuring the environment. As an example '\
@@ -86,18 +86,18 @@ class GaudiPython(GaudiBase):
              'https://twiki.cern.ch/twiki/bin/view/LHCb/SetupProject'
     _schema.datadict['setupProjectOptions'] = SimpleItem(defvalue='',
                                                          typelist=[
-                                                             'str', 'type(None)'],
+                                                             str, None],
                                                          doc=docstr)
     docstr = 'The name of the script to execute. A copy will be made ' + \
              'at submission time'
     _schema.datadict['script'] = FileItem(preparable=1, sequence=1, strict_sequence=0, defvalue=[],
                                           doc=docstr)
     docstr = "List of arguments for the script"
-    _schema.datadict['args'] = SimpleItem(defvalue=[], typelist=['str'],
+    _schema.datadict['args'] = SimpleItem(defvalue=[], typelist=[str],
                                           sequence=1, doc=docstr)
     docstr = 'The name of the Gaudi application (e.g. "DaVinci", "Gauss"...)'
     _schema.datadict['project'] = SimpleItem(preparable=1, defvalue=None,
-                                             typelist=['str', 'type(None)'],
+                                             typelist=[str, None],
                                              doc=docstr)
     _schema.version.major += 2
     _schema.version.minor += 0

--- a/python/GangaLHCb/Lib/Applications/Ostap.py
+++ b/python/GangaLHCb/Lib/Applications/Ostap.py
@@ -175,13 +175,13 @@ class Ostap(GaudiBase):
 
     _schema.datadict['package'] = SimpleItem(
         defvalue = None,
-        typelist = ['str', 'type(None)'],
+        typelist = [str, None],
         doc      = """The package the application belongs to (e.g. 'Sim', 'Phys')
         """
         )
     _schema.datadict['masterpackage'] = SimpleItem (
         defvalue = None,
-        typelist = [ 'str', 'type(None)' ],
+        typelist = [str, None],
         doc      = """The package where your top level requirements file is read from.
         Can be written either as a path 'Tutorial/Analysis/v6r0' or in traditional notation 
         'Analysis v6r0 Tutorial'
@@ -190,7 +190,7 @@ class Ostap(GaudiBase):
     
     _schema.datadict['setupProjectOptions'] = SimpleItem(
         defvalue = ''     ,
-        typelist = [ 'str', 'type(None)'],
+        typelist = [str, None],
         doc      = """Extra options to be passed onto the SetupProject command
         used for configuring the environment. As an example 
         setting it to '--dev' will give access to the DEV area. 
@@ -211,7 +211,7 @@ class Ostap(GaudiBase):
     
     _schema.datadict['commands'] = SimpleItem(
         defvalue = []      ,
-        typelist = ['str'] ,
+        typelist = [str] ,
         sequence =  1      ,
         doc      = """The commands to be executed,
         e.g. [ 'run(10)' , 'print ls()' , 'print dir()' ]
@@ -220,7 +220,7 @@ class Ostap(GaudiBase):
     
     _schema.datadict['arguments'] = SimpleItem(
         defvalue = []      ,
-        typelist = ['str'] ,
+        typelist = [str] ,
         sequence =  1      ,
         doc      = """List of command-line arguments for bender script,
         e.g. ['-w','-p5'], etc.

--- a/python/GangaLHCb/Lib/Backends/Bookkeeping.py
+++ b/python/GangaLHCb/Lib/Backends/Bookkeeping.py
@@ -14,7 +14,7 @@ logger = Ganga.Utility.logging.getLogger()
 #\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\#
 
 schema = {'status': SimpleItem(defvalue=None, protected=1, copyable=0,
-                               typelist=['str', 'type(None)'],
+                               typelist=[str, None],
                                doc='Status of the bookkeeping system')}
 
 

--- a/python/GangaLHCb/Lib/Files/LogicalFile.py
+++ b/python/GangaLHCb/Lib/Files/LogicalFile.py
@@ -26,17 +26,17 @@ class LogicalFile(DiracFile):
     # case
     _schema = Schema(Version(1, 0), {'name': SimpleItem(defvalue="", doc='the LFN filename a LogicalFile is constructed with'),
                                      'namePattern': SimpleItem(defvalue="", doc='pattern of the file name', transient=1),
-                                     'localDir': SimpleItem(defvalue=None, copyable=1, typelist=['str', 'type(None)'],
+                                     'localDir': SimpleItem(defvalue=None, copyable=1, typelist=[str, None],
                                                             doc='local dir where the file is stored, used from get and put methods', transient=1),
                                      'remoteDir': SimpleItem(defvalue="", doc='remote directory where the LFN is to be placed in the dirac base directory by the put method.', transient=1),
-                                     'locations': SimpleItem(defvalue=[], copyable=1, typelist=['str'], sequence=1,
+                                     'locations': SimpleItem(defvalue=[], copyable=1, typelist=[str], sequence=1,
                                                              doc="list of SE locations where the outputfiles are uploaded", transient=1),
                                      'compressed': SimpleItem(defvalue=False, typelist=['bool'], protected=0,
                                                               doc='wheather the output file should be compressed before sending somewhere', transient=1),
-                                     'lfn': SimpleItem(defvalue='', copyable=1, typelist=['str'],
+                                     'lfn': SimpleItem(defvalue='', copyable=1, typelist=[str],
                                                        doc='return the logical file name/set the logical file name to use if not '
                                                        'using wildcards in namePattern', transient=1),
-                                     'guid': SimpleItem(defvalue='', copyable=1, typelist=['str'],
+                                     'guid': SimpleItem(defvalue='', copyable=1, typelist=[str],
                                                         doc='return the GUID/set the GUID to use if not using wildcards in the namePattern.', transient=1),
                                      'subfiles': ComponentItem(category='gangafiles', defvalue=[], hidden=1, sequence=1, copyable=0,
                                                                typelist=[

--- a/python/GangaLHCb/Lib/LHCbDataset/BKQuery.py
+++ b/python/GangaLHCb/Lib/LHCbDataset/BKQuery.py
@@ -82,7 +82,7 @@ RecoToDST-07/90000000/DST" ,
     docstr = 'End date string yyyy-mm-dd (only works for type="RunsByDate")'
     schema['endDate'] = SimpleItem(defvalue='', doc=docstr)
     docstr = 'Data quality flag (string or list of strings).'
-    schema['dqflag'] = SimpleItem(defvalue='OK', typelist=['str', 'list'], doc=docstr)
+    schema['dqflag'] = SimpleItem(defvalue='OK', typelist=[str, list], doc=docstr)
     docstr = 'Type of query (Path, RunsByDate, Run, Production)'
     schema['type'] = SimpleItem(defvalue='Path', doc=docstr)
     docstr = 'Selection criteria: Runs, ProcessedRuns, NotProcessed (only works for type="RunsByDate")'

--- a/python/GangaLHCb/Lib/LHCbDataset/LHCbDataset.py
+++ b/python/GangaLHCb/Lib/LHCbDataset/LHCbDataset.py
@@ -37,14 +37,14 @@ class LHCbDataset(GangaDataset):
     '''
     schema = {}
     docstr = 'List of PhysicalFile and DiracFile objects'
-    schema['files'] = GangaFileItem(defvalue=[], typelist=['str', 'Ganga.GPIDev.Adapters.IGangaFile.IGangaFile'], sequence=1, doc=docstr)
+    schema['files'] = GangaFileItem(defvalue=[], typelist=[str, 'Ganga.GPIDev.Adapters.IGangaFile.IGangaFile'], sequence=1, doc=docstr)
     docstr = 'Ancestor depth to be queried from the Bookkeeping'
     schema['depth'] = SimpleItem(defvalue=0, doc=docstr)
     docstr = 'Use contents of file rather than generating catalog.'
     schema['XMLCatalogueSlice'] = GangaFileItem(defvalue=None, doc=docstr)
     docstr = 'Specify the dataset persistency technology'
     schema['persistency'] = SimpleItem(
-        defvalue=None, typelist=['str', 'type(None)'], doc=docstr)
+        defvalue=None, typelist=[str, None], doc=docstr)
     schema['treat_as_inputfiles'] = SimpleItem(defvalue=False, doc="Treat the inputdata as inputfiles, i.e. copy the inputdata to the WN")
 
     _schema = Schema(Version(3, 0), schema)

--- a/python/GangaLHCb/Lib/Splitters/SplitByFiles.py
+++ b/python/GangaLHCb/Lib/Splitters/SplitByFiles.py
@@ -36,11 +36,11 @@ class SplitByFiles(GaudiInputDataSplitter):
     _schema = Schema(Version(1, 0), {
         'filesPerJob': SimpleItem(defvalue=10,
                                   doc='Number of files per subjob',
-                                  typelist=['int']),
+                                  typelist=[int]),
 
         'maxFiles': SimpleItem(defvalue=None,
                                doc='Maximum number of files to use in a masterjob (None = all files)',
-                               typelist=['int', 'type(None)']),
+                               typelist=[int, None]),
 
         'bulksubmit': SimpleItem(defvalue=False,
                                  doc='determines if subjobs are split '
@@ -54,7 +54,7 @@ class SplitByFiles(GaudiInputDataSplitter):
 
         'splitterBackend': SimpleItem(defvalue=getBackend(),
                                       doc='name of the backend algorithm to use for splitting',
-                                      typelist=['str'], protected=1, visitable=0)
+                                      typelist=[str], protected=1, visitable=0)
     })
 
     _exportmethods = ['split']

--- a/python/GangaLHCb/Lib/Tasks/BKTestQuery.py
+++ b/python/GangaLHCb/Lib/Tasks/BKTestQuery.py
@@ -15,7 +15,7 @@ class BKTestQuery(BKQuery):
     ##     docstr = 'End date string yyyy-mm-dd (only works for type="RunsByDate")'
     ##     schema['endDate'] = SimpleItem(defvalue='' ,doc=docstr)
     ##     docstr = 'Data quality flag (string or list of strings).'
-    # schema['dqflag'] = SimpleItem(defvalue='All',typelist=['str','list'],
+    # schema['dqflag'] = SimpleItem(defvalue='All',typelist=[str, list],
     # doc=docstr)
     ##     docstr = 'Type of query (Path, RunsByDate, Run, Production)'
     ##     schema['type'] = SimpleItem(defvalue='Path',doc=docstr)
@@ -28,9 +28,9 @@ class BKTestQuery(BKQuery):
     _schema.datadict['fulldataset'] = ComponentItem(
         'datasets', defvalue=None, optional=1, load_default=False, doc='dataset', hidden=1)
     _schema.datadict['fulldatasetptr'] = SimpleItem(
-        defvalue=0, optional=0, load_default=True, doc='dataset position pointer', hidden=1, typeList=['int'])
+        defvalue=0, optional=0, load_default=True, doc='dataset position pointer', hidden=1, typeList=[int])
     _schema.datadict['filesToRelease'] = SimpleItem(
-        defvalue=3, optional=0, load_default=True, doc='number of files to release at a time', hidden=0, typeList=['int'])
+        defvalue=3, optional=0, load_default=True, doc='number of files to release at a time', hidden=0, typeList=[int])
     _category = 'query'
     _name = "BKTestQuery"
     _exportmethods = BKQuery._exportmethods

--- a/python/GangaLSST/Lib/Im3ShapeApp/Im3ShapeApp.py
+++ b/python/GangaLSST/Lib/Im3ShapeApp/Im3ShapeApp.py
@@ -51,7 +51,7 @@ class Im3ShapeApp(IPrepareApp):
         'catalog': SimpleItem(defvalue='all', types=[str], doc="Catalog which is used to describe what is processed"),
         'run_dir': SimpleItem(defvalue='im3shape-grid', types=[str], doc="Directory on the WN where the binary is"),
         ## Below is needed for prepared state stuff
-        'is_prepared': SimpleItem(defvalue=None, strict_sequence=0, visitable=1, copyable=1, hidden=0, typelist=[None, ShareDir], protected=0, comparable=1, doc='Location of shared resources. Presence of this attribute implies the application has been prepared.'),
+        'is_prepared': ComponentItem('shareddirs', strict_sequence=0, visitable=1, copyable=1, hidden=0, typelist=[None, ShareDir], protected=0, comparable=1, doc='Location of shared resources. Presence of this attribute implies the application has been prepared.'),
         'hash': SimpleItem(defvalue=None, typelist=[None, str], hidden=0, doc='MD5 hash of the string representation of applications preparable attributes'),
     })
     _category = 'applications'

--- a/python/GangaNA62/Lib/Applications/NA62MC.py
+++ b/python/GangaNA62/Lib/Applications/NA62MC.py
@@ -24,19 +24,19 @@ class NA62MC(IPrepareApp):
     NA62MC application -- running arbitrary programs.
     """
     _schema = Schema(Version(2,0), {
-        'run_number' : SimpleItem(defvalue=-1,typelist=['int'],doc="Run Number to pass to the scripts"),
-        'seed'       : SimpleItem(defvalue=-1,typelist=['int'],doc="Random seed to pass to the scripts - overwritten by run_number if not given"),
-        'num_events' : SimpleItem(defvalue=-1,typelist=['int'],doc="Number of events to generate"),
-        'decay_type' : SimpleItem(defvalue=-1,typelist=['int'],doc="Decay type to generate"),
-        'decay_name' : SimpleItem(defvalue="",typelist=['str'],doc="String of the Decay type"),
-        'mc_version' : SimpleItem(defvalue=8,typelist=['int'],doc="MC version to use"),
-        'revision'   : SimpleItem(defvalue=0,typelist=['int'],doc="MC revision to use"),
-        'script_name': SimpleItem(defvalue="",typelist=['str'],doc="The name of the script to download and use on submission"),
-        'radcor'     : SimpleItem(defvalue=False,typelist=['bool'],doc="Use radiatve corrections or not"),
-        'file_prefix': SimpleItem(defvalue='pluto',typelist=['str'],doc="Prefix for output file"),
-        'job_type'   : SimpleItem(defvalue='prod',typelist=['str'],doc="Job type (e.g. prod or test)"),
-        'is_prepared': SharedItem(defvalue=None, strict_sequence=0, visitable=1, copyable=1, typelist=['type(None)', 'bool', 'str'],protected=0,doc='Location of shared resources. Presence of this attribute implies the application has been prepared.'),
-        'hash': SimpleItem(defvalue=None, typelist=['type(None)', 'str'], hidden=1, doc='MD5 hash of the string representation of applications preparable attributes')
+        'run_number' : SimpleItem(defvalue=-1,typelist=[int],doc="Run Number to pass to the scripts"),
+        'seed'       : SimpleItem(defvalue=-1,typelist=[int],doc="Random seed to pass to the scripts - overwritten by run_number if not given"),
+        'num_events' : SimpleItem(defvalue=-1,typelist=[int],doc="Number of events to generate"),
+        'decay_type' : SimpleItem(defvalue=-1,typelist=[int],doc="Decay type to generate"),
+        'decay_name' : SimpleItem(defvalue="",typelist=[str],doc="String of the Decay type"),
+        'mc_version' : SimpleItem(defvalue=8,typelist=[int],doc="MC version to use"),
+        'revision'   : SimpleItem(defvalue=0,typelist=[int],doc="MC revision to use"),
+        'script_name': SimpleItem(defvalue="",typelist=[str],doc="The name of the script to download and use on submission"),
+        'radcor'     : SimpleItem(defvalue=False,typelist=[bool],doc="Use radiatve corrections or not"),
+        'file_prefix': SimpleItem(defvalue='pluto',typelist=[str],doc="Prefix for output file"),
+        'job_type'   : SimpleItem(defvalue='prod',typelist=[str],doc="Job type (e.g. prod or test)"),
+        'is_prepared': ComponentItem('shareddirs', strict_sequence=0, visitable=1, copyable=1, typelist=[None, bool, str, ShareDir],protected=0,doc='Location of shared resources. Presence of this attribute implies the application has been prepared.'),
+        'hash': SimpleItem(defvalue=None, typelist=[None, str], hidden=1, doc='MD5 hash of the string representation of applications preparable attributes')
         } )
     _category = 'applications'
     _name = 'NA62MC'

--- a/python/GangaTest/Lib/GListApp/GListApp.py
+++ b/python/GangaTest/Lib/GListApp/GListApp.py
@@ -27,7 +27,7 @@ class GListApp(IPrepareApp):
         'gListComp': ComponentItem('files', defvalue=[], sequence=1),
         'simple_print': SimpleItem(defvalue='', summary_print='_print_summary_simple_print'),
         'comp_print': ComponentItem('backends', defvalue=None, summary_print='_print_summary_comp_print'),
-        'is_prepared': SimpleItem(defvalue=None, strict_sequence=0, visitable=1, copyable=1, hidden=0, typelist=['type(None)', 'bool', ShareDir], protected=0, comparable=1, doc='Location of shared resources. Presence of this attribute implies the application has been prepared.'),
+        'is_prepared': ComponentItem('shareddirs', strict_sequence=0, visitable=1, copyable=1, hidden=0, typelist=[None, bool, ShareDir], protected=0, comparable=1, doc='Location of shared resources. Presence of this attribute implies the application has been prepared.'),
     })
 
     def configure(self, master_appconfig):

--- a/python/GangaTest/Lib/TestApplication/TestApplication.py
+++ b/python/GangaTest/Lib/TestApplication/TestApplication.py
@@ -10,18 +10,18 @@ from Ganga.GPIDev.Lib.File import File
 
 class TestApplication(IPrepareApp):
     _schema = Schema(Version(1,0), {'exe':SimpleItem(defvalue='/usr/bin/env'),
-                                    'derived_value' : SimpleItem(defvalue='',typelist=['str']),
-                                    'sequence' : SimpleItem([],sequence=1,typelist=['str']),
+                                    'derived_value' : SimpleItem(defvalue='',typelist=[str]),
+                                    'sequence' : SimpleItem([],sequence=1,typelist=[str]),
                                     'file_sequence' : FileItem(defvalue=[],sequence=1),
                                     'optsfile' : FileItem(),
                                     'modified' : SimpleItem(defvalue=0),
                                     'nodefault_file_item' : FileItem(defvalue=File('a')),
-                                    'args' :  SimpleItem(defvalue=["Hello World"],typelist=['str','Ganga.GPIDev.Lib.File.File'],sequence=1,doc="List of arguments for the executable. Arguments may be strings or File objects."),# introduced for RTHandler compatibility
+                                    'args' :  SimpleItem(defvalue=["Hello World"],typelist=[str,'Ganga.GPIDev.Lib.File.File'],sequence=1,doc="List of arguments for the executable. Arguments may be strings or File objects."),# introduced for RTHandler compatibility
                                     'env' : SimpleItem(defvalue={},doc='Environment'),# introduced for RTHandler compatibility
                                     'fail': SimpleItem(defvalue='',doc='Define the artificial runtime failures: "config", "prepare"'),
                                     'postprocess_mark_as_failed': SimpleItem(defvalue=False,doc='Update teh status of the job as failed in the postprocess step'),
-                                    'is_prepared' : SimpleItem(defvalue=None, strict_sequence=0, visitable=1, copyable=1, typelist=['type(None)','str','bool'],protected=0,comparable=1,doc='Location of shared resources. Presence of this attribute implies the application has been prepared.'),
-                                    'hash': SimpleItem(defvalue=None, typelist=['type(None)', 'str'], hidden=1)
+                                    'is_prepared' : SimpleItem(defvalue=None, strict_sequence=0, visitable=1, copyable=1, typelist=[None, str, bool],protected=0,comparable=1,doc='Location of shared resources. Presence of this attribute implies the application has been prepared.'),
+                                    'hash': SimpleItem(defvalue=None, typelist=[None, str], hidden=1)
                                     } )
     _name = 'TestApplication'
 


### PR DESCRIPTION
OK this PR cleans up some strings which still don't need to be in the Schema as they have to be parsed into Python objects which can be stored directly in lists.

I've also migrated the `is_prepared` attribute for several classes where it's clear that a `GangaObject` (`SharedDir`) is stored in the attribute.

I've also added an exception to throw when trying to store the `repr` of a `GangaObject` which is something we should **not** be doing within the XML.

At the very least this is just a PR with some more spring cleaning in the Schema of some classes and should help things run smoothly as there used to be an overhead associated with parsing all of these strings back into real python every time they were parsed.
