### PR TITLE
Fix to add the input files to the prepared sandbox

### DIFF
--- a/python/GangaLHCb/Lib/RTHandlers/GaudiExecRTHandlers.py
+++ b/python/GangaLHCb/Lib/RTHandlers/GaudiExecRTHandlers.py
@@ -112,6 +112,9 @@ def collectPreparedFiles(app):
         for name in dirs:
             input_folders.append(os.path.join(root, name))
 
+    for file_ in app.getJobObject().inputfiles :
+        input_files.append(os.path.join(file_.localDir, os.path.basename(file_.namePattern)))
+
     return input_files, input_folders
 
 

--- a/python/GangaLHCb/Lib/RTHandlers/GaudiExecRTHandlers.py
+++ b/python/GangaLHCb/Lib/RTHandlers/GaudiExecRTHandlers.py
@@ -112,7 +112,7 @@ def collectPreparedFiles(app):
         for name in dirs:
             input_folders.append(os.path.join(root, name))
 
-    for file_ in app.getJobObject().inputfiles :
+    for file_ in app.getJobObject().inputfiles:
         input_files.append(os.path.join(file_.localDir, os.path.basename(file_.namePattern)))
 
     return input_files, input_folders


### PR DESCRIPTION
Fix for #783 . I added a line to the collectPreparedFiles function to adding the job.inputfiles into the input_files to be uploaded. In my test the file gets uploaded to the WN successfully and used.

I am not sure if this is how @rob-c intended the logic to work though so he had best check it.