### PR TITLE
Moving some code around and allowing for 'ganga' to load plugins 

### DIFF
--- a/python/Ganga/Runtime/bootstrap.py
+++ b/python/Ganga/Runtime/bootstrap.py
@@ -849,7 +849,7 @@ under certain conditions; type license() for details.
         register_exitfunc()
 
         import Ganga.Utility.Config
-        from Ganga.Utility.Runtime import RuntimePackage, allRuntimes
+        from Ganga.Utility.Runtime import initSetupRuntimePackages
         from Ganga.Core import GangaException
 
         logger.debug("Import plugins")
@@ -861,36 +861,7 @@ under certain conditions; type license() for details.
             logger.exception(x)
             raise GangaException(x), None, sys.exc_info()[2]
 
-        # initialize runtime packages, they are registered in allRuntimes
-        # dictionary automatically
-        try:
-            import Ganga.Utility.files
-            from Ganga.Utility.Config.Config import getConfig
-            config = getConfig('Configuration')
-
-            #if config['IgnoreRuntimeWarnings']:
-            #    import warnings
-            #    warnings.filterwarnings(action="ignore", category=RuntimeWarning)
-
-            
-            import inspect
-            from os.path import expandvars, expanduser
-
-            GangaRootPath = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe()))), '../..'))
-            def transform(x):
-                return os.path.normpath(Ganga.Utility.files.expandfilename(os.path.join(GangaRootPath,x)))
-
-            paths = map(transform, filter(None, map(lambda x: expandvars(expanduser(x)), config['RUNTIME_PATH'].split(':'))))
-
-            for path in paths:
-                r = RuntimePackage(path)
-        except KeyError, err:
-            logger.debug("init KeyError: %s" % err)
-
-        # perform any setup of runtime packages
-        logger.debug('Setting up Runtime Packages')
-        for r in allRuntimes.values():
-            r.standardSetup()
+        initSetupRuntimePackages()
 
         from Ganga.Core.GangaThread.WorkerThreads import startUpQueues
         startUpQueues()

--- a/python/Ganga/Utility/Config/__init__.py
+++ b/python/Ganga/Utility/Config/__init__.py
@@ -20,3 +20,28 @@ def expandgangasystemvars(c, v):
         if option in v:
             v = v.replace(option, system[key])
     return v
+
+def load_config_files():
+    """
+    Load the config files as a normal Ganga session would, taking
+    into account environment variables etc.
+    """
+    from Ganga.Utility.Config import getConfig, setSessionValuesFromFiles
+    from Ganga.Runtime import GangaProgram
+    system_vars = {}
+    for opt in getConfig('System'):
+        system_vars[opt] = getConfig('System')[opt]
+        config_files = GangaProgram.get_config_files('')#os.path.expanduser('~/.gangarc'))
+        setSessionValuesFromFiles(config_files, system_vars)
+
+
+def clear_config():
+    """
+    Reset all the configs back to their default values
+    """
+    from Ganga.Utility.Config import allConfigs
+    for package in allConfigs.values():
+        package._user_handlers = []
+        package._session_handlers = []
+        package.revertToDefaultOptions()
+

--- a/python/Ganga/Utility/Config/__init__.py
+++ b/python/Ganga/Utility/Config/__init__.py
@@ -31,7 +31,8 @@ def load_config_files():
     system_vars = {}
     for opt in getConfig('System'):
         system_vars[opt] = getConfig('System')[opt]
-        config_files = GangaProgram.get_config_files(os.path.expanduser('~/.gangarc'))
+        user_config = os.environ.get('GANGA_CONFIG_FILE') or os.path.expanduser('~/.gangarc')
+        config_files = GangaProgram.get_config_files(user_config)
         setSessionValuesFromFiles(config_files, system_vars)
 
 

--- a/python/Ganga/Utility/Config/__init__.py
+++ b/python/Ganga/Utility/Config/__init__.py
@@ -31,7 +31,7 @@ def load_config_files():
     system_vars = {}
     for opt in getConfig('System'):
         system_vars[opt] = getConfig('System')[opt]
-        config_files = GangaProgram.get_config_files('')#os.path.expanduser('~/.gangarc'))
+        config_files = GangaProgram.get_config_files(os.path.expanduser('~/.gangarc'))
         setSessionValuesFromFiles(config_files, system_vars)
 
 

--- a/python/Ganga/Utility/Runtime.py
+++ b/python/Ganga/Utility/Runtime.py
@@ -122,7 +122,7 @@ class RuntimePackage(object):
             if allRuntimes[self.name].path != self.path:
                 logger.warning('possible clash: runtime "%s" already exists at path "%s"', self.name, allRuntimes[self.name].path)
 
-        allRuntimes[self.name] = self
+        allRuntimes[self.path] = self
 
         if self.syspath:
             # FIXME: not sure if I really want to modify sys.path (side effects!!)

--- a/python/Ganga/Utility/Runtime.py
+++ b/python/Ganga/Utility/Runtime.py
@@ -196,11 +196,11 @@ class RuntimePackage(object):
             template_pathname = os.path.join(self.modpath, 'templates')
             if os.path.isdir(template_pathname):
                 establishNamedTemplates(template_registryname,
-                                        template_pathname,
-                                        "Registry for '%s' NamedTemplates" % self.name.strip(
-                                            'Ganga'),
-                                        file_ext=file_ext,
-                                        pickle_files=pickle_files)
+       template_pathname,
+       "Registry for '%s' NamedTemplates" % self.name.strip(
+           'Ganga'),
+       file_ext=file_ext,
+       pickle_files=pickle_files)
         except:
             logger.debug('failed to load named template registry')
             raise
@@ -236,6 +236,42 @@ class RuntimePackage(object):
             logger.debug("no postBootstrapHook() in runtime package %s", self.name)
 
 
+def initSetupRuntimePackages():
+    """ Short wrapper function to init and setup Runtime Plugins """
+    initRuntimePackages()
+
+    # perform any setup of runtime packages
+    logger.debug('Setting up Runtime Packages')
+    for r in allRuntimes.values():
+        r.standardSetup()
+
+
+def initRuntimePackages():
+    """
+    initialize runtime packages, they are registered in allRuntimes
+    dictionary automatically
+    """
+    import Ganga.Utility.files
+    from Ganga.Utility.Config.Config import getConfig
+    config = getConfig('Configuration')
+
+    #if config['IgnoreRuntimeWarnings']:
+    #    import warnings
+    #    warnings.filterwarnings(action="ignore", category=RuntimeWarning)
+
+
+    import inspect
+    import os.path
+
+    GangaRootPath = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe()))), '../..'))
+    def transform(x):
+        return os.path.normpath(Ganga.Utility.files.expandfilename(os.path.join(GangaRootPath,x)))
+
+    paths = map(transform, filter(None, map(lambda x: os.path.expandvars(os.path.expanduser(x)), config['RUNTIME_PATH'].split(':'))))
+
+    for path in paths:
+        r = RuntimePackage(path)
+
 
 def loadPlugins(environment):
     """
@@ -245,7 +281,9 @@ def loadPlugins(environment):
     from Ganga.Utility.logging import getLogger
     logger = getLogger()
     env_dict = environment.__dict__
+    logger.debug("Loading: %s PLUGINS" % str(allRuntimes.keys()))
     for n, r in allRuntimes.iteritems():
+        logger.debug("Bootstrapping: %s" % n)
         try:
             r.bootstrap(env_dict)
         except Exception as err:
@@ -254,12 +292,13 @@ def loadPlugins(environment):
             raise err
         try:
             r.loadNamedTemplates(env_dict, Ganga.Utility.Config.getConfig('Configuration')['namedTemplates_ext'],
-                                           Ganga.Utility.Config.getConfig('Configuration')['namedTemplates_pickle'])
+          Ganga.Utility.Config.getConfig('Configuration')['namedTemplates_pickle'])
         except Exception as err:
             logger.error('problems with loading Named Templates for %s', n)
             logger.error('Reason: %s' % str(err))
 
     for n, r in allRuntimes.iteritems():
+        logger.debug("Loading: %s" % n)
         try:
             r.loadPlugins()
         except Exception as err:
@@ -319,7 +358,8 @@ def setPluginDefaults(my_interface=None):
     try:
         batch_default = allPlugins.find('backends', batch_default_name)
     except Exception as x:
-        raise Ganga.Utility.Config.ConfigError('Check configuration. Unable to set default Batch backend alias (%s)' % str(x))
+        from Ganga.Utility.Config import ConfigError
+        raise ConfigError('Check configuration. Unable to set default Batch backend alias (%s)' % str(x))
     else:
         allPlugins.add(batch_default, 'backends', 'Batch')
         from Ganga.Runtime.GPIexport import exportToInterface

--- a/python/ganga/__init__.py
+++ b/python/ganga/__init__.py
@@ -24,18 +24,29 @@ def ganga_license():
 # Setup the shutdown manager
 atexit.register(_ganga_run_exitfuncs)
 
-system_vars = {}
-for opt in getConfig('System'):
-    system_vars[opt] = getConfig('System')[opt]
-setSessionValuesFromFiles([os.path.expanduser('~/.gangarc')], system_vars)
-
 import ganga
-from Ganga.Runtime import plugins
 
+# Lets load the config files from disk
+from Ganga.Utility.Config import load_config_files
+load_config_files()
+
+# Setup the proxy interface early
 from Ganga.GPIDev.Base.Proxy import setProxyInterface
 setProxyInterface(ganga)
 
-from Ganga.Utility.Runtime import loadPlugins, autoPopulateGPI
+# Init Setup and Load the RuntimePlugins
+
+logger.debug("Import plugins")
+try:
+    # load Ganga system plugins...
+    from Ganga.Runtime import plugins
+except Exception as x:
+    logger.critical('Ganga system plugins could not be loaded due to the following reason: %s', x)
+    logger.exception(x)
+    raise GangaException(x), None, sys.exc_info()[2]
+
+from Ganga.Utility.Runtime import initSetupRuntimePackages, loadPlugins, autoPopulateGPI
+initSetupRuntimePackages()
 loadPlugins(ganga)
 autoPopulateGPI(ganga)
 


### PR DESCRIPTION
Fixes #863  This moves more code out of the bootstrap into the correct utility and calls it from both `ganga` and during normal startup.

Rough and ready so feel free to fix/improve/edit/take-inspiration from this PR.