### PR TITLE
Fixing unique test for outputfiles

### DIFF
--- a/python/Ganga/GPIDev/Lib/Job/Job.py
+++ b/python/Ganga/GPIDev/Lib/Job/Job.py
@@ -2088,9 +2088,9 @@ class Job(GangaObject):
 
             # reduce duplicate values here
             uniqueValues = GangaList()
-	     for val in values:
-		if val not in uniqueValues:
-			uniqueValues.append(val)
+            for val in values:
+                if val not in uniqueValues:
+                    uniqueValues.append(val)
 
             super(Job, self).__setattr__(attr, uniqueValues)
 

--- a/python/Ganga/GPIDev/Lib/Job/Job.py
+++ b/python/Ganga/GPIDev/Lib/Job/Job.py
@@ -2088,7 +2088,7 @@ class Job(GangaObject):
 
             # reduce duplicate values here
             uniqueValues = GangaList()
-            for val in values:
+            for val in value:
                 if val not in uniqueValues:
                     uniqueValues.append(val)
 

--- a/python/Ganga/GPIDev/Lib/Job/Job.py
+++ b/python/Ganga/GPIDev/Lib/Job/Job.py
@@ -2088,7 +2088,9 @@ class Job(GangaObject):
 
             # reduce duplicate values here
             uniqueValues = GangaList()
-            uniqueValues.extend(set(value))
+	    for val in values:
+		if val not in uniqueValues:
+			uniqueValues.append(val)
 
             super(Job, self).__setattr__(attr, uniqueValues)
 

--- a/python/Ganga/GPIDev/Lib/Job/Job.py
+++ b/python/Ganga/GPIDev/Lib/Job/Job.py
@@ -2088,7 +2088,7 @@ class Job(GangaObject):
 
             # reduce duplicate values here
             uniqueValues = GangaList()
-	    for val in values:
+	     for val in values:
 		if val not in uniqueValues:
 			uniqueValues.append(val)
 


### PR DESCRIPTION
Changing the Job.py outputfiles unique test to just use an append, extending a list from a set from the original list breaks the order ad the set function sorts the input.
This doesn't effect too many tests but does interfere with the File tests when running on different machines.

I'll merge this once the tests pass as this fixes a minor bug which has already been reviewed in a better way on top of the 6.3 branch.