### PR TITLE
Update gangarc on minor version change

### DIFF
--- a/python/Ganga/Runtime/bootstrap.py
+++ b/python/Ganga/Runtime/bootstrap.py
@@ -322,14 +322,22 @@ under certain conditions; type license() for details.
         if not os.path.exists(versions_filename):
             with open(versions_filename, 'w') as versions_file:
                 versions_file.write(_gangaVersion + '\n')
-            return True
+            return True, True
 
+        majVersion, minVersion, bugVersion = _gangaVersion.split('.')
+        newMinVersion = False
+        minVersion = majVersion+'.'+minVersion+'.'
+        # Check to see if this is a new bugfix version
         with open(versions_filename, 'r+') as versions_file:
             if versions_file.read().find(_gangaVersion) < 0:
+                # Check to see if this is a new minor version as well
+                versions_file.seek(0)
+                if versions_file.read().find(minVersion) < 0:
+                    newMinVersion = True
                 versions_file.write(_gangaVersion + '\n')
-                return True
+                return True, newMinVersion
 
-        return False
+        return False, newMinVersion
 
     @staticmethod
     def rollHistoryForward():
@@ -521,6 +529,7 @@ under certain conditions; type license() for details.
             load_user_config(specified_config, {})
             self.generate_config_file(specified_config, interactive)
             sys.exit(0)
+        bugVer, minVer = self.new_version()
         if not os.path.exists(specified_config) \
                 and not os.path.exists(default_config):
             # Sleep for 1 sec to allow for most of the bootstrap to finish so
@@ -534,7 +543,7 @@ under certain conditions; type license() for details.
                 self.generate_config_file(default_config, interactive)
                 if interactive:
                     raw_input('Press <Enter> to continue.\n')
-        elif self.new_version():
+        elif bugVer:
             self.print_release_notes()
             self.rollHistoryForward()
             # if config explicitly set we dont want to update the versions file
@@ -543,12 +552,13 @@ under certain conditions; type license() for details.
             # also if config explicitly set dont try to update it for new version
             # impacts hammercloud if you do?
             if not self.options.config_file_set_explicitly:
-                logger = getLogger('ConfigUpdater')
-                logger.info('It appears that this is the first time you have run %s' % _gangaVersion)
-                logger.info('Your ganga config file will be updated.')
-                logger.info('re-reading in old config for updating...')
-                load_user_config(specified_config, {})
-                self.generate_config_file(specified_config, interactive)
+                if minVer:
+                    logger = getLogger('ConfigUpdater')
+                    logger.info('It appears that this is the first time you have run %s' % _gangaVersion)
+                    logger.info('Your ganga config file will be updated.')
+                    logger.info('re-reading in old config for updating...')
+                    load_user_config(specified_config, {})
+                    self.generate_config_file(specified_config, interactive)
 
                 # config file generation overwrites user values so we need to reapply the cmd line options to these user settings
                 # e.g. set -o[Configuration]gangadir=/home/mws/mygangadir and the user value gets reset to the .gangarc value

--- a/python/Ganga/Runtime/bootstrap.py
+++ b/python/Ganga/Runtime/bootstrap.py
@@ -318,7 +318,7 @@ under certain conditions; type license() for details.
 
     @staticmethod
     def new_version():
-        versions_filename = os.path.join(getConfig('Configuration')['gangadir'], '.used_versions')
+        versions_filename = os.path.expanduser('~/.cache/Ganga/.used_versions')
         if not os.path.exists(versions_filename):
             with open(versions_filename, 'w') as versions_file:
                 versions_file.write(_gangaVersion + '\n')
@@ -341,7 +341,7 @@ under certain conditions; type license() for details.
 
     @staticmethod
     def rollHistoryForward():
-        versions_filename = os.path.join(getConfig('Configuration')['gangadir'], '.used_versions')
+        versions_filename = os.path.expanduser('~/.cache/Ganga/.used_versions')
         hasLoaded_newer = False
         with open(versions_filename, 'r') as versions_file:
             this_version = versions_file.read()


### PR DESCRIPTION
Fixes #1045 . 

As an aside would it be better to put the .used_versions file into the home directory? It is kind of annoying to have the gangarc updating when using different gangadirs .