### PR TITLE
Make diracLFNBase take the username from the DiracProxy

### DIFF
--- a/python/Ganga/GPIDev/Credentials/VomsProxy.py
+++ b/python/Ganga/GPIDev/Credentials/VomsProxy.py
@@ -110,19 +110,6 @@ class VomsProxyInfo(ICredentialInfo):
 
     @property
     @cache
-    def username(self):
-        """
-        This returns the username associated with a voms proxy on disk
-        """
-        status, output, message = self.shell.cmd1('voms-proxy-info -file "%s" -all' % self.location)
-        if status != 0:
-            return None
-        for line in output.splitlines():
-            if line.split(":")[0].strip() == 'attribute' and line.split(":")[1].split("=")[0].strip()=='nickname':
-                return line.split(":")[1].split("=")[1].strip().split(" ")[0]
-
-    @property
-    @cache
     def role(self):
         """
         This returns the role associated with a voms proxy on disk
@@ -179,7 +166,6 @@ class VomsProxy(ICredentialRequirement):
     _schema.datadict['vo'] = SimpleItem(defvalue=None, typelist=[str, None], doc='Virtual Organisation for the proxy. Defaults to LGC/VirtualOrganisation')
     _schema.datadict['role'] = SimpleItem(defvalue=None, typelist=[str, None], doc='Role that the proxy must have')
     _schema.datadict['group'] = SimpleItem(defvalue=None, typelist=[str, None], doc='Group for the proxy - either "group" or "group/subgroup"')
-    _schema.datadict['username'] = SimpleItem(defvalue=None, typelist=[str, None], doc='Username associated to the proxy.')
 
     _category = 'CredentialRequirement'
 

--- a/python/Ganga/GPIDev/Credentials/VomsProxy.py
+++ b/python/Ganga/GPIDev/Credentials/VomsProxy.py
@@ -110,6 +110,19 @@ class VomsProxyInfo(ICredentialInfo):
 
     @property
     @cache
+    def username(self):
+        """
+        This returns the username associated with a voms proxy on disk
+        """
+        status, output, message = self.shell.cmd1('voms-proxy-info -file "%s" -all' % self.location)
+        if status != 0:
+            return None
+        for line in output.splitlines():
+            if line.split(":")[0].strip() == 'attribute' and line.split(":")[1].split("=")[0].strip()=='nickname':
+                return line.split(":")[1].split("=")[1].strip().split(" ")[0]
+
+    @property
+    @cache
     def role(self):
         """
         This returns the role associated with a voms proxy on disk
@@ -166,6 +179,7 @@ class VomsProxy(ICredentialRequirement):
     _schema.datadict['vo'] = SimpleItem(defvalue=None, typelist=[str, None], doc='Virtual Organisation for the proxy. Defaults to LGC/VirtualOrganisation')
     _schema.datadict['role'] = SimpleItem(defvalue=None, typelist=[str, None], doc='Role that the proxy must have')
     _schema.datadict['group'] = SimpleItem(defvalue=None, typelist=[str, None], doc='Group for the proxy - either "group" or "group/subgroup"')
+    _schema.datadict['username'] = SimpleItem(defvalue=None, typelist=[str, None], doc='Username associated to the proxy.')
 
     _category = 'CredentialRequirement'
 

--- a/python/GangaDirac/Lib/Credentials/DiracProxy.py
+++ b/python/GangaDirac/Lib/Credentials/DiracProxy.py
@@ -116,6 +116,13 @@ class DiracProxyInfo(VomsProxyInfo):
         """
         return self.field('DIRAC group')
 
+    @cache
+    def username(self):
+        """
+        Returns the username associated with the dirac proxy
+        """
+        return self.field('username')
+
     @property
     def encodeDefaultProxyFileName(self):
         """

--- a/python/GangaDirac/Lib/Credentials/DiracProxy.py
+++ b/python/GangaDirac/Lib/Credentials/DiracProxy.py
@@ -116,6 +116,7 @@ class DiracProxyInfo(VomsProxyInfo):
         """
         return self.field('DIRAC group')
 
+    @property
     @cache
     def username(self):
         """

--- a/python/GangaDirac/Lib/Files/DiracFile.py
+++ b/python/GangaDirac/Lib/Files/DiracFile.py
@@ -20,7 +20,7 @@ import Ganga.Utility.Config
 from Ganga.Runtime.GPIexport import exportToGPI
 from Ganga.GPIDev.Credentials.CredentialStore import credential_store
 from Ganga.GPIDev.Credentials import require_credential
-from GangaDirac.Lib.Credentials.DiracProxy import DiracProxy
+from GangaDirac.Lib.Credentials.DiracProxy import DiracProxy, DiracProxyInfo
 from Ganga.Utility.Config import getConfig
 from Ganga.Utility.logging import getLogger
 config = getConfig('Configuration')
@@ -855,7 +855,7 @@ for f in glob.glob('###NAME_PATTERN###'):
         """
         if configDirac['DiracLFNBase']:
             return configDirac['DiracLFNBase']
-        return '/{0}/user/{1}/{2}'.format(configDirac['userVO'], credential_store[DiracProxy()].username[0], credential_store[DiracProxy()].username)
+        return '/{0}/user/{1}/{2}'.format(configDirac['userVO'], DiracProxyInfo(DiracProxy()).username()[0], DiracProxyInfo(DiracProxy()).username())
 
 # add DiracFile objects to the configuration scope (i.e. it will be
 # possible to write instatiate DiracFile() objects via config file)

--- a/python/GangaDirac/Lib/Files/DiracFile.py
+++ b/python/GangaDirac/Lib/Files/DiracFile.py
@@ -18,6 +18,7 @@ from Ganga.Core.exceptions import GangaFileError
 from GangaDirac.Lib.Utilities.DiracUtilities import getDiracEnv, execute, GangaDiracError
 import Ganga.Utility.Config
 from Ganga.Runtime.GPIexport import exportToGPI
+from Ganga.GPIDev.Credentials.CredentialStore import credential_store
 from Ganga.GPIDev.Credentials import require_credential
 from GangaDirac.Lib.Credentials.DiracProxy import DiracProxy
 from Ganga.Utility.Config import getConfig
@@ -854,7 +855,7 @@ for f in glob.glob('###NAME_PATTERN###'):
         """
         if configDirac['DiracLFNBase']:
             return configDirac['DiracLFNBase']
-        return '/{0}/user/{1}/{2}'.format(configDirac['userVO'], config['user'][0], config['user'])
+        return '/{0}/user/{1}/{2}'.format(configDirac['userVO'], credential_store[DiracProxy()].username[0], credential_store[DiracProxy()].username)
 
 # add DiracFile objects to the configuration scope (i.e. it will be
 # possible to write instatiate DiracFile() objects via config file)

--- a/python/GangaDirac/Lib/Files/DiracFile.py
+++ b/python/GangaDirac/Lib/Files/DiracFile.py
@@ -18,7 +18,6 @@ from Ganga.Core.exceptions import GangaFileError
 from GangaDirac.Lib.Utilities.DiracUtilities import getDiracEnv, execute, GangaDiracError
 import Ganga.Utility.Config
 from Ganga.Runtime.GPIexport import exportToGPI
-from Ganga.GPIDev.Credentials.CredentialStore import credential_store
 from Ganga.GPIDev.Credentials import require_credential
 from GangaDirac.Lib.Credentials.DiracProxy import DiracProxy, DiracProxyInfo
 from Ganga.Utility.Config import getConfig

--- a/python/GangaDirac/Lib/Files/DiracFile.py
+++ b/python/GangaDirac/Lib/Files/DiracFile.py
@@ -854,7 +854,7 @@ for f in glob.glob('###NAME_PATTERN###'):
         """
         if configDirac['DiracLFNBase']:
             return configDirac['DiracLFNBase']
-        return '/{0}/user/{1}/{2}'.format(configDirac['userVO'], DiracProxyInfo(DiracProxy()).username()[0], DiracProxyInfo(DiracProxy()).username())
+        return '/{0}/user/{1}/{2}'.format(configDirac['userVO'], DiracProxyInfo(DiracProxy()).username[0], DiracProxyInfo(DiracProxy()).username)
 
 # add DiracFile objects to the configuration scope (i.e. it will be
 # possible to write instatiate DiracFile() objects via config file)


### PR DESCRIPTION
Fixes #931 . This takes the `nickname` from the VomsProxy instead of the local username when making the diracLFNBase.
Should clear up problems for people running ganga on local systems with different usernames.