### PR TITLE
Fix config on start up

### DIFF
--- a/python/Ganga/Utility/Config/Config.py
+++ b/python/Ganga/Utility/Config/Config.py
@@ -856,9 +856,9 @@ def load_user_config(filename, system_vars):
         try:
             current_cfg_section = getConfig(name)
         except KeyError:
-            current_cfg_section = None
+            continue
 
-        if not current_cfg_section or not current_cfg_section.options:  # if this section does not exists
+        if not current_cfg_section.options:  # if this section does not exists
             # supressing these messages as depending on what stage of the bootstrap.py you
             # call the function more or less of the default options have been loaded
             # currently calling after initialise() could call after bootstrap()

--- a/python/Ganga/Utility/Config/Config.py
+++ b/python/Ganga/Utility/Config/Config.py
@@ -853,8 +853,12 @@ def load_user_config(filename, system_vars):
         return
     new_cfg = read_ini_files(filename, system_vars)
     for name in new_cfg.sections():
-        current_cfg_section = getConfig(name)
-        if not current_cfg_section.options:  # if this section does not exists
+        try:
+            current_cfg_section = getConfig(name)
+        except KeyError:
+            current_cfg_section = None
+
+        if not current_cfg_section or not current_cfg_section.options:  # if this section does not exists
             # supressing these messages as depending on what stage of the bootstrap.py you
             # call the function more or less of the default options have been loaded
             # currently calling after initialise() could call after bootstrap()


### PR DESCRIPTION
This fixes a bug in the config system that running the new user code without a .gangarc would lead to a crash. This fixes it. This is present in the 6.2.1 testing branch.