### PR TITLE
Remove _commit references from Atlas code

### DIFF
--- a/python/GangaPanda/Lib/Jedi/Jedi.py
+++ b/python/GangaPanda/Lib/Jedi/Jedi.py
@@ -432,8 +432,6 @@ class Jedi(IBackend):
                     do_master_update = False
 
                 tot_num_mjobs += num_mjobs
-                ## for some reason, one should call job._commit() to store panda jobs into the repository
-                job._commit()
                 logger.debug('Job %s retrieved %d Panda jobs' % (job.getFQID('.'),tot_num_mjobs) )
             # Now monitor the already attached Panda jobs
             else:
@@ -565,7 +563,6 @@ class Jedi(IBackend):
             j.status = 'submitted'
             j.time.timenow('submitted')
             master_job.subjobs.append(j)
-        master_job._commit()
         return True
 
     def get_stats(self):

--- a/python/GangaPanda/Lib/Panda/Panda.py
+++ b/python/GangaPanda/Lib/Panda/Panda.py
@@ -577,7 +577,6 @@ def retrieveMergeJobs(job, pandaJobDefId):
 
                             if mjobj.id not in [mj2.id for mj2 in job.backend.mergejobs]:
                                 job.backend.mergejobs.append(mjobj)
-                                job._commit()
                                 num_mjobs += 1
                             else:
                                 logger.debug("merging job %s already exists locally" % mjobj.id)
@@ -1189,7 +1188,6 @@ class Panda(IBackend):
         # mark merge job retrieval to be done for any new merges created
         self.domergeretrieve = True
         self.mergejobs = []
-        job._commit()
         
         logger.info('Resubmission successful')
         return True
@@ -1233,7 +1231,6 @@ class Panda(IBackend):
 
             if job.status in ['running', 'submitted'] and job.backend.domergeretrieve:
                 job.backend.mergejobs = []
-                job._commit()
                 
         # split into 2000-job pieces
         allJobIDs = jobdict.keys()
@@ -1487,7 +1484,6 @@ class Panda(IBackend):
         for j in clear_merge_jobs:
             j.backend.mergejobs = []
             j.backend.domergeretrieve = True
-            job._commit()
 
         # update merge status's
         for job in update_merge_master_status:
@@ -1564,9 +1560,6 @@ class Panda(IBackend):
                                     logger.warning('merging job retrival failure')
 
                                 tot_num_mjobs += num_mjobs
-
-                        ## for some reason, one should call job._commit() to store merging jobs into the repository
-                        job._commit()
                                                 
                         # set the flag to prevent further retrievals unless a resub is called
                         if tot_num_mjobs > 0:


### PR DESCRIPTION
As we now auto flush and the `GangaList` stuff is all fixed, `_commit` should be removed.