### PR TITLE
Fix order of xroot/root protocols

### DIFF
--- a/python/GangaLHCb/Lib/Server/DiracLHCbCommands.py
+++ b/python/GangaLHCb/Lib/Server/DiracLHCbCommands.py
@@ -57,7 +57,7 @@ def getDataset(path, dqflag, this_type, start, end, sel):
 def getAccessURL(lfn, SE, protocol=''):
     ''' Return the access URL for the given LFN, storage element and protocol. If 'root' or 'xroot' specified then request both as per LHCbDirac from which this is taken. '''
     if protocol == '':
-        protocol=['root', 'xroot']
+        protocol=['xroot', 'root']
     elif 'root' in protocol and 'xroot' not in protocol:
         protocol.insert( protocol.index( 'root' ), 'xroot' )
     elif 'xroot' in protocol and 'root' not in protocol:


### PR DESCRIPTION
Swapping the default order of protocols round as otherwise, CASTOR sites can have problems. Fixes #1024 