### PR TITLE
Enabling GaussSplitter support for GaudiExec

### DIFF
--- a/python/GangaLHCb/Lib/Splitters/GaussSplitter.py
+++ b/python/GangaLHCb/Lib/Splitters/GaussSplitter.py
@@ -1,13 +1,16 @@
+import pickle
+import os
+import copy
 from Ganga.GPIDev.Adapters.ISplitter import ISplitter
+from Ganga.GPIDev.Base.Proxy import stripProxy
 from Ganga.GPIDev.Schema import Schema, Version, SimpleItem
 from Ganga.Utility.Config import getConfig
 from Ganga.Utility.files import expandfilename
 from Ganga.GPIDev.Lib.Job import Job
-import pickle
-import os
-import copy
-import Ganga.Utility.logging
-logger = Ganga.Utility.logging.getLogger()
+from Ganga.Utility.logging import getLogger
+from GangaLHCb.Lib.Applications.GaudiExec import GaudiExec
+
+logger = getLogger()
 
 class GaussSplitter(ISplitter):
 
@@ -39,39 +42,59 @@ class GaussSplitter(ISplitter):
         return j
 
     def split(self, job):
+        """
+            Method to do the splitting work
+            Args:
+                job (Job): master job to be used as a template to split subjobs
+        """
+
+        # NB Not sure if we can ever _not_ import the Gauss app from the GPI
+        from Ganga.GPI import Gauss
+        if not isinstance(job.application, (stripProxy(Gauss), GaudiExec)):
+            logger.warning("This application is of type: '%s', be careful how you use it with the GaussSplitter!" % type(job.application))
+
         subjobs = []
 
         inputdata = job.inputdata
-        if not job.inputdata:
-            share_path = os.path.join(expandfilename(getConfig('Configuration')['gangadir']),
-                                      'shared',
-                                      getConfig('Configuration')['user'],
-                                      job.application.is_prepared.name,
-                                      'inputdata',
-                                      'options_data.pkl')
 
-            if os.path.exists(share_path):
-                f = open(share_path, 'r+b')
-                inputdata = pickle.load(f)
-                f.close()
+        if not isinstance(job.application, GaudiExec):
+            # I'm assuming this file is created by the Gauss Application at some stage?
+            if not job.inputdata:
+                share_path = os.path.join(expandfilename(getConfig('Configuration')['gangadir']),
+                                          'shared',
+                                          getConfig('Configuration')['user'],
+                                          job.application.is_prepared.name,
+                                          'inputdata',
+                                          'options_data.pkl')
+
+                if os.path.exists(share_path):
+                    f = open(share_path, 'r+b')
+                    #FIXME should this have been an addition?
+                    inputdata = pickle.load(f)
+                    f.close()
 
         for i in range(self.numberOfJobs):
             j = self._create_subjob(job, inputdata)
+            # FIXME this starts from the 1st event and not zero, is it clear why?
             first = self.firstEventNumber + i * self.eventsPerJob + 1
             opts = 'from Gaudi.Configuration import * \n'
             opts += 'from Configurables import GenInit \n'
             opts += 'ApplicationMgr().EvtMax = %d\n' % self.eventsPerJob
-            #opts += 'from Configurables import LHCbApp\n'
-            #opts += 'LHCbApp().EvtMax = %d\n' % self.eventsPerJob
+            opts += 'from Configurables import LHCbApp\n'
+            opts += 'LHCbApp().EvtMax = %d\n' % self.eventsPerJob
             opts += 'GenInit("GaussGen").FirstEventNumber = %d\n' % first
             spillOver = ["GaussGenPrev", "GaussGenPrevPrev", "GaussGenNext"]
             for s in spillOver:
                 opts += 'GenInit("%s").FirstEventNumber = %d\n' % (s, first)
             #j.application.extra.input_buffers['data.py'] += opts
-            j._splitter_data = opts
+            if isinstance(job.application, GaudiExec):
+                j.application.extraOpts = j.application.extraOpts + '\n' + opts
+            else:
+                j._splitter_data = opts
             # j.inputsandbox.append(File(FileBuffer(path,opts).create().name))
             logger.debug("Creating job %d w/ FirstEventNumber = %d" % (i, first))
             subjobs.append(j)
 
         return subjobs
+
 

--- a/python/GangaLHCb/Lib/Splitters/GaussSplitter.py
+++ b/python/GangaLHCb/Lib/Splitters/GaussSplitter.py
@@ -2,7 +2,6 @@ import pickle
 import os
 import copy
 from Ganga.GPIDev.Adapters.ISplitter import ISplitter
-from Ganga.GPIDev.Base.Proxy import stripProxy
 from Ganga.GPIDev.Schema import Schema, Version, SimpleItem
 from Ganga.Utility.Config import getConfig
 from Ganga.Utility.files import expandfilename
@@ -48,9 +47,8 @@ class GaussSplitter(ISplitter):
                 job (Job): master job to be used as a template to split subjobs
         """
 
-        # NB Not sure if we can ever _not_ import the Gauss app from the GPI
-        from Ganga.GPI import Gauss
-        if not isinstance(job.application, (stripProxy(Gauss), GaudiExec)):
+        from GangaLHCb.Lib.Applications import Gauss
+        if not isinstance(job.application, (Gauss, GaudiExec)):
             logger.warning("This application is of type: '%s', be careful how you use it with the GaussSplitter!" % type(job.application))
 
         subjobs = []


### PR DESCRIPTION
Fixes #631 

After running some quick tests this should be all that is required for GaussSplitter to be correctly supported by the `GaudiExec` application.

I've added the appropriate splitter options into the `extraOpts` attribute for each subjob and have verified that each subjob is correctly unique and that the job scripts appear to be picking up the correct extraOpts script which is created and sent to the WN.

I've managed to get as far as getting back a file, but I'm not an MC expert I was cobbling together a solution from an old tutorial so this may be rough around the edges.

If the 6.1.23 release hasn't been finalised I'd like to merge this as it should be working.