### PR TITLE
Adding simplest lock to Ganga

### DIFF
--- a/python/Ganga/Core/GangaRepository/FixedLock.py
+++ b/python/Ganga/Core/GangaRepository/FixedLock.py
@@ -75,7 +75,9 @@ class FixedLockManager(object):
         self.global_lock = os.path.join(sessions_folder, '%s_fixed_lock' % name)
         self.count = minimum_count
         if os.path.exists(self.global_lock):
-            raise RepositoryError(repo, "Cannot start this registry: %s Due to a lock file already existing: '%s'" % (name, self.global_lock))
+            msg = "\n\nCannot start this registry: %s due to a lock file already existing: '%s'\n" % (name, self.global_lock)
+            msg += "If you are trying to run only 1 ganga session please remove this file and re-launch ganga\n"
+            raise RepositoryError(repo, msg)
 
         with open(self.global_lock, 'w'):
             pass

--- a/python/Ganga/Core/GangaRepository/FixedLock.py
+++ b/python/Ganga/Core/GangaRepository/FixedLock.py
@@ -1,0 +1,163 @@
+# This class (SessionLockManager) encapsulates fcntl-based locking that works on NFS, AFS and locally.
+# You can use
+# python SessionLock.py {1|2}
+# to run locking tests (run several instances in the same directory, from
+# different machines)
+
+from __future__ import print_function
+
+import functools
+import threading
+from collections import namedtuple
+
+import os
+import time
+import errno
+import fcntl
+import random
+import datetime
+import getpass
+from pipes import quote
+
+import cPickle as pickle
+
+from Ganga.Utility.logging import getLogger
+
+from Ganga.Utility.Config.Config import getConfig, ConfigError
+from Ganga.GPIDev.Base.Proxy import getName
+
+from Ganga.Core.GangaThread import GangaThread
+from Ganga.Core.GangaRepository import RepositoryError
+
+logger = getLogger()
+
+def lock_synch(f):
+    """  
+        This decorator must be attached to a method on a ``Node`` subclass
+        It uses the object's lock to make sure that the object is held for the duration of the decorated function
+        Args:
+        f (function): This is the function which we want to wrap
+    """  
+    @functools.wraps(f)
+    def decorated_lock(self, *args, **kwargs):
+        with self.sync_lock:
+            return f(self, *args, **kwargs)
+    return decorated_lock
+
+class FixedLockManager(object):
+
+    """ Class with thread that keeps a single fixed lockfile which is removed on exit.
+    This explicitly forbids multiple parallel Ganga sessions.
+    """
+
+    def __init__(self, repo, root, name, minimum_count=0):
+
+
+        # Used for self runtime thread safety
+        self.sync_lock = threading.RLock()
+
+        # Required to pretend there are some locked jobs from other sessions
+        self.locked = set()
+
+        self.repo = repo
+        self.mkdir(root)
+        realpath = os.path.realpath(root)
+
+        # Location of the count file for this repo
+        self.cntfn = os.path.join(realpath, name, "cnt")
+
+        # Required for lock files
+        sessions_folder = os.path.join(realpath, "sessions")
+        if not os.path.exists(sessions_folder):
+            os.mkdir(sessions_folder) 
+
+        # Location of fixed lock for this repo
+        self.global_lock = os.path.join(sessions_folder, '%s_fixed_lock' % name)
+        self.count = minimum_count
+        if os.path.exists(self.global_lock):
+            raise RepositoryError(repo, "Cannot start this registry: %s Due to a lock file already existing: '%s'" % (name, self.global_lock))
+
+        with open(self.global_lock, 'w'):
+            pass
+
+    @lock_synch
+    def mkdir(self, dn):                                                                                                                                                                                           
+        """Make sure the given directory exists"""
+        try:
+            if not os.path.exists(dn):
+                os.makedirs(dn)
+        except OSError as x:
+            if x.errno != errno.EEXIST:
+                raise RepositoryError(self.repo, "OSError on directory create: %s" % x)
+
+    def startup(self):
+        pass
+
+    def finish_startup(self):
+        pass
+
+    def updateNow(self):
+        pass
+
+    def shutdown(self):
+        """Shutdown the thread and locking system (on ganga shutdown or repo error)"""
+        os.unlink(self.global_lock)
+    
+    def session_read(self, fn):
+        return set()
+
+    def session_write(self):
+        pass
+
+    @lock_synch
+    def cnt_read(self):
+        """Reads the counter file.
+        """
+        with open(self.cntfn) as fd:
+            # 100 bytes should be enough for any ID. Can raise ValueErrorr
+            _output = int(fd.readline())
+        self.count = max(self.count, _output)
+        return _output
+
+    @lock_synch
+    def cnt_write(self):
+        """ Writes the counter to the counter file.
+        """
+        with open(self.cntfn, 'w') as fd:
+            fd.write(str(self.count))
+
+    @lock_synch
+    def make_new_ids(self, n):
+        """This bumps the registry count by n ids"""
+        newcount = self.cnt_read()
+        ids = range(newcount, newcount + n)
+        self.count = ids[-1]+1
+        self.cnt_write()
+        return list(ids)
+
+    def lock_ids(self, ids):
+        """Pretend to lock IDs"""
+        return list(ids)
+
+    def release_ids(self, ids):
+        """Pretend to release IDs"""
+        return list(ids)
+
+    def check(self):
+        """ No need to check as we're disk/runtime consistent by construction. i.e. no parallel sessions """
+        pass
+
+    def get_lock_session(self, id):
+        """Return a dummy str of self as only we can own a session
+        """
+        return "self"
+
+    def get_other_sessions(self):
+        """Return an empty list as No other sessions by definition
+        """
+        return []
+
+    def reap_locks(self):
+        """ Return True to respect checks on SessionLock"""
+        return True
+

--- a/python/Ganga/Core/GangaRepository/GangaRepositoryXML.py
+++ b/python/Ganga/Core/GangaRepository/GangaRepositoryXML.py
@@ -229,13 +229,17 @@ class GangaRepositoryLocal(GangaRepository):
         else:
             raise RepositoryError(self, "Unknown Repository type: %s" % self.registry.type)
         if getConfig('Configuration')['lockingStrategy'] == "UNIX":
+            # First test the UNIX locks are working as expected
             try:
                 test_unix_locks(self.lockroot)
             except Exception as err:
+                # Locking has not worked, lets raise an error
                 logger.error("Error: %s" % err)
-                msg="\nUnable to launch due to underlying filesystem not working with unix locks."
+                msg="\n\nUnable to launch due to underlying filesystem not working with unix locks."
                 msg+="Please try launching again with [Configuration]lockingStrategy=FIXED to start Ganga without multiple session support."
                 raise RepositoryError(self, msg)
+
+            # Locks passed test so lets continue
             self.sessionlock = SessionLockManager(self, self.lockroot, self.registry.name)
         elif getConfig('Configuration')['lockingStrategy'] == "FIXED":
             self.sessionlock = FixedLockManager(self, self.lockroot, self.registry.name)

--- a/python/Ganga/Core/GangaRepository/GangaRepositoryXML.py
+++ b/python/Ganga/Core/GangaRepository/GangaRepositoryXML.py
@@ -13,6 +13,7 @@ import copy
 import threading
 
 from Ganga.Core.GangaRepository.SessionLock import SessionLockManager
+from Ganga.Core.GangaRepository.FixedLock import FixedLockManager
 
 import Ganga.Utility.logging
 
@@ -27,6 +28,8 @@ from Ganga.GPIDev.Base.Objects import Node
 from Ganga.Core.GangaRepository.SubJobXMLList import SubJobXMLList
 
 from Ganga.GPIDev.Base.Proxy import isType, stripProxy, getName
+
+from Ganga.Utility.Config import getConfig
 
 logger = Ganga.Utility.logging.getLogger()
 
@@ -225,7 +228,10 @@ class GangaRepositoryLocal(GangaRepository):
             self.from_file = pickle_from_file
         else:
             raise RepositoryError(self.repo, "Unknown Repository type: %s" % self.registry.type)
-        self.sessionlock = SessionLockManager(self, self.lockroot, self.registry.name)
+        if getConfig('Configuration')['lockingStrategy'] == "UNIX":
+            self.sessionlock = SessionLockManager(self, self.lockroot, self.registry.name)
+        else:
+            self.sessionlock = FixedLockManager(self, self.lockroot, self.registry.name)
         self.sessionlock.startup()
         # Load the list of files, this time be verbose and print out a summary
         # of errors

--- a/python/Ganga/Core/GangaRepository/GangaRepositoryXML.py
+++ b/python/Ganga/Core/GangaRepository/GangaRepositoryXML.py
@@ -12,7 +12,7 @@ import errno
 import copy
 import threading
 
-from Ganga.Core.GangaRepository.SessionLock import SessionLockManager, test_unix_locks
+from Ganga.Core.GangaRepository.SessionLock import SessionLockManager, dry_run_unix_locks
 from Ganga.Core.GangaRepository.FixedLock import FixedLockManager
 
 import Ganga.Utility.logging
@@ -231,7 +231,7 @@ class GangaRepositoryLocal(GangaRepository):
         if getConfig('Configuration')['lockingStrategy'] == "UNIX":
             # First test the UNIX locks are working as expected
             try:
-                test_unix_locks(self.lockroot)
+                dry_run_unix_locks(self.lockroot)
             except Exception as err:
                 # Locking has not worked, lets raise an error
                 logger.error("Error: %s" % err)

--- a/python/Ganga/Core/GangaRepository/SessionLock.py
+++ b/python/Ganga/Core/GangaRepository/SessionLock.py
@@ -255,6 +255,33 @@ def synchronised(f):
             return f(self, *args, **kwargs)
     return decorated
 
+def test_unix_locks(folder):
+    """
+    This attempts to make a 'sessions/test_lock' file in folder and lock it using unix lock commands
+    Args:
+        folder(str): This is the folder where the lock file will be created for testing
+    """
+
+    test_file = os.path.join(os.path.realpath(folder), 'sessions', 'test_lock')
+    # Create file if it doesn't exit
+    with open(test_file, 'w'):
+        pass
+
+    # Open test lock file
+    with open(test_file) as f_lock:
+        # If lock file is locked, wait until we can lock it and continue
+        while True:
+            try:
+                fcntl.flock(f_lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                break
+            except IOError as e:
+                if e.errno != errno.EAGAIN:
+                    raise
+                time.sleep(0.1)
+            finally:
+                fcntl.flock(f_lock, fcntl.LOCK_UN)
+
+
 def global_disk_lock(f):
     @functools.wraps(f)
     def decorated_global(self, *args, **kwds):

--- a/python/Ganga/Core/GangaRepository/SessionLock.py
+++ b/python/Ganga/Core/GangaRepository/SessionLock.py
@@ -263,6 +263,8 @@ def test_unix_locks(folder):
     """
 
     test_file = os.path.join(os.path.realpath(folder), 'sessions', 'test_lock')
+    if not os.path.isdir(os.path.dirname(test_file)):
+        os.makedirs(os.path.dirname(test_file))
     # Create file if it doesn't exit
     with open(test_file, 'w'):
         pass
@@ -281,6 +283,7 @@ def test_unix_locks(folder):
             finally:
                 fcntl.flock(f_lock, fcntl.LOCK_UN)
 
+    os.unlink(test_file)
 
 def global_disk_lock(f):
     @functools.wraps(f)

--- a/python/Ganga/Core/GangaRepository/SessionLock.py
+++ b/python/Ganga/Core/GangaRepository/SessionLock.py
@@ -255,7 +255,7 @@ def synchronised(f):
             return f(self, *args, **kwargs)
     return decorated
 
-def test_unix_locks(folder):
+def dry_run_unix_locks(folder):
     """
     This attempts to make a 'sessions/test_lock' file in folder and lock it using unix lock commands
     Args:

--- a/python/Ganga/__init__.py
+++ b/python/Ganga/__init__.py
@@ -121,7 +121,7 @@ conf_config.addOption('ReleaseNotes', True, 'Flag to print out the relevent subs
 conf_config.addOption('gangadir', expandvars(None, '~/gangadir'),
                  'Location of local job repositories and workspaces. Default is ~/gangadir but in somecases (such as LSF CNAF) this needs to be modified to point to the shared file system directory.', filter=Ganga.Utility.Config.expandvars)
 conf_config.addOption('repositorytype', 'LocalXML', 'Type of the repository.', examples='LocalXML')
-conf_config.addOption('lockingStrategy', 'UNIX', 'Type of locking strategy which can be used. UNIX or FIXED')
+conf_config.addOption('lockingStrategy', 'UNIX', 'Type of locking strategy which can be used. UNIX or FIXED . default = UNIX')
 conf_config.addOption('workspacetype', 'LocalFilesystem',
                  'Type of workspace. Workspace is a place where input and output sandbox of jobs are stored. Currently the only supported type is LocalFilesystem.')
 conf_config.addOption('user', getpass.getuser(),

--- a/python/Ganga/__init__.py
+++ b/python/Ganga/__init__.py
@@ -120,8 +120,8 @@ conf_config.addOption('StartupGPI', '', 'block of GPI commands executed at start
 conf_config.addOption('ReleaseNotes', True, 'Flag to print out the relevent subsection of release notes for each experiment at start up')
 conf_config.addOption('gangadir', expandvars(None, '~/gangadir'),
                  'Location of local job repositories and workspaces. Default is ~/gangadir but in somecases (such as LSF CNAF) this needs to be modified to point to the shared file system directory.', filter=Ganga.Utility.Config.expandvars)
-conf_config.addOption(
-    'repositorytype', 'LocalXML', 'Type of the repository.', examples='LocalXML')
+conf_config.addOption('repositorytype', 'LocalXML', 'Type of the repository.', examples='LocalXML')
+conf_config.addOption('lockingStrategy', 'UNIX', 'Type of locking strategy which can be used. UNIX or FIXED')
 conf_config.addOption('workspacetype', 'LocalFilesystem',
                  'Type of workspace. Workspace is a place where input and output sandbox of jobs are stored. Currently the only supported type is LocalFilesystem.')
 conf_config.addOption('user', getpass.getuser(),


### PR DESCRIPTION
This was something I was playing with over the weekend mainly.

This PR shows how we can have the simplest lock possible which only prevents Ganga from running multiple sessions. The shutdown is relatively friendly and doesn't have a stack trace.

This would likely be useful for non-POSIX envs where a user would be able to launch similar to:

```
IPYTHONDIR=/tmp/somePath ganga -o'[Configuration]lockingStrategy=Fixed'
```

This may be useful for unusual installs or debugging (or even in testing as this reduces a lot of I/O).

I'm not sure if someone else has an idea of how they would like to solve this but this would be what I suggest.


NB:
filelock in python still relies on posix locking (I think) if it's there so migrating SessionLock to this is only a cleaning up exercise and doesn't help if we can't posix lock a file.