### PR TITLE
Whitespace in interactive arguments

### DIFF
--- a/python/Ganga/Lib/Interactive/Interactive.py
+++ b/python/Ganga/Lib/Interactive/Interactive.py
@@ -184,7 +184,7 @@ class Interactive(IBackend):
         exeString = jobconfig.getExeString()
         argList = jobconfig.getArgStrings()
         argString = " ".join(map(lambda x: " %s " % x, argList))
-
+        argString = argString.replace(" ", "\ ")
         outputSandboxPatterns = jobconfig.outputbox
         patternsToZip = []
         wnCodeForPostprocessing = ''


### PR DESCRIPTION
Turns whitespaces in the arguments of interactive jobs to ```\ ``` so they are read correctly in the command line.