### PR TITLE
Moving to use userConfig to configure test

### DIFF
--- a/python/Ganga/test/GPI/Tasks/TestCoreTasks.py
+++ b/python/Ganga/test/GPI/Tasks/TestCoreTasks.py
@@ -8,7 +8,7 @@ class TestCoreTasks(GangaUnitTest):
 
     def setUp(self):
         """Make sure that the Tasks object isn't destroyed between tests"""
-        extra_opts = [('TestingFramework', 'AutoCleanup', 'False'), ('Tasks', 'TaskLoopFrequency', 1)]
+        extra_opts = [('TestingFramework', 'AutoCleanup', 'False'), ('Tasks', 'TaskLoopFrequency', 1.)]
         super(TestCoreTasks, self).setUp(extra_opts=extra_opts)
         self._numTasks = 50
 

--- a/python/Ganga/testlib/GangaUnitTest.py
+++ b/python/Ganga/testlib/GangaUnitTest.py
@@ -108,9 +108,9 @@ def start_ganga(gangadir_for_test, extra_opts=[], extra_args=None):
     Ganga.Runtime._prog.parseOptions()
 
     # For all the default and extra options, we set the session value
-    from Ganga.Utility.Config import setConfigOption
+    from Ganga.Utility.Config import setUserValue
     for opt in default_opts + extra_opts:
-        setConfigOption(*opt)
+        setUserValue(*opt)
 
     # The configuration is currently created at module import and hence can't be
     # regenerated.
@@ -151,7 +151,7 @@ def start_ganga(gangadir_for_test, extra_opts=[], extra_args=None):
     # Make sure that all the config options are really set.
     # Some from plugins may not have taken during startup
     for opt in default_opts + extra_opts:
-        setConfigOption(*opt)
+        setUserValue(*opt)
 
     logger.info("Passing to Unittest")
 


### PR DESCRIPTION
This PR moves the tests over to use the user vs session tests. This should help the nightly tests.

If there are no objections I'd like to merge this for 6.3.1 so I can try and debug/fix the nightly tests failing.