### PR TITLE
Fix accessing key from wrong config

### DIFF
--- a/python/Ganga/GPIDev/Lib/Job/Job.py
+++ b/python/Ganga/GPIDev/Lib/Job/Job.py
@@ -1966,7 +1966,7 @@ class Job(GangaObject):
                 rjobs = [self]
             elif auto_resubmit:  # get only the failed jobs for auto resubmit
                 rjobs = [s for s in rjobs
-                         if s.status == 'failed' and s.info.submit_counter <= config['MaxNumResubmits']]
+                         if s.status == 'failed' and s.info.submit_counter <= getConfig("PollThread")['MaxNumResubmits']]
 
             if rjobs:
                 for sjs in rjobs:


### PR DESCRIPTION
This fixes a bug reported by Jibo this morning on lhcb-distributed-analysis which was introduced in #996 where I used the wrong config dictionary to access the value of MaxNumResubmits.