### PR TITLE
Fix DiracProxy for Vanilla Dirac.

### DIFF
--- a/python/GangaDirac/Lib/Credentials/DiracProxy.py
+++ b/python/GangaDirac/Lib/Credentials/DiracProxy.py
@@ -14,6 +14,7 @@ from Ganga.GPIDev.Adapters.ICredentialInfo import cache, retry_command
 from Ganga.GPIDev.Adapters.ICredentialRequirement import ICredentialRequirement
 from Ganga.Core.exceptions import CredentialRenewalError
 from Ganga.GPIDev.Credentials.VomsProxy import VomsProxyInfo
+from Ganga.Utility.Shell import Shell
 
 from GangaDirac.Lib.Utilities.DiracUtilities import getDiracEnv
 
@@ -32,7 +33,7 @@ class DiracProxyInfo(VomsProxyInfo):
             check_file (bool): Raise an exception if the file does not exist
             create (bool): Create the credential file
         """
-        self._shell = None
+        self._shell = Shell()
 
         super(DiracProxyInfo, self).__init__(requirements, check_file, create)
 
@@ -64,7 +65,7 @@ class DiracProxyInfo(VomsProxyInfo):
         Construct and store a shell which has the appropriate DIRAC env saved in it
         """
         if self._shell is None:
-            self._shell = super(DiracProxyInfo, self).shell
+            self._shell = Shell()
             self._shell.env.update(getDiracEnv())
         return self._shell
 


### PR DESCRIPTION
This fixes https://github.com/ganga-devs/ganga/issues/883.
The solution is as suggested by @rob-c i.e. just attach a new Shell object. I don't know the implications of this in the wider credentials universe (although it looks fairly innocuous) but it seems to fix the issue for me. Lets see what the tests reveal.