### PR TITLE
Multiple options for GaudiExec

### DIFF
--- a/python/Ganga/GPIDev/Base/Objects.py
+++ b/python/Ganga/GPIDev/Base/Objects.py
@@ -493,7 +493,9 @@ class Descriptor(object):
         if item['sequence']:
             # These objects are lists
             _preparable = True if item['preparable'] else False
-            if len(val) == 0:
+            if val is None:
+                new_val = None
+            elif len(val) == 0:
                 new_val = GangaList()
             else:
                 if isinstance(item, ComponentItem):

--- a/python/GangaLHCb/Lib/Applications/GaudiExecUtils.py
+++ b/python/GangaLHCb/Lib/Applications/GaudiExecUtils.py
@@ -29,9 +29,12 @@ importOptions('%s')
 # Import data.py
 importOptions('%s')
 
+for script_file in %s:
+    importOptions( script_file )
+
 # Run the command
 execfile('%s')
-""" % (sys_args, options, data_file, script_file)
+""" % (sys_args, options, data_file, repr(script_file[1:]), script_file[0])
     return wrapper_script
 
 def getTimestampContent():

--- a/python/GangaLHCb/test/GPI/TestGaudiExec.py
+++ b/python/GangaLHCb/test/GPI/TestGaudiExec.py
@@ -25,9 +25,9 @@ class TestGaudiExec(GangaUnitTest):
 
         gr = GaudiExec(directory=gaudi_testFol, options=[LocalFile(gaudi_testOpts)])
 
-        assert isinstance(stripProxy(gr).getOptsFile()[0], stripProxy(LocalFile))
+        assert isinstance(stripProxy(gr).getOptsFiles()[0], stripProxy(LocalFile))
 
-        reconstructed_path = path.join(stripProxy(gr).getOptsFile()[0].localDir, stripProxy(gr).getOptsFile()[0].namePattern)
+        reconstructed_path = path.join(stripProxy(gr).getOptsFiles()[0].localDir, stripProxy(gr).getOptsFiles()[0].namePattern)
 
         assert reconstructed_path == gaudi_testOpts
 

--- a/python/GangaLHCb/test/GPI/TestGaudiExec.py
+++ b/python/GangaLHCb/test/GPI/TestGaudiExec.py
@@ -23,11 +23,11 @@ class TestGaudiExec(GangaUnitTest):
 
         assert path.exists(gaudi_testOpts)
 
-        gr = GaudiExec(directory=gaudi_testFol, options=LocalFile(gaudi_testOpts))
+        gr = GaudiExec(directory=gaudi_testFol, options=[LocalFile(gaudi_testOpts)])
 
-        assert isinstance(stripProxy(gr).getOptsFile(), stripProxy(LocalFile))
+        assert isinstance(stripProxy(gr).getOptsFile()[0], stripProxy(LocalFile))
 
-        reconstructed_path = path.join(stripProxy(gr).getOptsFile().localDir, stripProxy(gr).getOptsFile().namePattern)
+        reconstructed_path = path.join(stripProxy(gr).getOptsFile()[0].localDir, stripProxy(gr).getOptsFile()[0].namePattern)
 
         assert reconstructed_path == gaudi_testOpts
 
@@ -40,9 +40,9 @@ class TestGaudiExec(GangaUnitTest):
 
         df = DiracFile(lfn='/not/some/file')
 
-        gr.options = df
+        gr.options = [df]
 
-        assert gr.options.lfn == df.lfn
+        assert gr.options[0].lfn == df.lfn
 
         shutil.rmtree(gaudi_testFol, ignore_errors=True)
 


### PR DESCRIPTION
This PR migrates the GaudiExec to use a list in the `options` attribute and makes the necessary modifications to the script.

I think asking the users to add an extra `[ ]` around their arguments isn't too bad and unfortunately I can't get this to work unless I mark the schema attribute as being a list.
Do we support anywhere the mixing of list and none list assignment to attributes in the Schema I couldn't find an example of this that fully worked?

In addition to this I've fixed:
 1. Bug where the sys.argv[0] shouldn't be passed to the running script on the WN.
 2. Bug where scripts for subjobs > 0 were being lost to the ether during submit.
 3. Bug due to bad support of DiracFile for opts files
 4. Bug in GangaObject where objects would be unloadable from disk due to defaults conflicting with a code assumption.

I think I'd like to get this in before 6.1.23 to avoid having any schema changes in 6.1.24+ I think it makes sense to try and stabilize asap on the most flexible set of options.