### PR TITLE
BUGFIX: Fixing error with backend missing when raising BackendError

### DIFF
--- a/python/GangaDirac/Lib/Backends/DiracBase.py
+++ b/python/GangaDirac/Lib/Backends/DiracBase.py
@@ -707,7 +707,7 @@ class DiracBase(IBackend):
                 job.updateStatus('failed')
                 if job.master:
                     job.master.updateMasterJobStatus()
-                raise BackendError('Problem retrieving outputsandbox: %s' % str(getSandboxResult))
+                raise BackendError('Dirac', 'Problem retrieving outputsandbox: %s' % str(getSandboxResult))
 
             # finally update job to completed
             DiracBase._getStateTime(job, 'completed', completeTimeResult)


### PR DESCRIPTION
The signature for one of the 10 BackendError calls is missing the first argument ("Dirac"). (one line fix) This causes the following incorrect error message when a job fails:

```
raise BackendError('Problem retrieving outputsandbox: %s' % str(getSandboxResult))
TypeError: __init__() takes exactly 3 arguments (2 given)
```