### PR TITLE
Make sure the --trf option is added to Jedi jobs

### DIFF
--- a/python/GangaPanda/Lib/Athena/AthenaJediRTHandler.py
+++ b/python/GangaPanda/Lib/Athena/AthenaJediRTHandler.py
@@ -486,6 +486,9 @@ class AthenaJediRTHandler(IRuntimeHandler):
              },
             ]
 
+        # Add the --trf option to jobParameters if required
+        if app.atlas_exetype == "TRF":
+            taskParamMap['jobParameters'] += [{'type': 'constant', 'value': '--trf'}]
 
         # output
         # output files


### PR DESCRIPTION
Jedi needs the `--trf` flag set for TRF jobs. This makes sure this is set correctly.