### PR TITLE
Fix LHCb job migration

### DIFF
--- a/python/Ganga/GPIDev/Base/Proxy.py
+++ b/python/Ganga/GPIDev/Base/Proxy.py
@@ -270,6 +270,8 @@ def addProxy(obj):
                 return getattr(obj, proxyObject)
             else:
                 return GPIProxyObjectFactory(obj)
+    elif isclass(obj) and issubclass(obj, GangaObject):
+        return getProxyClass(obj)
     return obj
 
 

--- a/python/Ganga/GPIDev/Schema/Schema.py
+++ b/python/Ganga/GPIDev/Schema/Schema.py
@@ -21,6 +21,8 @@ import types
 
 from Ganga.GPIDev.TypeCheck import _valueTypeAllowed
 
+from inspect import isclass
+
 logger = Ganga.Utility.logging.getLogger()
 
 # Dictionary for storing data from the Config system which takes a while to lookup
@@ -296,6 +298,8 @@ class Schema(object):
                     if category not in _found_components or has_modified:
                         _found_components[category] = allPlugins.find(category, defvalue)
                     return _found_components[category]()
+                if isclass(defvalue):
+                    return defvalue()
 
         # If needed/requested make a copy of the function elsewhwre
         return defvalue

--- a/python/Ganga/Runtime/GPIexport.py
+++ b/python/Ganga/Runtime/GPIexport.py
@@ -14,18 +14,13 @@ import Ganga.GPI
 
 from .gangadoc import adddoc
 
-from Ganga.GPIDev.Base.Proxy import isType, addProxy, getProxyClass
+from Ganga.GPIDev.Base.Proxy import isType, addProxy
 from Ganga.GPIDev.Base.Objects import GangaObject
 from inspect import isclass
 
 def _addToInterface(interface, name, _object):
 
-    if isType(_object, GangaObject):
-        setattr(interface, name, addProxy(_object))
-    elif isclass(_object) and issubclass(_object, GangaObject):
-        setattr(interface, name, getProxyClass(_object))
-    else:
-        setattr(interface, name, _object)
+    setattr(interface, name, addProxy(_object))
 
 def exportToInterface(myInterface, name, _object, doc_section, docstring=None):
     '''

--- a/python/Ganga/test/GPI/FileTests/TestMassStorageClient.py
+++ b/python/Ganga/test/GPI/FileTests/TestMassStorageClient.py
@@ -6,7 +6,7 @@ import tempfile
 from Ganga.testlib.GangaUnitTest import GangaUnitTest
 from Ganga.testlib.file_utils import generate_unique_temp_file
 from Ganga.Utility.Config import getConfig
-from Ganga.GPIDev.Base.Proxy import stripProxy, getProxyClass
+from Ganga.GPIDev.Base.Proxy import stripProxy, addProxy
 from GangaTest.Framework.utils import sleep_until_completed
 from Ganga.GPIDev.Lib.File.MassStorageFile import MassStorageFile, SharedFile
 from Ganga.GPIDev.Base.Objects import _getName
@@ -19,7 +19,7 @@ class TestMassStorageClient(GangaUnitTest):
     # Num of sj in tests
     sj_len = 3
 
-    fileClass = getProxyClass(MassStorageFile)
+    fileClass = addProxy(MassStorageFile)
 
     # Where on local storage we want to have our 'MassStorage solution'
     outputFilePath = '/tmp/Test' + _getName(fileClass) + 'Client'
@@ -142,5 +142,5 @@ class TestMassStorageClient(GangaUnitTest):
 
 class TestSharedClient(TestMassStorageClient):
     """test for sjid in filename names explain each test"""
-    fileClass = getProxyClass(SharedFile)
+    fileClass = addProxy(SharedFile)
 

--- a/python/Ganga/test/GPI/FileTests/TestMassStorageGetPut.py
+++ b/python/Ganga/test/GPI/FileTests/TestMassStorageGetPut.py
@@ -7,7 +7,7 @@ import tempfile
 from Ganga.testlib.GangaUnitTest import GangaUnitTest
 from Ganga.testlib.file_utils import generate_unique_temp_file
 from Ganga.Core.exceptions import GangaException
-from Ganga.GPIDev.Base.Proxy import stripProxy, getProxyClass
+from Ganga.GPIDev.Base.Proxy import stripProxy, addProxy
 from GangaTest.Framework.utils import sleep_until_completed
 from Ganga.GPIDev.Lib.File.MassStorageFile import MassStorageFile, SharedFile
 from Ganga.GPIDev.Base.Objects import _getName
@@ -21,7 +21,7 @@ class TestMassStorageGetPut(GangaUnitTest):
     # Num of sj in tests
     sj_len = 3
 
-    fileClass = getProxyClass(MassStorageFile)
+    fileClass = addProxy(MassStorageFile)
 
     # Where on local storage we want to have our 'MassStorage solution'
     outputFilePath = '/tmp/Test' + _getName(fileClass) + 'GetPut'
@@ -152,5 +152,5 @@ class TestMassStorageGetPut(GangaUnitTest):
 
 class TestSharedFileGetPut(TestMassStorageGetPut):
     """Testing the get/put/copyTo methods of SharedFile"""
-    fileClass = getProxyClass(SharedFile)
+    fileClass = addProxy(SharedFile)
 

--- a/python/Ganga/test/GPI/FileTests/TestMassStorageInput.py
+++ b/python/Ganga/test/GPI/FileTests/TestMassStorageInput.py
@@ -9,7 +9,7 @@ from Ganga.testlib.file_utils import generate_unique_temp_file
 from GangaTest.Framework.utils import sleep_until_completed
 from Ganga.GPIDev.Lib.File.MassStorageFile import MassStorageFile, SharedFile
 from Ganga.GPIDev.Base.Objects import _getName
-from Ganga.GPIDev.Base.Proxy import getProxyClass
+from Ganga.GPIDev.Base.Proxy import addProxy
 
 class TestMassStorageClientInput(GangaUnitTest):
     """Testing MassStorage on input to a job"""
@@ -19,7 +19,7 @@ class TestMassStorageClientInput(GangaUnitTest):
     # Num of sj in tests
     sj_len = 3
 
-    fileClass = getProxyClass(MassStorageFile)
+    fileClass = addProxy(MassStorageFile)
 
     # Where on local storage we want to have our 'MassStorage solution'
     outputFilePath = '/tmp/Test' + _getName(fileClass) + 'Input'
@@ -105,5 +105,5 @@ class TestMassStorageClientInput(GangaUnitTest):
 
 class TestMassStorageWNInput(TestMassStorageClientInput):
     """Testing SharedFile on input to a job"""
-    fileClass = getProxyClass(SharedFile)
+    fileClass = addProxy(SharedFile)
 

--- a/python/Ganga/test/GPI/FileTests/TestMassStorageWN.py
+++ b/python/Ganga/test/GPI/FileTests/TestMassStorageWN.py
@@ -6,7 +6,7 @@ import tempfile
 from Ganga.testlib.GangaUnitTest import GangaUnitTest
 from Ganga.testlib.file_utils import generate_unique_temp_file
 
-from Ganga.GPIDev.Base.Proxy import stripProxy, getProxyClass
+from Ganga.GPIDev.Base.Proxy import stripProxy, addProxy
 from GangaTest.Framework.utils import sleep_until_completed
 from Ganga.GPIDev.Lib.File.MassStorageFile import MassStorageFile, SharedFile
 from Ganga.GPIDev.Base.Objects import _getName
@@ -19,7 +19,7 @@ class TestMassStorageWN(GangaUnitTest):
     # Num of sj in tests
     sj_len = 3
 
-    fileClass = getProxyClass(MassStorageFile)
+    fileClass = addProxy(MassStorageFile)
 
     # Where on local storage we want to have our 'MassStorage solution'
     outputFilePath = '/tmp/Test' + _getName(fileClass) + 'WN'
@@ -260,5 +260,5 @@ class TestMassStorageWN(GangaUnitTest):
 
 class TestSharedWN(TestMassStorageWN):
     """Testing SharedFile when completing a file"""
-    fileClass = getProxyClass(SharedFile)
+    fileClass = addProxy(SharedFile)
 

--- a/python/Ganga/test/GPI/Mergers/TestCustomMerger.py
+++ b/python/Ganga/test/GPI/Mergers/TestCustomMerger.py
@@ -6,14 +6,14 @@ import tempfile
 import pytest
 
 from GangaTest.Framework.utils import write_file
-from Ganga.GPIDev.Base.Proxy import getProxyClass
+from Ganga.GPIDev.Base.Proxy import addProxy
 from Ganga.GPIDev.Adapters.IPostProcessor import PostProcessException
 
 from Ganga.testlib.GangaUnitTest import GangaUnitTest
 from Ganga.testlib.monitoring import run_until_completed, run_until_state
 from .CopySplitter import CopySplitter
 
-CopySplitter = getProxyClass(CopySplitter)
+CopySplitter = addProxy(CopySplitter)
 
 
 class TestCustomMerger(GangaUnitTest):

--- a/python/Ganga/test/GPI/Mergers/TestMergeFailures.py
+++ b/python/Ganga/test/GPI/Mergers/TestMergeFailures.py
@@ -6,14 +6,14 @@ import pytest
 
 from GangaTest.Framework.utils import sleep_until_state
 from Ganga.testlib.monitoring import run_until_state
-from Ganga.GPIDev.Base.Proxy import getProxyClass
+from Ganga.GPIDev.Base.Proxy import addProxy
 
 from Ganga.testlib.GangaUnitTest import GangaUnitTest
 from .MergerTester import MergerTester
 from .CopySplitter import CopySplitter
 
-CopySplitter = getProxyClass(CopySplitter)
-MergerTester = getProxyClass(MergerTester)
+CopySplitter = addProxy(CopySplitter)
+MergerTester = addProxy(MergerTester)
 
 
 class TestMergeFailures(GangaUnitTest):

--- a/python/Ganga/test/Unit/GangaList/TFile/TestTFile.py
+++ b/python/Ganga/test/Unit/GangaList/TFile/TestTFile.py
@@ -1,9 +1,9 @@
 import unittest
 
-from Ganga.GPIDev.Base.Proxy import getProxyClass
+from Ganga.GPIDev.Base.Proxy import addProxy
 from . import TFile
 
-TFile = getProxyClass(TFile)
+TFile = addProxy(TFile)
 
 class TestTFile(unittest.TestCase):
 

--- a/python/Ganga/test/Unit/GangaList/TestGangaList.py
+++ b/python/Ganga/test/Unit/GangaList/TestGangaList.py
@@ -7,12 +7,12 @@ except ImportError:
 import random
 import string
 
-from Ganga.GPIDev.Base.Proxy import addProxy, getProxyClass, getProxyAttr, isProxy, isType, stripProxy
+from Ganga.GPIDev.Base.Proxy import addProxy, getProxyAttr, isProxy, isType, stripProxy
 
 from Ganga.GPIDev.Lib.GangaList.GangaList import GangaList
-GangaList = getProxyClass(GangaList)
+GangaList = addProxy(GangaList)
 from .TFile import TFile
-TFile = getProxyClass(TFile)
+TFile = addProxy(TFile)
 
 # set the seed for repeatable tests
 random.seed(666)

--- a/python/GangaDirac/Lib/Backends/DiracBase.py
+++ b/python/GangaDirac/Lib/Backends/DiracBase.py
@@ -94,7 +94,7 @@ class DiracBase(IBackend):
                                 'if you *really* know what you are doing'),
         'settings': SimpleItem(defvalue={'CPUTime': 2 * 86400},
                                doc='Settings for DIRAC job (e.g. CPUTime, BannedSites, etc.)'),
-        'credential_requirements': ComponentItem('CredentialRequirement', defvalue=DiracProxy()),
+        'credential_requirements': ComponentItem('CredentialRequirement', defvalue=DiracProxy),
     })
     _exportmethods = ['getOutputData', 'getOutputSandbox', 'removeOutputData',
                       'getOutputDataLFNs', 'getOutputDataAccessURLs', 'peek', 'reset', 'debug']

--- a/python/GangaDirac/Lib/Backends/DiracBase.py
+++ b/python/GangaDirac/Lib/Backends/DiracBase.py
@@ -22,7 +22,6 @@ from Ganga.Utility.ColourText import getColour
 from Ganga.Utility.Config import getConfig
 from Ganga.Utility.logging import getLogger, log_user_exception
 from Ganga.GPIDev.Credentials import require_credential, credential_store, needed_credentials
-from GangaDirac.Lib.Credentials.DiracProxy import DiracProxy
 from Ganga.GPIDev.Base.Proxy import stripProxy, isType, getName
 from Ganga.Core.GangaThread.WorkerThreads import getQueues
 from Ganga.Core import monitoring_component
@@ -95,7 +94,7 @@ class DiracBase(IBackend):
                                 'if you *really* know what you are doing'),
         'settings': SimpleItem(defvalue={'CPUTime': 2 * 86400},
                                doc='Settings for DIRAC job (e.g. CPUTime, BannedSites, etc.)'),
-        'credential_requirements': ComponentItem('CredentialRequirement', defvalue=DiracProxy),
+        'credential_requirements': ComponentItem('CredentialRequirement', defvalue=DiracProxy()),
     })
     _exportmethods = ['getOutputData', 'getOutputSandbox', 'removeOutputData',
                       'getOutputDataLFNs', 'getOutputDataAccessURLs', 'peek', 'reset', 'debug']

--- a/python/GangaDirac/test/GPI/testJobLoading.py
+++ b/python/GangaDirac/test/GPI/testJobLoading.py
@@ -7,7 +7,10 @@ from Ganga.GPIDev.Base.Objects import _getName
 from Ganga.GPIDev.Base.Proxy import stripProxy, GPIProxyClassFactory, setProxyInterface
 
 from Ganga.testlib.decorators import add_config
+from Ganga.Runtime.GPIexport import exportToGPI
 
+# This logic allows for the loading of classes which depend on the GangaDirac object...
+# Failing to import a module is ugly but this prevents the user from mis-configuring their DIRAC, so...
 from Ganga.Utility.Config import getConfig, makeConfig
 makeConfig('defaults_DiracProxy', '')
 getConfig('defaults_DiracProxy').addOption('group', 'some_group', '')
@@ -20,12 +23,18 @@ from GangaDirac.Lib.Backends.Dirac import Dirac as origDirac
 from Ganga.Utility.Plugin import allPlugins
 
 def getDiracSchema():
+    """ This returns a new Schema which doesn't have the credential_requirements attribute as in Ganga 6.2.x """
     new_schema = DiracBase._schema.inherit_copy()
     new_schema.datadict = copy.deepcopy(new_schema.datadict)
     del new_schema.datadict['credential_requirements']
     return new_schema
 
 class FakeDirac(DiracBase):
+    """
+    This is a fake DIRAC class used in tetsing
+    This HAS TO EXIST AT THE IMPORT LEVEL in order to allow for this class to overload the Dirac class elsewhere in Ganga
+    This is by design!
+    """
 
     _name = 'Dirac'
     _category = 'backends'
@@ -34,12 +43,13 @@ class FakeDirac(DiracBase):
     _packed_input_sandbox = DiracBase._packed_input_sandbox
     __doc__ = DiracBase.__doc__
 
-    def __init__(self):
-        super(FakeDirac, self).__init__()
-
 
 def removeClassFromGPI(class_):
-    """ Remove a given class object from the GPI """
+    """
+    Remove a given class object from the GPI
+    Args:
+        class_ (class): This is the class object to remove from the GPI
+    """
     import Ganga.GPI
     del Ganga.GPI.__dict__[_getName(class_)]
     del allPlugins.all_dict[class_._category][_getName(class_)]
@@ -47,12 +57,12 @@ def removeClassFromGPI(class_):
 
 
 def insertClassIntoGPI(class_):
-    """ Insert a given class object into the GPI """
-
-    from Ganga.Runtime.GPIexport import exportToGPI
-
+    """
+    Insert a given class object into the GPI
+    Args:
+        class_ (class): This is the class object to insert into the GPI
+    """
     exportToGPI(_getName(class_), class_, "Objects")
-
     allPlugins.add(class_, class_._category, _getName(class_))
     allPlugins._prev_found = {}
 
@@ -68,9 +78,12 @@ class TestJobMigration(object):
         from Ganga.Utility.Config import getConfig
         assert not getConfig('TestingFramework')['AutoCleanup']
 
+        # Remember FakeDirac = Dirac from Ganga 6.2.x
         j = Job(backend=FakeDirac())
         assert len(jobs) == 1
         assert 'credential_requirements' not in stripProxy(j.backend)._schema.datadict
+
+        # We have no constructed a Ganga 6.2.x like Job
 
         removeClassFromGPI(FakeDirac)        
 
@@ -81,18 +94,22 @@ class TestJobMigration(object):
 
         from Ganga.GPI import jobs, Dirac
 
-        print str(jobs[-1].backend)
-        print str(Dirac())
+        # This tests that the job loads:
+        str1= str(jobs[-1].backend)
+        # This gets the string rep for Dirac in Ganga 6.3.x
+        str2= str(Dirac())
+
+        # Compare the backend we just created vs the one we migrated
+        assert str1 == str2
 
         assert jobs[-1].backend.credential_requirements is not None
 
     def test_c_JobIsSerializable(self):
-        """ Test that we can represent the job as a string """
+        """ Test that we can represent the whole job as a string """
 
         from Ganga.GPI import jobs
 
         this_jobStr = str(jobs[-1])
 
         print("Job String:\n%s" % this_jobStr)
-
 

--- a/python/GangaDirac/test/GPI/testJobLoading.py
+++ b/python/GangaDirac/test/GPI/testJobLoading.py
@@ -1,0 +1,98 @@
+from __future__ import absolute_import
+
+import copy
+import pytest
+
+from Ganga.GPIDev.Base.Objects import _getName
+from Ganga.GPIDev.Base.Proxy import stripProxy, GPIProxyClassFactory, setProxyInterface
+
+from Ganga.testlib.decorators import add_config
+
+from Ganga.Utility.Config import getConfig, makeConfig
+makeConfig('defaults_DiracProxy', '')
+getConfig('defaults_DiracProxy').addOption('group', 'some_group', '')
+from GangaDirac.Lib.Credentials.DiracProxy import DiracProxy, DiracProxyInfo
+getConfig('defaults_DiracProxy').setSessionValue('group', 'some_group')
+
+from GangaDirac.Lib.Backends.DiracBase import DiracBase
+from GangaDirac.Lib.Backends.Dirac import Dirac as origDirac
+
+from Ganga.Utility.Plugin import allPlugins
+
+def getDiracSchema():
+    new_schema = DiracBase._schema.inherit_copy()
+    new_schema.datadict = copy.deepcopy(new_schema.datadict)
+    del new_schema.datadict['credential_requirements']
+    return new_schema
+
+class FakeDirac(DiracBase):
+
+    _name = 'Dirac'
+    _category = 'backends'
+    _schema = getDiracSchema()
+    _exportmethods = DiracBase._exportmethods[:]
+    _packed_input_sandbox = DiracBase._packed_input_sandbox
+    __doc__ = DiracBase.__doc__
+
+    def __init__(self):
+        super(FakeDirac, self).__init__()
+
+
+def removeClassFromGPI(class_):
+    """ Remove a given class object from the GPI """
+    import Ganga.GPI
+    del Ganga.GPI.__dict__[_getName(class_)]
+    del allPlugins.all_dict[class_._category][_getName(class_)]
+    allPlugins._prev_found = {}
+
+
+def insertClassIntoGPI(class_):
+    """ Insert a given class object into the GPI """
+
+    from Ganga.Runtime.GPIexport import exportToGPI
+
+    exportToGPI(_getName(class_), class_, "Objects")
+
+    allPlugins.add(class_, class_._category, _getName(class_))
+    allPlugins._prev_found = {}
+
+@add_config([('TestingFramework', 'AutoCleanup', 'False')])
+@pytest.mark.usefixtures('gpi')
+class TestJobMigration(object):
+
+    def test_a_JobConstruction(self):
+        """ First construct the Job object """
+
+        from Ganga.GPI import Job, jobs
+
+        from Ganga.Utility.Config import getConfig
+        assert not getConfig('TestingFramework')['AutoCleanup']
+
+        j = Job(backend=FakeDirac())
+        assert len(jobs) == 1
+        assert 'credential_requirements' not in stripProxy(j.backend)._schema.datadict
+
+        removeClassFromGPI(FakeDirac)        
+
+    def test_b_JobLoads(self):
+        """ Test that loading the Job works """
+
+        insertClassIntoGPI(origDirac)
+
+        from Ganga.GPI import jobs, Dirac
+
+        print str(jobs[-1].backend)
+        print str(Dirac())
+
+        assert jobs[-1].backend.credential_requirements is not None
+
+    def test_c_JobIsSerializable(self):
+        """ Test that we can represent the job as a string """
+
+        from Ganga.GPI import jobs
+
+        this_jobStr = str(jobs[-1])
+
+        print("Job String:\n%s" % this_jobStr)
+
+


### PR DESCRIPTION
This fixes a bug where on loading a job with a Dirac backend from Ganga 6.2.x in Ganga 6.3.x

This bug crept in between the credentials branch being fixed and the 6.3 release so I've added a test to make sure that this doesn't happen again.

The consequence is any DIRAC job from Ganga 6.2 can't be loaded in 6.3.
(There won't be too many of these as DIRAC lost a lot of sandboxes but users still on Ganga 6.2.x not moving to 6.3 may create new jobs in the future that can't be read in without this fix).

The fix is small in DiracBase and was due to some shortcoming to check for classes in the Schema. The schema is clearly not working correctly in the case of classes as defaults and this should be examined by someone in more detail in a future PR!

This should be working and I think may prompt a quick release of 6.3.1