### PR TITLE
Fix NameError when using prepareGaudiExec

### DIFF
--- a/python/GangaLHCb/Lib/Applications/GaudiExecUtils.py
+++ b/python/GangaLHCb/Lib/Applications/GaudiExecUtils.py
@@ -2,7 +2,7 @@ import subprocess
 from datetime import datetime
 import time
 import uuid
-from os import path
+from os import makedirs, path
 from Ganga.Core.exceptions import GangaException
 from Ganga.Runtime.GPIexport import exportToGPI
 from Ganga.Utility.files import expandfilename
@@ -99,7 +99,6 @@ def prepare_cmake_app(myApp, myVer, myPath='$HOME/cmtuser', myGetpack=None):
     full_path = expandfilename(myPath, True)
     if not path.exists(full_path):
         makedirs(full_path)
-        chdir(full_path)
     if not path.exists(full_path + '/' + myApp + 'Dev_' +myVer):
         _exec_cmd('lb-dev %s %s' % (myApp, myVer), full_path)
     else:


### PR DESCRIPTION
Using `prepareGaudiExec` without a `cmtuser` directory results in a crash due to `makedirs` not being imported (stack trace below).

The following line then uses `chdir` which also isn't imported, however, I don't immediately see why it's needed so I've removed it.

```python
ERROR    Error: global name 'makedirs' is not defined
ERROR    !!Unknown/Unexpected ERROR!!
ERROR    If you're able to reproduce this please report this to the Ganga developers!
---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
/afs/cern.ch/lhcb/software/releases/GANGA/GANGA_v603r1/install/ganga/python/Ganga/GPI/__init__.py in <module>()
----> 1 execfile('submit.py')

/afs/cern.ch/lhcb/software/releases/GANGA/GANGA_v603r1/install/ganga/python/Ganga/GPI/__init__.py in <module>()
      8
      9 # Configure Brunel
---> 10 brunel = prepareGaudiExec('Brunel', 'v51r1')
     11 brunel.optsfile = [
     12     APPCONFIGOPTS+'/Brunel/MC-WithTruth.py',

/afs/cern.ch/lhcb/software/releases/GANGA/GANGA_v603r1/install/ganga/python/GangaLHCb/Lib/Applications/GaudiExecUtils.py in prepareGaudiExec(myApp, myVer, myPath, myGetpack)
    123             myGepPack (str): This is a getpack which will be run once the lb-dev has executed
    124     """
--> 125     path = prepare_cmake_app(myApp, myVer, myPath, myGetpack)
    126     from Ganga.GPI import GaudiExec
    127     return GaudiExec(directory=path)

/afs/cern.ch/lhcb/software/releases/GANGA/GANGA_v603r1/install/ganga/python/GangaLHCb/Lib/Applications/GaudiExecUtils.py in prepare_cmake_app(myApp, myVer, myPath, myGetpack)
     99     full_path = expandfilename(myPath, True)
    100     if not path.exists(full_path):
--> 101         makedirs(full_path)
    102         chdir(full_path)
    103     if not path.exists(full_path + '/' + myApp + 'Dev_' +myVer):

NameError: global name 'makedirs' is not defined
```