### PR TITLE
Fix Condor errors and some Atlas cmd line problems

### DIFF
--- a/python/Ganga/Lib/Condor/Condor.py
+++ b/python/Ganga/Lib/Condor/Condor.py
@@ -542,8 +542,16 @@ class Condor(IBackend):
                         if exitCode.isdigit():
                             jobStatus = "completed"
                         else:
-                            logger.error("Problem extracting exit code from job %s. Line found was '%s'." % (
-                                jobDict[id].fqid, exitLine))
+                            # Some filesystems/setups have the file created but empty - only worry if it's been 10mins
+                            if len(lineList) == 0:
+                                if (time.time() - os.path.getmtime(stdoutPath)) < 10*60:
+                                    continue
+                                else:
+                                    logger.error("Empty stdout file from job %s after waiting 10mins. Marking job as"
+                                                 "failed." % jobDict[id].fqid)
+                            else:
+                                logger.error("Problem extracting exit code from job %s. Line found was '%s'." % (
+                                    jobDict[id].fqid, exitLine))
 
                     jobDict[id].updateStatus(jobStatus)
 

--- a/python/Ganga/Lib/Condor/Condor.py
+++ b/python/Ganga/Lib/Condor/Condor.py
@@ -130,6 +130,10 @@ class Condor(IBackend):
         }
 
     def __init__(self):
+
+        # Add a volatile variable for recording the first time a job's stdout is checked
+        self._stdout_check_time = 0
+
         super(Condor, self).__init__()
 
     def submit(self, jobconfig, master_input_sandbox):
@@ -543,8 +547,12 @@ class Condor(IBackend):
                             jobStatus = "completed"
                         else:
                             # Some filesystems/setups have the file created but empty - only worry if it's been 10mins
+                            # since we first checked the file
                             if len(lineList) == 0:
-                                if (time.time() - os.path.getmtime(stdoutPath)) < 10*60:
+                                if not jobDict[id].backend._stdout_check_time:
+                                    jobDict[id].backend._stdout_check_time = time.time()
+
+                                if (time.time() - jobDict[id].backend._stdout_check_time) < 10*60:
                                     continue
                                 else:
                                     logger.error("Empty stdout file from job %s after waiting 10mins. Marking job as"

--- a/python/GangaAtlas/Lib/Athena/Athena.py
+++ b/python/GangaAtlas/Lib/Athena/Athena.py
@@ -932,9 +932,6 @@ class Athena(IPrepareApp):
         if self.atlas_cmtconfig == "":
             if 'CMTCONFIG' in os.environ:
                 self.atlas_cmtconfig = os.environ['CMTCONFIG']
-                if self.atlas_cmtconfig.startswith('x86_64'):
-                    #raise ApplicationConfigurationError(None, 'CMTCONFIG = %s, Your CMT setup is using 64 bit - please change to 32 bit !'% self.atlas_cmtconfig )
-                    logger.warning('CMTCONFIG = %s, Your CMT setup is using 64 bit - are you sure you want to use 64 bit ?'% self.atlas_cmtconfig)
             else:
                 self.atlas_cmtconfig = config['CMTCONFIG']
                 os.environ['CMTCONFIG'] = self.atlas_cmtconfig 

--- a/python/GangaAtlas/Lib/Athena/AthenaLocalRTHandler.py
+++ b/python/GangaAtlas/Lib/Athena/AthenaLocalRTHandler.py
@@ -450,7 +450,7 @@ class AthenaLocalRTHandler(IRuntimeHandler):
             self.output_datasetname, self.output_lfn = dq2outputdatasetname(dq2_datasetname, jobid, dq2_isGroupDS, dq2_groupname)
 
         # Expand Athena jobOptions
-        if not app.option_file:
+        if not app.option_file and not app.command_line:
             raise ConfigError("j.application.option_file='' - No Athena jobOptions files specified.")
 
         athena_options = ''
@@ -470,6 +470,10 @@ class AthenaLocalRTHandler(IRuntimeHandler):
                 if app.options:
                     athena_options =  app.options + ' ' + athena_options
                 inputbox += [ File(option_file.name) ]
+
+
+            if app.command_line:
+                athena_options = app.command_line
 
         athena_usersetupfile = os.path.basename(app.user_setupfile.name)
 
@@ -540,7 +544,7 @@ class AthenaLocalRTHandler(IRuntimeHandler):
             'DQ2_SETUP_SCRIPT': configDQ2['setupScript']
         }
 
-        # Set athena architecture: 32 or 64 bit    
+        # Set athena architecture: 32 or 64 bit
         environment['ATLAS_ARCH'] = '32'
         cmtconfig = app.atlas_cmtconfig
         if cmtconfig.find('x86_64')>=0:

--- a/python/GangaAtlas/Lib/Athena/athena-local.sh
+++ b/python/GangaAtlas/Lib/Athena/athena-local.sh
@@ -335,12 +335,12 @@ then
 	    CP_CMD="cp" 
 	fi
 
-	$MKDIR_CMD -p $OUTPUT_LOCATION
+	$MKDIR_CMD -p `readlink -m $OUTPUT_LOCATION`
 	cat output_files | while read filespec
 	do
 	  for file in $filespec
 	  do
-	    $CP_CMD $file $OUTPUT_LOCATION/$file
+	    $CP_CMD $file `readlink -m $OUTPUT_LOCATION/$file`
 	  done
 	done
     fi

--- a/python/GangaAtlas/scripts/athena
+++ b/python/GangaAtlas/scripts/athena
@@ -95,7 +95,6 @@ p.add_option('--usefax', action='store_true', dest='usefax', help='Allow submiss
 p.add_option('--lcg', action='store_const', const='lcg', dest='backend', help='Submit job(s) to LCG Grid')
 p.add_option('--cream', action='store_const', const='cream', dest='backend', help='Submit job(s) to a CREAM CE')
 p.add_option('--ng', action='store_const', const='ng', dest='backend', help='Submit job(s) to NorduGrid')
-p.add_option('--panda', action='store_const', const='panda', dest='backend', help='Submit job(s) to Panda')
 p.add_option('--jedi', action='store_const', const='jedi', dest='backend', help='Submit job(s) to jedi')
 p.add_option('--lsf', action='store_const', const='lsf', dest='backend', help='Submit job(s) to the local LSF batch system, e.g. on lxplus')
 p.add_option('--condor', action='store_const', const='condor', dest='backend', help='Submit job(s) to the local Condor batch system')
@@ -184,7 +183,7 @@ opt, args = p.parse_args()
 
 # make panda the default backend
 if not opt.backend:
-    opt.backend = "panda"
+    opt.backend = "jedi"
 
 # Job query
 if opt.jobid:
@@ -214,9 +213,9 @@ if opt.jobid:
 
 if args:
     option_files=[]
-    if args:  
+    if args:
         for option_file in args:
-            if not opt.athena_exe in ['EXE', 'TRF']:        
+            if not opt.athena_exe in ['EXE', 'TRF'] and opt.backend == "jedi":
                 if not os.access(option_file,os.R_OK):
                     print >>sys.stderr, 'ERROR: Cannot read athena job option file: %s' % option_file
                     sys.exit(4)
@@ -280,14 +279,27 @@ if opt.user_area_path:
 if opt.group_area:
     j.application.group_area=opt.group_area
 
-j.application.option_file = option_files
-if opt.options:
-    if opt.athena_exe in ['EXE', 'TRF', 'PYARA']:
-        j.application.options = " %s " %opt.options
-    else:
-        aoptions = opt.options.replace('"',"'''")        
-    	aoptions = opt.options.replace('\'',"'''")
-        j.application.options = "-c '''%s''' " %aoptions
+# TODO: Check if this works with Jedi as well
+if opt.backend != "jedi":
+    # Just pass the command line straight through to Athena
+    # options make this a bit more tricky...
+    j.application.command_line = ' '.join(args)
+    if opt.options:
+        if opt.athena_exe in ['EXE', 'TRF', 'PYARA']:
+            j.application.command_line += " " + opt.options
+        else:
+            aoptions = opt.options.replace('"',"'''")
+            aoptions = opt.options.replace('\'',"'''")
+            j.application.command_line = " -c '''%s''' %s " % (aoptions, j.application.command_line)
+else:
+    j.application.option_file = option_files
+    if opt.options:
+        if opt.athena_exe in ['EXE', 'TRF', 'PYARA']:
+            j.application.options = " %s " %opt.options
+        else:
+            aoptions = opt.options.replace('"',"'''")
+            aoptions = opt.options.replace('\'',"'''")
+            j.application.options = "-c '''%s''' " %aoptions
 
 if opt.user_setupfile:
     j.application.user_setupfile = opt.user_setupfile

--- a/python/GangaAtlas/scripts/athena
+++ b/python/GangaAtlas/scripts/athena
@@ -398,7 +398,7 @@ if opt.input_dataset or opt.tag_input_dataset or opt.tag_input_files or opt.inpu
                         if opt.nth_field_as_outdir:
 
                             # grab the field numbers
-                            field_nums = [ int(f.strip()) for f in opt.nth_field_as_outdir.split(',') ]
+                            field_nums = [int(f.strip()) for f in opt.nth_field_as_outdir.split(',')]
                             toks = pfn_list.split('.')
                             new_pfn_toks = []
                             for f in field_nums:

--- a/python/GangaAtlas/scripts/athena
+++ b/python/GangaAtlas/scripts/athena
@@ -288,9 +288,7 @@ if opt.backend != "jedi":
         if opt.athena_exe in ['EXE', 'TRF', 'PYARA']:
             j.application.command_line += " " + opt.options
         else:
-            aoptions = opt.options.replace('"',"'''")
-            aoptions = opt.options.replace('\'',"'''")
-            j.application.command_line = " -c '''%s''' %s " % (aoptions, j.application.command_line)
+            j.application.command_line = " -c \"%s\" %s " % (opt.options, j.application.command_line)
 else:
     j.application.option_file = option_files
     if opt.options:


### PR DESCRIPTION
This PR addresses a few things:

* I've had Atlas report an issue in some Condor installs that the stdout file is slow to be populated which leads to odd errors. This may or may not be directly related to Atlas but I've put in a fix to wait up to 10mins after first seeing the job has finished for the stdout to be filled. Fixes #741 

* GangaAtlas was being very particular about how the job options were specified. This was basically due to legacy code where the JOs were originally only thought to be a file that you'd ship. This is now far too restrictive so I've added a `command_line` option to Athena that is passed straight through to the final Athena call. This means it runs exactly as you would from the command line without translation. Fixes #542 

* Combined with the above was an issue with the command line options being put in too many strings. This has also been cleaned up. Fixes #739 

* GangaAtlas was still warning about selecting a 64-bit config. This has been removed. Fixes #743 

* Added a `readlink -m` call to make sure the output location is expanded properly. Fixes #545 

* Cleaned up some unused TAG code that I happened to find along the way 😄 

I would very much like this to go in for 6.1.25 as the local use of GangaAtlas is starting to ramp up and it would good to have it fully working!


