### PR TITLE
Adding whitespace to all test dirs

### DIFF
--- a/python/Ganga/Core/GangaRepository/SessionLock.py
+++ b/python/Ganga/Core/GangaRepository/SessionLock.py
@@ -17,6 +17,7 @@ import fcntl
 import random
 import datetime
 import getpass
+from pipes import quote
 
 try:
     import cPickle as pickle
@@ -501,7 +502,7 @@ class SessionLockManager(object):
                     nowtime = time.time()
                     if abs(int(nowtime) - oldtime) > 10:
                         #logger.debug( "cleaning global lock" )
-                        os.system("fs setacl %s %s rlidwka" % (lock_path, getpass.getuser()))
+                        os.system("fs setacl %s %s rlidwka" % (quote(lock_path), getpass.getuser()))
 
                 while True:
                     try:
@@ -513,7 +514,7 @@ class SessionLockManager(object):
                         logger.debug("Global Lock aquire Exception: %s" % err)
                         time.sleep(0.01)
 
-                os.system("fs setacl %s %s rliwka" % (lock_path, getpass.getuser()))
+                os.system("fs setacl %s %s rliwka" % (quote(lock_path), getpass.getuser()))
 
                 while not os.path.isfile(lock_file):
                     with open(lock_file, "w"):
@@ -531,7 +532,7 @@ class SessionLockManager(object):
         try:
             if self.afs:
                 lock_path = str(self.lockfn) + '.afs'
-                os.system("fs setacl %s %s rlidwka" % (lock_path, getpass.getuser()))
+                os.system("fs setacl %s %s rlidwka" % (quote(lock_path), getpass.getuser()))
             else:
                 fcntl.lockf(self.lockfd, fcntl.LOCK_UN)
 

--- a/python/Ganga/Runtime/Repository_runtime.py
+++ b/python/Ganga/Runtime/Repository_runtime.py
@@ -2,9 +2,10 @@
 Internal initialization of the repositories.
 """
 
+from pipes import quote
+import os.path
 from Ganga.Utility.Config import getConfig, setConfigOption
 from Ganga.Utility.logging import getLogger
-import os.path
 from Ganga.Utility.files import expandfilename, fullpath
 from Ganga.Core.GangaRepository import getRegistries
 from Ganga.Core.GangaRepository import getRegistry
@@ -66,11 +67,11 @@ def checkDiskQuota():
     for data_partition in folders_to_check:
 
         if fullpath(data_partition, True).find('/afs') == 0:
-            quota = subprocess.Popen(['fs', 'quota', '%s' % data_partition], stdout=subprocess.PIPE)
+            quota = subprocess.Popen(" ".join(['fs', 'quota', '%s' % quote(data_partition)]), shell=True, stdout=subprocess.PIPE)
             output = quota.communicate()[0]
-            logger.debug("fs quota %s:\t%s" % (data_partition, output))
+            logger.debug("fs quota %s:\t%s" % (quote(data_partition), output))
         else:
-            df = subprocess.Popen(["df", '-Pk', data_partition], stdout=subprocess.PIPE)
+            df = subprocess.Popen(["df", '-Pk', '%s' % quote(data_partition)], stdout=subprocess.PIPE)
             output = df.communicate()[0]
 
         try:

--- a/python/Ganga/testlib/GangaUnitTest.py
+++ b/python/Ganga/testlib/GangaUnitTest.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, absolute_import
+from __future__ import print_function
 
 import sys
 import shutil

--- a/python/Ganga/testlib/GangaUnitTest.py
+++ b/python/Ganga/testlib/GangaUnitTest.py
@@ -8,7 +8,7 @@ try:
 except ImportError:
     import unittest
 
-ganga_test_dir = 'gangadir testing'
+ganga_test_dir_name = 'gangadir testing'
 
 def _getGangaPath():
     """
@@ -244,7 +244,7 @@ class GangaUnitTest(unittest.TestCase):
         """
         Return the directory that this test should store its registry and repository in
         """
-        return os.path.join(_getGangaPath(), ganga_test_dir, cls.__name__)
+        return os.path.join(_getGangaPath(), ganga_test_dir_name, cls.__name__)
 
     @classmethod
     def setUpClass(cls):

--- a/python/Ganga/testlib/GangaUnitTest.py
+++ b/python/Ganga/testlib/GangaUnitTest.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
 import sys
 import shutil
@@ -8,6 +8,7 @@ try:
 except ImportError:
     import unittest
 
+ganga_test_dir = 'gangadir testing'
 
 def _getGangaPath():
     """
@@ -243,7 +244,7 @@ class GangaUnitTest(unittest.TestCase):
         """
         Return the directory that this test should store its registry and repository in
         """
-        return os.path.join(_getGangaPath(), 'gangadir_testing', cls.__name__)
+        return os.path.join(_getGangaPath(), ganga_test_dir, cls.__name__)
 
     @classmethod
     def setUpClass(cls):

--- a/python/Ganga/testlib/fixtures.py
+++ b/python/Ganga/testlib/fixtures.py
@@ -5,7 +5,7 @@ import shutil
 
 import pytest
 
-from Ganga.testlib.GangaUnitTest import start_ganga, stop_ganga, _getGangaPath, ganga_test_dir
+from Ganga.testlib.GangaUnitTest import start_ganga, stop_ganga, _getGangaPath, ganga_test_dir_name
 
 def gangadir(request):
     """
@@ -18,7 +18,7 @@ def gangadir(request):
         str: the name of the gangadir directory to use
 
     """
-    return os.path.join(_getGangaPath(), ganga_test_dir, request.module.__name__)
+    return os.path.join(_getGangaPath(), ganga_test_dir_name, request.module.__name__)
 
 
 @pytest.yield_fixture(scope='module')

--- a/python/Ganga/testlib/fixtures.py
+++ b/python/Ganga/testlib/fixtures.py
@@ -5,8 +5,7 @@ import shutil
 
 import pytest
 
-from Ganga.testlib.GangaUnitTest import start_ganga, stop_ganga, _getGangaPath
-
+from Ganga.testlib.GangaUnitTest import start_ganga, stop_ganga, _getGangaPath, ganga_test_dir
 
 def gangadir(request):
     """
@@ -19,7 +18,7 @@ def gangadir(request):
         str: the name of the gangadir directory to use
 
     """
-    return os.path.join(_getGangaPath(), 'gangadir_testing', request.module.__name__)
+    return os.path.join(_getGangaPath(), ganga_test_dir, request.module.__name__)
 
 
 @pytest.yield_fixture(scope='module')


### PR DESCRIPTION
Just a quick PR to highlight the effect of adding whitespace to the test directory name.

This shouldn't effect tests run through the `PR Builder` but will highlight problems in the `nightly` builds.

Depending on how people feel I propose changing `gangadir_testing` to `gangadir testing` in the test-suite to catch problems with whitespaces which crop up atm under some tests but not others.

I'm happy to revert if there is opposition, but I thought this might be a good idea.