### PR TITLE
Add DiracSplitter for using DiracFiles locally

### DIFF
--- a/python/GangaLHCb/Lib/LHCbDataset/LHCbDataset.py
+++ b/python/GangaLHCb/Lib/LHCbDataset/LHCbDataset.py
@@ -83,7 +83,8 @@ class LHCbDataset(GangaDataset):
                 for this_file in files:
                     self.files.append(deepcopy(this_file))
             elif isType(files, IGangaFile):
-                self.files.append(deepcopy(this_file))
+                for this_file in files:
+                    self.files.append(deepcopy(this_file))
             elif isType(files, (list, tuple, GangaList)):
                 new_list = []
                 for this_file in files:

--- a/python/GangaLHCb/Lib/LHCbDataset/LHCbDataset.py
+++ b/python/GangaLHCb/Lib/LHCbDataset/LHCbDataset.py
@@ -83,7 +83,7 @@ class LHCbDataset(GangaDataset):
                 for this_file in files:
                     self.files.append(deepcopy(this_file))
             elif isType(files, IGangaFile):
-                    self.files.append(deepcopy(files))
+                self.files.append(deepcopy(files))
             elif isType(files, (list, tuple, GangaList)):
                 new_list = []
                 for this_file in files:

--- a/python/GangaLHCb/Lib/LHCbDataset/LHCbDataset.py
+++ b/python/GangaLHCb/Lib/LHCbDataset/LHCbDataset.py
@@ -83,8 +83,7 @@ class LHCbDataset(GangaDataset):
                 for this_file in files:
                     self.files.append(deepcopy(this_file))
             elif isType(files, IGangaFile):
-                for this_file in files:
-                    self.files.append(deepcopy(this_file))
+                    self.files.append(deepcopy(files))
             elif isType(files, (list, tuple, GangaList)):
                 new_list = []
                 for this_file in files:

--- a/python/GangaLHCb/Lib/Splitters/SplitByFiles.py
+++ b/python/GangaLHCb/Lib/Splitters/SplitByFiles.py
@@ -146,8 +146,6 @@ class SplitByFiles(GaudiInputDataSplitter):
 
         indata = inputdata
 
-        print 'type: ', type(indata)
-
         if indata is not None:
 
             self.depth = indata.depth

--- a/python/GangaLHCb/Lib/Splitters/SplitByFiles.py
+++ b/python/GangaLHCb/Lib/Splitters/SplitByFiles.py
@@ -146,6 +146,8 @@ class SplitByFiles(GaudiInputDataSplitter):
 
         indata = inputdata
 
+        print 'type: ', type(indata)
+
         if indata is not None:
 
             self.depth = indata.depth
@@ -195,6 +197,14 @@ class SplitByFiles(GaudiInputDataSplitter):
                 raise SplitterError("Backend algorithm not selected!")
 
             logger.debug("outdata: %s " % str(outdata))
+            return outdata
+        #If we are not running the jobs on Dirac but are using DiracFiles we want some of the same checks
+        elif all(isinstance(this_file, DiracFile) for this_file in indata):
+            from GangaDirac.Lib.Splitters.OfflineGangaDiracSplitter import OfflineGangaDiracSplitter
+            outdata = OfflineGangaDiracSplitter(indata,
+                                              self.filesPerJob,
+                                              self.maxFiles,
+                                              self.ignoremissing)
             return outdata
         else:
             logger.debug("Calling Parent Splitter as not on Dirac")


### PR DESCRIPTION
Fixes #945 
This adds a check for DiracFiles in the dataset when splitting and not using the Dirac backend. If they are all DiracFiles then it uses the `OfflineGangaDiracSplitter' in order to check for the availability of all the files.

I also found a bug in LHCbDataset  - I wasn't sure of the logic that the code was after but I think this fixes it.