### PR TITLE
Bugfix/forward compatibility with 6.3

### DIFF
--- a/python/Ganga/Core/GangaRepository/GangaRepositoryXML.py
+++ b/python/Ganga/Core/GangaRepository/GangaRepositoryXML.py
@@ -936,6 +936,8 @@ class GangaRepositoryLocal(GangaRepository):
 
         if len(errs) > 0:
             logger.error("#%s Error(s) Loading File: %s" % (len(errs), fobj.name))
+            for err in errs:
+                logger.error("err: %s" % err)
             raise InaccessibleObjectError(self, this_id, errs[0])
 
         logger.debug("Checking children: %s" % str(this_id))

--- a/python/Ganga/GPIDev/Credentials/ICredential.py
+++ b/python/Ganga/GPIDev/Credentials/ICredential.py
@@ -81,16 +81,6 @@ logTimeStamp = 0.0
 logRepeatDuration = 120.0
 
 
-class VomsProxyInfo(GangaObject):
-    """ dummy class to allow for loading of 6.3.x jobs inside 6.2.x. PLEASE NEVER USE THIS! """
-    _schema = Schema(Version(1, 0), {})
-    _category = 'CredentialRequirement'
-
-class DiracProxyInfo(GangaObject):
-    """ dummy class to allow for loading of 6.3.x jobs inside 6.2.x. PLEASE NEVER USE THIS! """
-    _schema = Schema(Version(1, 0), {})
-    _category = 'CredentialRequirement'
-
 def registerCommandSet(commandClass=None):
 
     try:
@@ -534,3 +524,4 @@ class ICredential(GangaObject):
         """
         logger.warning("Dummy method used - no information returned")
         return ""
+

--- a/python/Ganga/GPIDev/Credentials/ICredential.py
+++ b/python/Ganga/GPIDev/Credentials/ICredential.py
@@ -81,6 +81,16 @@ logTimeStamp = 0.0
 logRepeatDuration = 120.0
 
 
+class VomsProxyInfo(GangaObject):
+
+    """ dummy class to allow for loading of 6.3.x jobs inside 6.2.x. PLEASE NEVER USE THIS! """
+    _category = 'CredentialRequirement'
+
+class DiracProxyInfo(GangaObject):
+    
+    """ dummy class to allow for loading of 6.3.x jobs inside 6.2.x. PLEASE NEVER USE THIS! """
+    _category = 'CredentialRequirement'
+
 def registerCommandSet(commandClass=None):
 
     try:

--- a/python/Ganga/GPIDev/Credentials/ICredential.py
+++ b/python/Ganga/GPIDev/Credentials/ICredential.py
@@ -82,13 +82,13 @@ logRepeatDuration = 120.0
 
 
 class VomsProxyInfo(GangaObject):
-
     """ dummy class to allow for loading of 6.3.x jobs inside 6.2.x. PLEASE NEVER USE THIS! """
+    _schema = Schema(Version(1, 0), {})
     _category = 'CredentialRequirement'
 
 class DiracProxyInfo(GangaObject):
-    
     """ dummy class to allow for loading of 6.3.x jobs inside 6.2.x. PLEASE NEVER USE THIS! """
+    _schema = Schema(Version(1, 0), {})
     _category = 'CredentialRequirement'
 
 def registerCommandSet(commandClass=None):

--- a/python/Ganga/GPIDev/Credentials/ICredential.py
+++ b/python/Ganga/GPIDev/Credentials/ICredential.py
@@ -524,3 +524,4 @@ class ICredential(GangaObject):
         """
         logger.warning("Dummy method used - no information returned")
         return ""
+

--- a/python/Ganga/GPIDev/Credentials/ICredential.py
+++ b/python/Ganga/GPIDev/Credentials/ICredential.py
@@ -524,4 +524,3 @@ class ICredential(GangaObject):
         """
         logger.warning("Dummy method used - no information returned")
         return ""
-

--- a/python/Ganga/GPIDev/Credentials/__init__.py
+++ b/python/Ganga/GPIDev/Credentials/__init__.py
@@ -92,3 +92,15 @@ def getCredential(name="", create=True):
         credential = False
 
     return credential
+
+
+class VomsProxyInfo(GangaObject):
+    """ dummy class to allow for loading of 6.3.x jobs inside 6.2.x. PLEASE NEVER USE THIS! """
+    _schema = Schema(Version(1, 0), {})
+    _category = 'CredentialRequirement'
+
+class DiracProxyInfo(GangaObject):
+    """ dummy class to allow for loading of 6.3.x jobs inside 6.2.x. PLEASE NEVER USE THIS! """
+    _schema = Schema(Version(1, 0), {})
+    _category = 'CredentialRequirement'
+

--- a/python/Ganga/GPIDev/Credentials/__init__.py
+++ b/python/Ganga/GPIDev/Credentials/__init__.py
@@ -31,6 +31,8 @@ __author__ = "K.Harrison <Harrison@hep.phy.cam.ac.uk>"
 __date__ = "25 September 2007"
 __version__ = "1.5"
 
+from Ganga.GPIDev.Base.Objects import GangaObject
+from Ganga.GPIDev.Schema.Schema import Schema, Version
 from Ganga.GPIDev.Credentials.AfsToken import AfsToken
 from Ganga.Utility.logging import getLogger
 from Ganga.Utility.Plugin import allPlugins
@@ -94,13 +96,14 @@ def getCredential(name="", create=True):
     return credential
 
 
-class VomsProxyInfo(GangaObject):
+class VomsProxy(GangaObject):
     """ dummy class to allow for loading of 6.3.x jobs inside 6.2.x. PLEASE NEVER USE THIS! """
     _schema = Schema(Version(1, 0), {})
     _category = 'CredentialRequirement'
+    _name = 'VomsProxy'
 
-class DiracProxyInfo(GangaObject):
+class DiracProxy(GangaObject):
     """ dummy class to allow for loading of 6.3.x jobs inside 6.2.x. PLEASE NEVER USE THIS! """
     _schema = Schema(Version(1, 0), {})
     _category = 'CredentialRequirement'
-
+    _name = 'DiracProxy'

--- a/python/Ganga/GPIDev/Credentials/__init__.py
+++ b/python/Ganga/GPIDev/Credentials/__init__.py
@@ -105,3 +105,4 @@ class DiracProxy(GangaObject):
     """ dummy class to allow for loading of 6.3.x jobs inside 6.2.x. PLEASE NEVER USE THIS! """
     _schema = Schema(Version(1, 0))
     _category = 'CredentialRequirement'
+

--- a/python/Ganga/GPIDev/Credentials/__init__.py
+++ b/python/Ganga/GPIDev/Credentials/__init__.py
@@ -98,12 +98,10 @@ def getCredential(name="", create=True):
 
 class VomsProxy(GangaObject):
     """ dummy class to allow for loading of 6.3.x jobs inside 6.2.x. PLEASE NEVER USE THIS! """
-    _schema = Schema(Version(1, 0), {})
+    _schema = Schema(Version(1, 0))
     _category = 'CredentialRequirement'
-    _name = 'VomsProxy'
 
 class DiracProxy(GangaObject):
     """ dummy class to allow for loading of 6.3.x jobs inside 6.2.x. PLEASE NEVER USE THIS! """
-    _schema = Schema(Version(1, 0), {})
+    _schema = Schema(Version(1, 0))
     _category = 'CredentialRequirement'
-    _name = 'DiracProxy'


### PR DESCRIPTION
This PR adds dummy Voms and Dirac proxy classes to allow us to load jobs from 6.3.x within Ganga 6.2.x. This is needed and prevents data corruption when moving between versions (as I'm sure some users will inevitably try to do)

I'm happy to move the classes around/rename them/completely rewrite them and I can look at if they're exposed to the GPI and try to prevent this. However the classes need to be present within Ganga in some form to prevent data corruption.
The intention was to hide these in a file which is being removed in the transition to 6.3.x so this will not effect us when this is merged.