### PR TITLE
Update default options path in LHCb RT template

### DIFF
--- a/python/GangaLHCb/Lib/RTHandlers/WorkerScript.py.template
+++ b/python/GangaLHCb/Lib/RTHandlers/WorkerScript.py.template
@@ -15,15 +15,13 @@ if not os.path.exists(opts):
     opts = 'notavailable'
     os.environ['JOBOPTPATH'] = opts
 else:
-    os.environ['JOBOPTPATH'] = os.path.join(os.environ[app + '_release_area'],
+    os.environ['JOBOPTPATH'] = os.path.join(os.environ['LHCBRELEASES'],
             app_upper,
-            app_upper,
-            version,
+            app_upper+'_'+version,
             package,
             app,
-            version,
             'options',
-            'job.opts')
+            app+'-Default.py')
     sys.stdout.write('Using the master optionsfile: %s' % opts)
     sys.stdout.flush()
 


### PR DESCRIPTION
Fixes #973 . This now uses an environment variable that is set by the latest LbScripts and points to the default options file for the application.