### PR TITLE
Making sure ~/.gangarc file isn't parsed during startup of tests

### DIFF
--- a/python/Ganga/testlib/GangaUnitTest.py
+++ b/python/Ganga/testlib/GangaUnitTest.py
@@ -9,6 +9,7 @@ except ImportError:
     import unittest
 
 ganga_test_dir_name = 'gangadir testing'
+ganga_config_file = '/not/a/file'
 
 def _getGangaPath():
     """
@@ -41,7 +42,7 @@ def load_config_files():
     system_vars = {}
     for opt in getConfig('System'):
         system_vars[opt] = getConfig('System')[opt]
-    config_files = GangaProgram.get_config_files(os.path.expanduser('~/.gangarc'))
+    config_files = GangaProgram.get_config_files(ganga_config_file)
     setSessionValuesFromFiles(config_files, system_vars)
 
 
@@ -101,6 +102,7 @@ def start_ganga(gangadir_for_test, extra_opts=[]):
 
     # Actually parse the options
     Ganga.Runtime._prog = Ganga.Runtime.GangaProgram(argv=this_argv)
+    Ganga.Runtime._prog.default_config_file = ganga_config_file
     Ganga.Runtime._prog.parseOptions()
 
     # For all the default and extra options, we set the session value


### PR DESCRIPTION
Fixes #799 

I've changed the default config file to point to a non-existent path so that changes to `~/.gangarc` on dev machines (and Jenkins) are isolated from the running of the tests.

This should hopefully reduce confusion and will mean anyone running a test doesn't run the risk of torching a production repo while they do so.

This appears to work without problem and I've verified it solved my problem with my tests taking forever to shutdown while they torched my 2k Job test repo.

Can someone review this as I'd like to merge this for other dev work I'm doing. Thanks!