### PR TITLE
Switching to getFQDN

### DIFF
--- a/python/Ganga/Utility/util.py
+++ b/python/Ganga/Utility/util.py
@@ -157,7 +157,7 @@ def hostname():
         # [bugfix #20333]:
         # while working offline and with an improper /etc/hosts configuration
         # the localhost cannot be resolved
-        except socket.error as err:
+        except socket.error:
             hostname._hostname_cache = 'localhost'
 
     return hostname._hostname_cache

--- a/python/Ganga/Utility/util.py
+++ b/python/Ganga/Utility/util.py
@@ -153,11 +153,11 @@ def hostname():
     if hostname._hostname_cache == '':
         import socket
         try:
-            hostname._hostname_cache = socket.gethostbyaddr(hostname_tmp)[0]
+            hostname._hostname_cache = socket.getfqdn()
         # [bugfix #20333]:
         # while working offline and with an improper /etc/hosts configuration
         # the localhost cannot be resolved
-        except:
+        except socket.error as err:
             hostname._hostname_cache = 'localhost'
 
     return hostname._hostname_cache


### PR DESCRIPTION
Fixes #758 moves to use a different method to get the fqdn of the site we're running on. Used to identify the host machine in various sections of the code.

I've had a look at the docs and I'm not sure if we need to protect against any other form of exception. But if this is called and cached I don't see too much risk in having the code just check for a socket.error