### PR TITLE
Adding return True for a credential which didn't throw an exception

### DIFF
--- a/python/Ganga/Core/MonitoringComponent/Local_GangaMC_Service.py
+++ b/python/Ganga/Core/MonitoringComponent/Local_GangaMC_Service.py
@@ -6,6 +6,7 @@ from contextlib import contextmanager
 
 from Ganga.Core.GangaThread import GangaThread
 from Ganga.Core.GangaRepository import RegistryKeyError, RegistryLockError
+from Ganga.GPIDev.Credentials2.exceptions import CredentialRenewalError
 
 from Ganga.Utility.threads import SynchronisedObject
 

--- a/python/Ganga/Core/MonitoringComponent/Local_GangaMC_Service.py
+++ b/python/Ganga/Core/MonitoringComponent/Local_GangaMC_Service.py
@@ -1159,12 +1159,14 @@ class JobRegistry_Monitor(GangaThread):
             log.debug("Checking %s." % getName(credObj))
             try:
                 s = credObj.renew()
-            except Exception as msg:
+            except CredentialRenewalError:
+                return False
+            except Exception as err:
+                logger.error("Unexpected exception!")
+                logger.error("Error: %s" % err)
                 return False
             else:
-                if s is None:
-                    return True
-                return s
+                return True
         return credChecker
 
     def diskSpaceCheckJobInsertor(self):
@@ -1176,8 +1178,7 @@ class JobRegistry_Monitor(GangaThread):
 
         def cb_Failure():
             self.disableCallbackHook(self.diskSpaceCheckJobInsertor)
-            self._handleError(
-                'Available disk space checking failed and it has been disabled!', 'DiskSpaceChecker', False)
+            self._handleError('Available disk space checking failed and it has been disabled!', 'DiskSpaceChecker', False)
 
         log.debug('Inserting disk space checking function to Qin.')
         _action = JobAction(function=Coordinator._diskSpaceChecker,
@@ -1195,8 +1196,7 @@ class JobRegistry_Monitor(GangaThread):
             self.__sleepCounter = 0.0
         else:
             self.progressCallback("Processing... Please wait.")
-            log.debug(
-                "Updates too close together... skipping latest update request.")
+            log.debug("Updates too close together... skipping latest update request.")
             self.__sleepCounter = self.minPollRate
 
     def _handleError(self, x, backend_name, show_traceback):

--- a/python/Ganga/Core/MonitoringComponent/Local_GangaMC_Service.py
+++ b/python/Ganga/Core/MonitoringComponent/Local_GangaMC_Service.py
@@ -1162,6 +1162,8 @@ class JobRegistry_Monitor(GangaThread):
             except Exception as msg:
                 return False
             else:
+                if s is None:
+                    return True
                 return s
         return credChecker
 


### PR DESCRIPTION
This adds a `return True` for the case that a credential is valid and an exception isn't raised.
If this is not here AFS users get an error that the AFS token is invalid and that the monitoring will stop for it.
@milliams Does this look sensible compared to the design of the new credentials?