### PR TITLE
Fixing Executable on Dirac backend.

### DIFF
--- a/python/GangaDirac/Lib/RTHandlers/ExeDiracRTHandler.py
+++ b/python/GangaDirac/Lib/RTHandlers/ExeDiracRTHandler.py
@@ -157,7 +157,7 @@ if __name__ == '__main__':
 
     err = None
     try:
-        rc = subprocess.call(exe_cmd, env=my_env, shell=True)
+        rc = subprocess.call(exe_cmd, env=my_env, shell=False)
     except Exception as x:
         rc = -9999
         print('Exception occured in running process: ' + exe_cmd)


### PR DESCRIPTION
As described in issue [#521](https://github.com/ganga-devs/ganga/issues/521) the args of Executable apps were getting lost on the Dirac backend. This is fixed simply by switching shell=True to shell=False in the call to subprocess.call.