### PR TITLE
Fix for user configurations

### DIFF
--- a/python/Ganga/Runtime/bootstrap.py
+++ b/python/Ganga/Runtime/bootstrap.py
@@ -697,13 +697,15 @@ under certain conditions; type license() for details.
 
         def set_cmdline_config_options(sects=None):
             try:
+               
                 opts = self.parse_cmdline_config_options(self.options.cmdline_options)
                 for section, option, val in opts:
                     should_set = True
                     if not sects is None and not section in sects:
                         should_set = False
                     if should_set:
-                        config = Ganga.Utility.Config.setSessionValue(section, option, val)
+                        Ganga.Utility.Config.setSessionValue(section, option, val)
+                        config = Ganga.Utility.Config.setUserValue(section, option, val)
             except ConfigError as x:
                 self.exit('command line option error: %s' % x)
 
@@ -750,7 +752,6 @@ under certain conditions; type license() for details.
                 'Cannot modify [System] settings (attempted %s=%s)' % (name, x))
         syscfg.attachUserHandler(deny_modification, None)
         syscfg.attachSessionHandler(deny_modification, None)
-
         Ganga.Utility.Config.setSessionValuesFromFiles(config_files, system_vars)
 
         # set the system variables to the [System] module

--- a/python/Ganga/Runtime/bootstrap.py
+++ b/python/Ganga/Runtime/bootstrap.py
@@ -697,14 +697,12 @@ under certain conditions; type license() for details.
 
         def set_cmdline_config_options(sects=None):
             try:
-               
                 opts = self.parse_cmdline_config_options(self.options.cmdline_options)
                 for section, option, val in opts:
                     should_set = True
                     if not sects is None and not section in sects:
                         should_set = False
                     if should_set:
-                        Ganga.Utility.Config.setSessionValue(section, option, val)
                         config = Ganga.Utility.Config.setUserValue(section, option, val)
             except ConfigError as x:
                 self.exit('command line option error: %s' % x)

--- a/python/Ganga/Utility/Config/Config.py
+++ b/python/Ganga/Utility/Config/Config.py
@@ -458,9 +458,13 @@ class PackageConfig(object):
         return self.getEffectiveOption(o)
 
     def addOption(self, name, default_value, docstring, override=False, **meta):
+        """
+        Add a new option to the configuration.
+        """
         if _after_bootstrap and not self.is_open:
             raise ConfigError('attempt to add a new option [%s]%s after bootstrap' % (self.name, name))
 
+        # has the option already been made
         try:
             option = self.options[name]
         except KeyError:
@@ -474,6 +478,7 @@ class PackageConfig(object):
         option.defineOption(default_value, docstring, **meta)
         self.options[option.name] = option
 
+        # is it in the list of unknown options from the standard config files
         try:
             conf_value = unknownConfigFileValues[self.name]
         except KeyError:
@@ -491,6 +496,7 @@ class PackageConfig(object):
                 msg = "Error Setting Session Value: %s" % err
                 if locals().get('logger') is not None:
                     locals().get('logger').debug("dbg: %s" % msg)
+        # is it in the list of unknown options specified by the user at the command line or gangarc
         try:
             conf_value = unknownUserConfigValues[self.name]
         except KeyError:
@@ -832,6 +838,12 @@ def read_ini_files(filenames, system_vars):
 
 
 def setUserValue(config_name, option_name, value):
+    """
+    Sets the user value for the given config and option.
+    If the given config has not already been set the it is added
+    to the dict to be added later. The user values supersede the
+    session values so are the command line or gangarc options.
+    """
     if config_name in allConfigs:
         c = getConfig(config_name)
         if option_name in c.options:
@@ -847,6 +859,12 @@ def setUserValue(config_name, option_name, value):
 
 
 def setSessionValue(config_name, option_name, value):
+    """
+    Sets the session value for the given config and option.
+    If the given config has not been set already then it is added
+    to the dict to be added later. The session value is superseded by
+    the user value.
+    """
     if config_name in allConfigs:
         c = getConfig(config_name)
         if option_name in c.options:

--- a/python/Ganga/Utility/Config/Config.py
+++ b/python/Ganga/Utility/Config/Config.py
@@ -458,7 +458,6 @@ class PackageConfig(object):
         return self.getEffectiveOption(o)
 
     def addOption(self, name, default_value, docstring, override=False, **meta):
-
         if _after_bootstrap and not self.is_open:
             raise ConfigError('attempt to add a new option [%s]%s after bootstrap' % (self.name, name))
 
@@ -492,7 +491,6 @@ class PackageConfig(object):
                 msg = "Error Setting Session Value: %s" % err
                 if locals().get('logger') is not None:
                     locals().get('logger').debug("dbg: %s" % msg)
-
         try:
             conf_value = unknownUserConfigValues[self.name]
         except KeyError:
@@ -504,7 +502,7 @@ class PackageConfig(object):
         if option.name in conf_value:
             user_value = conf_value[option.name]
             try:
-                option.setUserValue(session_value)
+                option.setUserValue(user_value) 
                 del conf_value[option.name]
             except Exception as err:
                 msg = "Error Setting User Value: %s" % err
@@ -874,7 +872,6 @@ def setSessionValuesFromFiles(filenames, system_vars):
     At the time of reading the initialization files, the default options in
     the configuration options (default values) may have not yet been defined.
     """
-
     cfg = read_ini_files(filenames, system_vars)
 
     for name in cfg.sections():
@@ -883,14 +880,14 @@ def setSessionValuesFromFiles(filenames, system_vars):
             # the configuration units!
             if o in cfg.defaults():
                 continue
-            try:
+            try:               
                 v = cfg.get(name, o)
             except (ConfigParser.InterpolationMissingOptionError, ConfigParser.InterpolationSyntaxError) as err:
                 logger = getLogger()
                 logger.debug("Parse Error!:\n  %s" % err)
                 logger.warning("Can't expand the config file option %s:%s, treating it as raw" % (name, o))
                 v = cfg.get(name, o, raw=True)
-            setSessionValue(name, o, v)
+            setUserValue(name, o, v)
 
 
 def load_user_config(filename, system_vars):
@@ -966,7 +963,6 @@ def expandConfigPath(path, top):
 
 
 def sanityCheck():
-
     logger = getLogger()
     for c in allConfigs.values():
         if not c._config_made:

--- a/python/Ganga/Utility/Config/Config.py
+++ b/python/Ganga/Utility/Config/Config.py
@@ -880,7 +880,7 @@ def setSessionValuesFromFiles(filenames, system_vars):
             # the configuration units!
             if o in cfg.defaults():
                 continue
-            try:               
+            try:
                 v = cfg.get(name, o)
             except (ConfigParser.InterpolationMissingOptionError, ConfigParser.InterpolationSyntaxError) as err:
                 logger = getLogger()

--- a/python/Ganga/Utility/Config/__init__.py
+++ b/python/Ganga/Utility/Config/__init__.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-from .Config import getConfig, makeConfig, ConfigError, setSessionValuesFromFiles, allConfigs, setConfigOption, expandConfigPath, config_scope, setSessionValue
+from .Config import getConfig, makeConfig, ConfigError, setSessionValuesFromFiles, allConfigs, setConfigOption, expandConfigPath, config_scope, setSessionValue, setUserValue
 import os.path
 
 ## from Config import getConfigDict


### PR DESCRIPTION
Fixes #829 . Now the config files and command line options are set as UserValues rather than SessionValues so they take precedence over the later plugin loaded options. The command line options are loaded after the config ones, so they are still top.