### PR TITLE
Some fixes to LHCbDataset

### DIFF
--- a/python/GangaLHCb/Lib/LHCbDataset/LHCbDataset.py
+++ b/python/GangaLHCb/Lib/LHCbDataset/LHCbDataset.py
@@ -378,7 +378,7 @@ class LHCbDataset(GangaDataset):
         other_files = self._checkOtherFiles(other)
         files = set(self.getFullFileNames()).difference(other_files)
         data = LHCbDataset()
-        data.extend([list(files)])
+        data.extend(list(files))
         data.depth = self.depth
         return data
 
@@ -395,10 +395,10 @@ class LHCbDataset(GangaDataset):
     def symmetricDifference(self, other):
         '''Returns a new data set w/ files in either this or other but not
         both.'''
-        other_files = other.checkOtherFiles(other)
+        other_files = other._checkOtherFiles(other)
         files = set(self.getFullFileNames()).symmetric_difference(other_files)
         data = LHCbDataset()
-        data.extend([list(files)])
+        data.extend(list(files))
         data.depth = self.depth
         return data
 
@@ -407,7 +407,7 @@ class LHCbDataset(GangaDataset):
         other_files = other._checkOtherFiles(other)
         files = set(self.getFullFileNames()).intersection(other_files)
         data = LHCbDataset()
-        data.extend([list(files)])
+        data.extend(list(files))
         data.depth = self.depth
         return data
 
@@ -416,7 +416,7 @@ class LHCbDataset(GangaDataset):
         other_files = self._checkOtherFiles(other)
         files = set(self.getFullFileNames()).union(other_files)
         data = LHCbDataset()
-        data.extend([list(files)])
+        data.extend(list(files))
         data.depth = self.depth
         return data
 


### PR DESCRIPTION
This fixes some issues in LHCbDataset #855 . The ```difference```, ```symmetricDifference``` and ```union``` functions were calling ```extend()``` with a ```[list(set)]```. So the set was being changed to a list but then put inside another list which was causing problems.

I think this is just a hangover from when the code was changed to use ```extend``` instead of the now-defunct ```construct``` function.