### PR TITLE
Fix exception in executable script

### DIFF
--- a/python/GangaDirac/Lib/RTHandlers/ExeDiracRTHandler.py
+++ b/python/GangaDirac/Lib/RTHandlers/ExeDiracRTHandler.py
@@ -160,9 +160,9 @@ if __name__ == '__main__':
         rc = subprocess.call(exe_cmd, env=my_env, shell=False)
     except Exception as x:
         rc = -9999
-        print('Exception occured in running process: ' + exe_cmd)
-        print('Err was: ' + str(err))
-        subprocess.call('''['echo', '$PATH']''')
+        print('Exception occured in running process: ' + repr(exe_cmd))
+        print('Err was: ' + str(x))
+        subprocess.call('echo $PATH', shell=True)
         print('PATH: ' + str(my_env['PATH']))
         print('PWD: ' + str(my_env['PWD']))
         print("files on WN: " + str(listdir('.')))

--- a/python/GangaDirac/test/Unit/RTHandlers/TestExeDiracRTHandler.py
+++ b/python/GangaDirac/test/Unit/RTHandlers/TestExeDiracRTHandler.py
@@ -1,0 +1,33 @@
+from __future__ import absolute_import
+from Ganga.testlib.GangaUnitTest import GangaUnitTest
+from Ganga.testlib.mark import external
+from Ganga.testlib.monitoring import run_until_completed, run_until_state
+import os
+
+
+class TestExeDiracRTHandler(GangaUnitTest):
+
+    @external
+    def testFailure(self):
+        """
+        Check a simple job fails and raises the correct exception
+        """
+        from Ganga.GPI import Job, Dirac, Executable
+        import time
+        j =  Job(backend = Dirac())
+        j.application = Executable(exe = 'ech')
+        j.application.args = ['Hello World']
+        j.submit()
+        assert run_until_state(j, 'failed', 220)
+        filepath = os.path.join(j.outputdir, 'Ganga_Executable.log')
+        i = 0
+        while not os.path.exists(filepath) and i < 10:
+            i=i+1
+            time.sleep(5)
+
+        found = False
+        with open(filepath, 'r') as f:
+            for line in f:
+                if "Exception occured in running process: ['ech', 'Hello World']" in line:
+                    found = True
+        assert found


### PR DESCRIPTION
Fixes #946 
Put the executed command inside a repr so it prints out. Have the raised exception printed out instead of None. Also changed the subprocess.call to work properly.