### PR TITLE
Adding a more complex fixture to protect LCG tests

### DIFF
--- a/python/Ganga/Utility/execute.py
+++ b/python/Ganga/Utility/execute.py
@@ -274,7 +274,7 @@ def execute(command,
     try:
         if stdout:
             stdout = pickle.loads(stdout)
-    except pickle.UnpicklingError as err:
+    except (pickle.UnpicklingError, EOFError) as err:
         if not shell:
             logger.error("Execute Err: %s", err)
         else:

--- a/python/Ganga/test/GPI/LCG/TestCREAM.py
+++ b/python/Ganga/test/GPI/LCG/TestCREAM.py
@@ -3,10 +3,11 @@ import subprocess
 
 from Ganga.Utility.Config import getConfig
 
-from Ganga.testlib.mark import external
+from Ganga.testlib.mark import external, skipif_config
 
 
 @external
+@skipif_config('LCG', 'GLITE_ENABLE', False, reason='GLITE not enabled')
 def test_job_kill(gpi):
     from Ganga.GPI import Job, CREAM
 

--- a/python/Ganga/test/GPI/LCG/TestLCG.py
+++ b/python/Ganga/test/GPI/LCG/TestLCG.py
@@ -5,11 +5,12 @@ try:
 except ImportError:
     from mock import patch
 
-from Ganga.testlib.mark import external
+from Ganga.testlib.mark import external, skipif_config
 from Ganga.testlib.monitoring import run_until_completed
 
 
 @external
+@skipif_config('LCG', 'GLITE_ENABLE', False, reason='GLITE not enabled')
 def test_job_submit_and_monitor(gpi):
     from Ganga.GPI import Job, LCG
 
@@ -21,6 +22,7 @@ def test_job_submit_and_monitor(gpi):
     stripProxy(LCG).master_updateMonitoringInformation([stripProxy(j)])
 
 @external
+@skipif_config('LCG', 'GLITE_ENABLE', False, reason='GLITE not enabled')
 def test_job_kill(gpi):
     from Ganga.GPI import Job, LCG
 
@@ -29,7 +31,7 @@ def test_job_kill(gpi):
     j.submit()
     j.kill()
 
-
+@skipif_config('LCG', 'GLITE_ENABLE', False, reason='GLITE not enabled')
 def test_submit_kill_resubmit(gpi):
     """
     Test that a simple submit-kill-resubmit-kill cycle works
@@ -57,7 +59,7 @@ def test_submit_kill_resubmit(gpi):
     with patch('Ganga.Lib.LCG.Grid.cancel', return_value=True):
         j.kill()
 
-
+@skipif_config('LCG', 'GLITE_ENABLE', False, reason='GLITE not enabled')
 def test_submit_monitor(gpi):
     """
     Test that an LCG job can be monitored
@@ -95,3 +97,4 @@ def test_submit_monitor(gpi):
 
     with patch('Ganga.Lib.LCG.Grid.cancel', return_value=True):
         j.kill()
+

--- a/python/Ganga/testlib/mark.py
+++ b/python/Ganga/testlib/mark.py
@@ -31,12 +31,12 @@ class skipif_config(object):
         self.value = value
         self.reason = reason
 
-    def __call__(self, function):
+    def __call__(self, function, *args, **kwds):
         """
         Args:
             function (method, class): This is the test method or class we want to skip if the conditions aren't met
         """
-        def _skip_if_config(*args, **kwds):
+        def _skip_if_config():
             # Load config
             load_config_files()
             # test if the config parameter is what we require

--- a/python/Ganga/testlib/mark.py
+++ b/python/Ganga/testlib/mark.py
@@ -43,11 +43,7 @@ class skipif_config(object):
         clear_config()
         if test:
             # Mark test as skip if it's not what we require
-            return pytest.skip(self.reason)
+            return pytest.mark.skip(self.reason)(function)
 
-        @functools.wraps(function)
-        def _skip_if_config(function):
-            # run test if we have met the requirements
-            return function
-        return _skip_if_config
+        return function
 

--- a/python/Ganga/testlib/mark.py
+++ b/python/Ganga/testlib/mark.py
@@ -1,6 +1,51 @@
+from __future__ import absolute_import
 import pytest
+import functools
+
+from .GangaUnitTest import load_config_files, clear_config
+from Ganga.Utility.Config import getConfig
 
 external = pytest.mark.skipif(
-    not pytest.config.getoption("--runexternals"),
-    reason="need --runexternals option to run external tests"
-)
+        not pytest.config.getoption("--runexternals"),
+        reason="need --runexternals option to run external tests"
+        )
+
+class skipif_config(object):
+    """
+    Class used to skip a test when it cannot be run due to a conflicting env config
+    Args:
+        function (method, class): This is the test method or class we want to skip if the conditions aren't met
+    """
+
+    def __init__(self, section, item, value, reason):
+        """
+        This is the constructor which takes the flags required by the wrapper
+        Args:
+            section(str): This is the name of the section in getConfig
+            item(str): This is the name of the item under getConfig
+            value(anything): This is the value we require to run the test
+            reason(str): This is the string which will be returned if we skip the test explaining why
+        """
+        self.section = section
+        self.item = item
+        self.value = value
+        self.reason = reason
+
+    def __call__(self, function):
+        """
+        Args:
+            function (method, class): This is the test method or class we want to skip if the conditions aren't met
+        """
+        def _skip_if_config(*args, **kwds):
+            # Load config
+            load_config_files()
+            # test if the config parameter is what we require
+            test = getConfig(self.section)[self.item] == self.value
+            clear_config()
+            if test:
+                # Mark test as skip if it's not what we require
+                return pytest.skip(self.reason)
+            # run test if we have met the requirements
+            return function(*args, **kwds)
+        return _skip_if_config
+

--- a/python/Ganga/testlib/mark.py
+++ b/python/Ganga/testlib/mark.py
@@ -31,21 +31,23 @@ class skipif_config(object):
         self.value = value
         self.reason = reason
 
-    def __call__(self, function, *args, **kwds):
+    def __call__(self, function):
         """
         Args:
             function (method, class): This is the test method or class we want to skip if the conditions aren't met
         """
-        def _skip_if_config():
-            # Load config
-            load_config_files()
-            # test if the config parameter is what we require
-            test = getConfig(self.section)[self.item] == self.value
-            clear_config()
-            if test:
-                # Mark test as skip if it's not what we require
-                return pytest.skip(self.reason)
+        # Load config
+        load_config_files()
+        # test if the config parameter is what we require
+        test = getConfig(self.section)[self.item] == self.value
+        clear_config()
+        if test:
+            # Mark test as skip if it's not what we require
+            return pytest.skip(self.reason)
+
+        @functools.wraps(function)
+        def _skip_if_config(function):
             # run test if we have met the requirements
-            return function(*args, **kwds)
+            return function
         return _skip_if_config
 


### PR DESCRIPTION
This PR adds a more complex fixture which allows us to skip a test if we know that the config will always cause the test to fail.

I'd like to merge this into `develop` to get the nightly tests working for all backends.
I know this can be viewed as an enhancement but I'm keen to get the nightlies running with core tests for LHCb so I'm viewing this as a bugfix as the LCG tests will incorrectly fail when inside an LHCb environment.

Does anyone have any objections to me merging this?