### PR TITLE
Add option to not need an AFS token

### DIFF
--- a/python/Ganga/Runtime/bootstrap.py
+++ b/python/Ganga/Runtime/bootstrap.py
@@ -879,7 +879,7 @@ under certain conditions; type license() for details.
 
         from Ganga.Runtime import Workspace_runtime, Repository_runtime
         from Ganga.GPIDev.Credentials import credential_store
-        if Workspace_runtime.requiresAfsToken() or Repository_runtime.requiresAfsToken():
+        if (Workspace_runtime.requiresAfsToken() or Repository_runtime.requiresAfsToken()) and not config['NoAfsToken']:
             # If the registry or the workspace needs an AFS token then add one to the credential store.
             # Note that this happens before the monitoring starts so that it gets tracked properly
 

--- a/python/Ganga/__init__.py
+++ b/python/Ganga/__init__.py
@@ -134,6 +134,8 @@ conf_config.addOption('deleteUnusedShareDir', 'always',
 
 conf_config.addOption('autoGenerateJobWorkspace', False, 'Autogenerate workspace dirs for new jobs')
 
+conf_config.addOption('NoAfsToken', False, 'Do not require an AFS token when running on an AFS filesystem. Not recommended!')
+
 # add named template options
 conf_config.addOption('namedTemplates_ext', 'tpl',
                  'The default file extension for the named template system. If a package sets up their own by calling "establishNamedTemplates" from python/Ganga/GPIDev/Lib/Job/NamedJobTemplate.py in their ini file then they can override this without needing the config option')


### PR DESCRIPTION
Fixes #944 . Config option to not need an AFS token when running on AFS.