### PR TITLE
Replace get with CopyTo

### DIFF
--- a/python/GangaDirac/Lib/Backends/DiracBase.py
+++ b/python/GangaDirac/Lib/Backends/DiracBase.py
@@ -465,11 +465,7 @@ class DiracBase(IBackend):
             if os.path.exists(os.path.join(dirac_file.localDir, os.path.basename(dirac_file.lfn))) and not force:
                 return
             try:
-                if isType(dirac_file, DiracFile):
-                    dirac_file.copyTo(targetPath=dirac_file.localDir)
-                else:
-                    dirac_file.get()
-                return dirac_file.lfn
+                dirac_file.get()
             # should really make the get method throw if doesn't suceed. todo
             except (GangaDiracError, GangaFileError) as e:
                 logger.warning(e)

--- a/python/GangaDirac/Lib/Backends/DiracBase.py
+++ b/python/GangaDirac/Lib/Backends/DiracBase.py
@@ -467,9 +467,9 @@ class DiracBase(IBackend):
                 return
             try:
                 if isType(dirac_file, DiracFile):
-                    dirac_file.internalCopyTo(targetPath=dirac_file.localDir)
+                    dirac_file.get(targetPath=dirac_file.localDir)
                 else:
-                    dirac_file.internalCopyTo()
+                    dirac_file.get()
                 return dirac_file.lfn
             # should really make the get method throw if doesn't suceed. todo
             except (GangaDiracError, GangaFileError) as e:

--- a/python/GangaDirac/Lib/Backends/DiracBase.py
+++ b/python/GangaDirac/Lib/Backends/DiracBase.py
@@ -466,7 +466,7 @@ class DiracBase(IBackend):
                 return
             try:
                 if isType(dirac_file, DiracFile):
-                    dirac_file.get(targetPath=dirac_file.localDir)
+                    dirac_file.copyTo(targetPath=dirac_file.localDir)
                 else:
                     dirac_file.get()
                 return dirac_file.lfn

--- a/python/GangaDirac/Lib/Backends/DiracBase.py
+++ b/python/GangaDirac/Lib/Backends/DiracBase.py
@@ -467,9 +467,9 @@ class DiracBase(IBackend):
                 return
             try:
                 if isType(dirac_file, DiracFile):
-                    dirac_file.get(localPath=dirac_file.localDir)
+                    dirac_file.internalCopyTo(targetPath=dirac_file.localDir)
                 else:
-                    dirac_file.get()
+                    dirac_file.internalCopyTo()
                 return dirac_file.lfn
             # should really make the get method throw if doesn't suceed. todo
             except (GangaDiracError, GangaFileError) as e:

--- a/python/GangaDirac/Lib/Backends/DiracBase.py
+++ b/python/GangaDirac/Lib/Backends/DiracBase.py
@@ -466,6 +466,7 @@ class DiracBase(IBackend):
                 return
             try:
                 dirac_file.get()
+                return dirac_file.lfn
             # should really make the get method throw if doesn't suceed. todo
             except (GangaDiracError, GangaFileError) as e:
                 logger.warning(e)

--- a/python/GangaDirac/Lib/Files/DiracFile.py
+++ b/python/GangaDirac/Lib/Files/DiracFile.py
@@ -61,7 +61,7 @@ class DiracFile(IGangaFile):
 
     _category = 'gangafiles'
     _name = "DiracFile"
-    _exportmethods = ["get", "getMetadata", "getReplicas", 'getSubFiles', 'remove',
+    _exportmethods = ["internalCopyTo", "getMetadata", "getReplicas", 'getSubFiles', 'remove',
                       "replicate", 'put', 'locations', 'location', 'accessURL',
                       '_updateRemoteURLs', 'hasMatchedFiles']
     _remoteURLs = {}

--- a/python/GangaDirac/Lib/Files/DiracFile.py
+++ b/python/GangaDirac/Lib/Files/DiracFile.py
@@ -61,7 +61,7 @@ class DiracFile(IGangaFile):
 
     _category = 'gangafiles'
     _name = "DiracFile"
-    _exportmethods = ["internalCopyTo", "getMetadata", "getReplicas", 'getSubFiles', 'remove',
+    _exportmethods = ["get", "getMetadata", "getReplicas", 'getSubFiles', 'remove',
                       "replicate", 'put', 'locations', 'location', 'accessURL',
                       '_updateRemoteURLs', 'hasMatchedFiles']
     _remoteURLs = {}


### PR DESCRIPTION
Fixes #910 .
The ```get ``` function got renamed at some point to internalCopyTo, which broke the getOutputData function in DiracBase.

I replaced get in the export methods with the new name.