### PR TITLE
Change LHCb Backends import to its own Dirac

### DIFF
--- a/python/GangaLHCb/Lib/Backends/__init__.py
+++ b/python/GangaLHCb/Lib/Backends/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import absolute_import
-from GangaDirac.Lib.Backends.Dirac import Dirac
 from .Bookkeeping import Bookkeeping
+from .Dirac import Dirac


### PR DESCRIPTION
Fixes #930. Sets the LHCb plugin to load its own version of Dirac, rather than vanilla.