### PR TITLE
Removing LHCbApp references in GaussSplitter

### DIFF
--- a/python/GangaLHCb/Lib/Splitters/GaussSplitter.py
+++ b/python/GangaLHCb/Lib/Splitters/GaussSplitter.py
@@ -78,8 +78,6 @@ class GaussSplitter(ISplitter):
             opts = 'from Gaudi.Configuration import * \n'
             opts += 'from Configurables import GenInit \n'
             opts += 'ApplicationMgr().EvtMax = %d\n' % self.eventsPerJob
-            opts += 'from Configurables import LHCbApp\n'
-            opts += 'LHCbApp().EvtMax = %d\n' % self.eventsPerJob
             opts += 'GenInit("GaussGen").FirstEventNumber = %d\n' % first
             spillOver = ["GaussGenPrev", "GaussGenPrevPrev", "GaussGenNext"]
             for s in spillOver:


### PR DESCRIPTION
Removing LHCbApp references in GaussSplitter

Having this in the splitter causes problems. I'm removing it from 6.1.25 onwards as any bugs from not having this I would argue are user/application bugs.