### PR TITLE
Revert "Adding skip test around LCG tests"

### DIFF
--- a/python/Ganga/test/GPI/LCG/TestCREAM.py
+++ b/python/Ganga/test/GPI/LCG/TestCREAM.py
@@ -1,19 +1,12 @@
 import re
 import subprocess
-import pytest
 
 from Ganga.Utility.Config import getConfig
 
 from Ganga.testlib.mark import external
 
-from Ganga.Utility.Config.Config import getConfig
-from Ganga.testlib.GangaUnitTest import load_config_files, clear_config
-load_config_files()
-glite_status = getConfig('LCG')['GLITE_ENABLE']
-clear_config()
 
 @external
-@pytest.mark.skipif(glite_status == False, reason="Cannot run test GLITE not enabled")
 def test_job_kill(gpi):
     from Ganga.GPI import Job, CREAM
 

--- a/python/Ganga/test/GPI/LCG/TestLCG.py
+++ b/python/Ganga/test/GPI/LCG/TestLCG.py
@@ -1,4 +1,3 @@
-import pytest
 from Ganga.GPIDev.Base.Proxy import stripProxy
 
 try:
@@ -9,14 +8,8 @@ except ImportError:
 from Ganga.testlib.mark import external
 from Ganga.testlib.monitoring import run_until_completed
 
-from Ganga.Utility.Config.Config import getConfig
-from Ganga.testlib.GangaUnitTest import load_config_files, clear_config
-load_config_files()
-glite_status = getConfig('LCG')['GLITE_ENABLE']
-clear_config()
 
 @external
-@pytest.mark.skipif(glite_status == False, reason="Cannot run test GLITE not enabled")
 def test_job_submit_and_monitor(gpi):
     from Ganga.GPI import Job, LCG
 
@@ -28,7 +21,6 @@ def test_job_submit_and_monitor(gpi):
     stripProxy(LCG).master_updateMonitoringInformation([stripProxy(j)])
 
 @external
-@pytest.mark.skipif(glite_status == False, reason="Cannot run test GLITE not enabled")
 def test_job_kill(gpi):
     from Ganga.GPI import Job, LCG
 
@@ -37,7 +29,7 @@ def test_job_kill(gpi):
     j.submit()
     j.kill()
 
-@pytest.mark.skipif(glite_status == False, reason="Cannot run test GLITE not enabled")
+
 def test_submit_kill_resubmit(gpi):
     """
     Test that a simple submit-kill-resubmit-kill cycle works
@@ -65,7 +57,7 @@ def test_submit_kill_resubmit(gpi):
     with patch('Ganga.Lib.LCG.Grid.cancel', return_value=True):
         j.kill()
 
-@pytest.mark.skipif(glite_status == False, reason="Cannot run test GLITE not enabled")
+
 def test_submit_monitor(gpi):
     """
     Test that an LCG job can be monitored
@@ -103,4 +95,3 @@ def test_submit_monitor(gpi):
 
     with patch('Ganga.Lib.LCG.Grid.cancel', return_value=True):
         j.kill()
-


### PR DESCRIPTION
Reverts ganga-devs/ganga#777

Hitting the 1 button revert option as was discussed in the previous PR.

This is unfortunately mute as the DIRAC tests are now all stalling preventing this code from being properly tested.