### PR TITLE
Fix for prepare in old style apps

### DIFF
--- a/python/GangaGaudi/Lib/Applications/GaudiBase.py
+++ b/python/GangaGaudi/Lib/Applications/GaudiBase.py
@@ -190,7 +190,7 @@ class GaudiBase(IPrepareApp):
                 env=self.getenv(False),
                 cwd=self.user_release_area)
 
-    def unprepare(self):
+    def unprepare(self, force=False):
         self._unregister()
 
     def _unregister(self):


### PR DESCRIPTION
Fixes #860. Added in the ```force``` argument for the ```unprepare``` function in the GaudiBase. Doesn't actually do anything but other places call ```unprepare``` with a force flag so I added it in.