### PR TITLE
Add CMake support and Fix minor Credential problem

### DIFF
--- a/python/Ganga/Core/Sandbox/WNSandbox.py
+++ b/python/Ganga/Core/Sandbox/WNSandbox.py
@@ -23,14 +23,8 @@ def getPackedInputSandbox(tarpath, dest_dir='.'):
     """
 
     with closing(tarfile.open(tarpath, "r:*")) as tf:
-        for file_ in tf:
-            try:
-                tf.extract(file_)
-            except IOError as e:
-                os.remove(file_.name)
-                tar.extract(file_)
-            finally:
-                os.chmod(file_.name, file_.mode)
+        tf.extractAll()
+
 
 def createOutputSandbox(output_patterns, filter, dest_dir):
     """Get all files matching output patterns except filtered with filter and

--- a/python/Ganga/Core/Sandbox/WNSandbox.py
+++ b/python/Ganga/Core/Sandbox/WNSandbox.py
@@ -23,7 +23,7 @@ def getPackedInputSandbox(tarpath, dest_dir='.'):
     """
 
     with closing(tarfile.open(tarpath, "r:*")) as tf:
-        tf.extractAll()
+        tf.extractall(dest_dir)
 
 
 def createOutputSandbox(output_patterns, filter, dest_dir):

--- a/python/Ganga/GPIDev/Lib/File/OutputFileManager.py
+++ b/python/Ganga/GPIDev/Lib/File/OutputFileManager.py
@@ -201,7 +201,7 @@ def getWNCodeForDownloadingInputFiles(job, indent):
         Args: job(Job) This is the job which we're testing for inputfiles """
         if job.inputfiles is not None and len(job.inputfiles) != 0:
             return True
-        if (job.inputdata is not None and len(job.inputdata) != 0) and isinstance(job.inputdata, GangaDataset) and job.inputdata.treat_as_inputfiles:
+        if job.inputdata is not None and isinstance(job.inputdata, GangaDataset) and job.inputdata.treat_as_inputfiles:
             return True
         return False
 

--- a/python/Ganga/Lib/Localhost/LocalHostExec.py.template
+++ b/python/Ganga/Lib/Localhost/LocalHostExec.py.template
@@ -76,6 +76,8 @@ sys.path.insert(0, ###GANGADIR###)
 sys.path.insert(0,os.path.join(os.getcwd(),PYTHON_DIR))
 
 fullenvironment = os.environ.copy()
+for key,value in environment.iteritems():
+    fullenvironment[key] = value
 
 outfile=open('stdout','w')
 errorfile=open('stderr','w')

--- a/python/GangaAtlas/Lib/ATLASDataset/DQ2Dataset.py
+++ b/python/GangaAtlas/Lib/ATLASDataset/DQ2Dataset.py
@@ -2124,6 +2124,9 @@ logger = getLogger()
 # New for DQ2 client 2.3.0
 from Ganga.GPIDev.Credentials_old import GridProxy
 gridProxy = GridProxy()
+if not gridProxy.isValid():
+    gridProxy.create()
+
 username = gridProxy.identity(safe=True)
 nickname = getNickname(allowMissingNickname=False)
 if nickname:

--- a/python/GangaAtlas/Lib/Athena/Athena.py
+++ b/python/GangaAtlas/Lib/Athena/Athena.py
@@ -375,6 +375,7 @@ class Athena(IPrepareApp):
                  'useNoDebugLogs'         : SimpleItem(defvalue = False, doc='Use debug print-out in logfiles of Local/Batch/CREAM/LCG backend'),
                  'useNewTRF'              : SimpleItem(defvalue = True, doc='Use the original filename with the attempt number for input in --trf when there is only one input, which follows the globbing scheme of new transformation framework'),
                  'useNoAthenaSetup'       : SimpleItem(defvalue = False, doc='Use No Athena setup to allow e.g. free ROOT setup'),
+                 'useCMake'            : SimpleItem(defvalue = False, doc='Use CMake when packing/running the job'),
                  })
                      
     _category = 'applications'
@@ -1154,7 +1155,11 @@ class Athena(IPrepareApp):
             maxFileSize = config['EXE_MAXFILESIZE']
             archiveName, archiveFullName = create_tarball(self.userarea, runDir, currentDir, archiveDir, self.append_to_user_area, self.exclude_from_user_area, maxFileSize, self.useAthenaPackages, verbose, self.athena_compile )
         else:
-            archiveName, archiveFullName = AthenaUtils.archiveSourceFiles(self.userarea, runDir, currentDir, archiveDir, verbose, self.glue_packages, config['dereferenceSymLinks'])
+            if AthenaUtils.useCMake():
+                self.useCMake = True
+                archiveName,archiveFullName = AthenaUtils.archiveWithCpack(True,tmpDir,True)
+
+            archiveName, archiveFullName = AthenaUtils.archiveSourceFiles(self.userarea, runDir, currentDir, archiveDir, verbose, self.glue_packages, config['dereferenceSymLinks'], archiveName=archiveName)
         logger.info('Creating %s ...', archiveFullName )
 
         # Add InstallArea

--- a/python/GangaAtlas/Lib/Athena/run-athena-new.sh
+++ b/python/GangaAtlas/Lib/Athena/run-athena-new.sh
@@ -1,0 +1,180 @@
+#!/bin/bash
+
+# Vastly simplified script to unpack and run an Athena job on local resources
+
+# store env variables that get stomped on by the setup below
+MY_ATHENA_OPTIONS=$ATHENA_OPTIONS
+MY_OUTPUT_LOCATION=$OUTPUT_LOCATION
+
+# setup Atlas enviroenment
+shopt -s expand_aliases
+source $ATLAS_LOCAL_ROOT_BASE/user/atlasLocalSetup.sh
+
+# setup the base athena release
+echo "------>  Setting up the base athena release $ATLAS_PROJECT $ATLAS_RELEASE $ATLAS_PRODUCTION"
+if [ n$ATLAS_PRODUCTION = n ]; then
+    ATLAS_VERSION=$ATLSA_RELEASE
+else
+    ATLAS_VERSION=$ATLAS_PRODUCTION
+fi
+
+# now do asetup
+echo "------>  Running asetup $ATLAS_PROJECT,$ATLAS_VERSION,here..."
+source $AtlasSetup/scripts/asetup.sh $ATLAS_PROJECT,$ATLAS_VERSION,here
+
+# Now create the build directory
+echo "------>  Building using cmake..."
+mkdir __athena_build__
+cd __athena_build__
+cmake ../
+make clean
+make
+source x86_64-slc6-gcc49-opt/setup.sh
+cd ../
+
+################################################
+# create the input.py file
+cat - >preJobO.py <<EOF
+ic = []
+if os.path.exists('input_files'):
+    for lfn in file('input_files'):
+        name = os.path.basename(lfn.strip())
+        pfn = os.path.join(os.getcwd(),name)
+        if (os.path.exists(pfn) and (os.stat(pfn).st_size>0)):
+            print 'Input: %s' % name
+            ic.append('%s' % name)
+        elif (os.path.exists(lfn.strip()) and (os.stat(lfn.strip()).st_size>0)):
+            print 'Input: %s' % lfn.strip()
+            ic.append('%s' % lfn.strip())
+
+try:
+    from EventSelectorAthenaPool.EventSelectorAthenaPoolConf import EventSelectorAthenaPool
+    orig_ESAP__getattribute =  EventSelectorAthenaPool.__getattribute__
+
+    def _dummy(self,attr):
+        if attr == 'InputCollections':
+            return ic
+        else:
+            return orig_ESAP__getattribute(self,attr)
+
+    EventSelectorAthenaPool.__getattribute__ = _dummy
+    print 'Overwrite InputCollections'
+    print EventSelectorAthenaPool.InputCollections
+except:
+    try:
+        EventSelectorAthenaPool.__getattribute__ = orig_ESAP__getattribute
+    except:
+        pass
+      
+try:
+    import AthenaCommon.AthenaCommonFlags
+
+    def _dummyFilesInput(*argv):
+        return ic
+
+    AthenaCommon.AthenaCommonFlags.FilesInput.__call__ = _dummyFilesInput
+except:
+    pass
+
+try:
+    import AthenaCommon.AthenaCommonFlags
+
+    def _dummyGet_Value(*argv):
+        return ic
+
+    for tmpAttr in dir (AthenaCommon.AthenaCommonFlags):
+        import re
+        if re.search('^(Pool|BS).*Input$',tmpAttr) != None:
+            try:
+                getattr(AthenaCommon.AthenaCommonFlags,tmpAttr).get_Value = _dummyGet_Value
+            except:
+                pass
+except:
+    pass
+
+try:
+    from AthenaServices.SummarySvc import *
+    useAthenaSummarySvc()
+except:
+    pass
+EOF
+cat - >input.py <<EOF
+ic = []
+if os.path.exists('input_files'):
+    for lfn in file('input_files'):
+        name = os.path.basename(lfn.strip())
+        pfn = os.path.join(os.getcwd(),name)
+        if (os.path.exists(pfn) and (os.stat(pfn).st_size>0)):
+            print 'Input: %s' % name
+            ic.append('%s' % name)
+        elif (os.path.exists(lfn.strip()) and (os.stat(lfn.strip()).st_size>0)):
+            print 'Input: %s' % lfn.strip()
+            ic.append('%s' % lfn.strip())
+            
+    # set the InputCollections depending on what's in the namespace
+    try:
+        EventSelector.InputCollections = ic
+    except NameError:
+        svcMgr.EventSelector.InputCollections = ic
+
+    if os.environ.has_key('ATHENA_MAX_EVENTS'):
+        theApp.EvtMax = int(os.environ['ATHENA_MAX_EVENTS'])
+    else:
+        theApp.EvtMax = -1
+EOF
+
+sed 's/EventSelector/ServiceMgr.EventSelector/' input.py > input.py.new
+mv input.py.new input.py
+
+
+
+# Running Athena
+echo "------>  Running athena preJobO.py $MY_ATHENA_OPTIONS input.py..."
+athena preJobO.py $MY_ATHENA_OPTIONS input.py
+
+echo "------>  Staging output to $MY_OUTPUT_LOCATION..."
+OUTPUT_LOCATION=$MY_OUTPUT_LOCATION
+# check for EOS use
+case $OUTPUT_LOCATION in
+    root*) 
+	echo "EOS output detected"
+	OUTPUT_LOCATION=`echo ${OUTPUT_LOCATION} | sed 's/root://' | sed 's|//[a-z0-9]*/||'`
+	echo "Changed output location to ${OUTPUT_LOCATION}"
+	MKDIR_CMD="eos mkdir"
+	CP_CMD="eos cp"
+	;;
+	*)
+	  echo "Defaulting to mkdir and cp commands..."
+	  MKDIR_CMD="mkdir" 
+	  CP_CMD="cp" 
+	  ;;
+esac
+
+echo $MKDIR_CMD -p $OUTPUT_LOCATION
+$MKDIR_CMD -p $OUTPUT_LOCATION
+cat output_files | while read filespec; do
+    for file in $filespec; do
+	if [ $SINGLE_OUTPUT_DIR ]
+	then
+	    outfile="${file%.*}.${SINGLE_OUTPUT_DIR}.${file##*.}"
+	    echo "Changed output file from ${file} to ${outfile}"
+	else
+	    outfile=$file
+	fi
+	echo $CP_CMD $file $OUTPUT_LOCATION/$outfile
+	$CP_CMD $file $OUTPUT_LOCATION/$outfile; echo $? > retcode.tmp
+	retcode=`cat retcode.tmp`
+	rm -f retcode.tmp
+	if [ $retcode -ne 0 ]; then
+	    sleep 60
+	    $CP_CMD $file $OUTPUT_LOCATION/$outfile; echo $? > retcode.tmp
+	    retcode=`cat retcode.tmp`
+	    rm -f retcode.tmp
+	    if [ $retcode -ne 0 ]; then
+		echo 'An ERROR during output stage-out occurred'
+		break
+	    fi
+	fi
+    done
+done
+

--- a/python/GangaAtlas/Lib/Athena/run-athena-new.sh
+++ b/python/GangaAtlas/Lib/Athena/run-athena-new.sh
@@ -2,12 +2,22 @@
 
 # Vastly simplified script to unpack and run an Athena job on local resources
 
+# make sure some output files are present just in case
+echo "Create output files to keep Condor happy..."
+touch  output_location
+touch output_guids
+touch output_data
+touch stats.pickle
+
 # store env variables that get stomped on by the setup below
 MY_ATHENA_OPTIONS=$ATHENA_OPTIONS
 MY_OUTPUT_LOCATION=$OUTPUT_LOCATION
 
 # setup Atlas enviroenment
 shopt -s expand_aliases
+echo "------>  Setting up atlas environment"
+# note: need to set this env variable as it's used in subsequent scripts
+export ATLAS_LOCAL_ROOT_BASE=/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase
 source $ATLAS_LOCAL_ROOT_BASE/user/atlasLocalSetup.sh
 
 # setup the base athena release
@@ -32,8 +42,8 @@ make
 source x86_64-slc6-gcc49-opt/setup.sh
 cd ../
 
-################################################
-# create the input.py file
+# create the input.py file to load in the input data
+echo "------>  Creating the pre/post JO files..."
 cat - >preJobO.py <<EOF
 ic = []
 if os.path.exists('input_files'):
@@ -125,7 +135,6 @@ EOF
 
 sed 's/EventSelector/ServiceMgr.EventSelector/' input.py > input.py.new
 mv input.py.new input.py
-
 
 
 # Running Athena

--- a/python/GangaAtlas/PACKAGE.py
+++ b/python/GangaAtlas/PACKAGE.py
@@ -32,7 +32,7 @@ _external_packages = {
                      'RUCIO_APPID' : 'ganga',
                      },
 
-    'panda-client' : { 'version' : '0.5.69',
+    'panda-client' : { 'version' : '0.5.80',
                        'syspath':['lib/python2.6/site-packages'],
                        'CONFIGEXTRACTOR_PATH':'etc/panda/share',
                        'PANDA_SYS':'.',

--- a/python/GangaPanda/PACKAGE.py
+++ b/python/GangaPanda/PACKAGE.py
@@ -8,7 +8,7 @@
 """
 
 _external_packages = {
-    'panda-client' : { 'version' : '0.5.69',
+    'panda-client' : { 'version' : '0.5.80',
                     'syspath':['lib/python2.6/site-packages'],
                     'CONFIGEXTRACTOR_PATH':'etc/panda/share',
                     'PANDA_SYS':'.',


### PR DESCRIPTION
This PR adds CMake support into the Atlas plugin. It auto detects this using PandaUtils (which also will need an upgrade) and if it is found, runs a **much** simplified wrapper script on the WN. A later PR will perform clean up of the old code that this supersedes.

In addition, this ensures an Atlas proxy is available when running. This is a 'hacky' fix before I try to get this working properly with the new credential system.

Finally, I found an issue specifically at Cambridge that the code to untar the input sandbox in local and batch jobs was failing on a particular tarball. I've switched the relevant code back to what it was (`extractall()`) and this seems to work.