### PR TITLE
Don't quote arguments passed to non-shell Popen

### DIFF
--- a/python/Ganga/Runtime/Repository_runtime.py
+++ b/python/Ganga/Runtime/Repository_runtime.py
@@ -71,7 +71,7 @@ def checkDiskQuota():
             output = quota.communicate()[0]
             logger.debug("fs quota %s:\t%s" % (quote(data_partition), output))
         else:
-            df = subprocess.Popen(["df", '-Pk', '%s' % quote(data_partition)], stdout=subprocess.PIPE)
+            df = subprocess.Popen(["df", '-Pk', '%s' % data_partition], stdout=subprocess.PIPE)
             output = df.communicate()[0]
 
         try:


### PR DESCRIPTION
At present the `checkDiskQuota()` function is printing errors like:
```
df: `\'/disk/homedisk/home/mpw/ganga/ganga/python/gangadir testing/TestSJSubmit/repository/testframework/LocalXML\'': No such file or directory
df: no file systems processed
```
`Popen` will do the quoting automatically when passed a list of arguments in non-shell mode and so the presence of the `quote` function is causing spurious double quoting.

