### PR TITLE
Check for existence of cache folder

### DIFF
--- a/python/Ganga/Runtime/bootstrap.py
+++ b/python/Ganga/Runtime/bootstrap.py
@@ -319,6 +319,8 @@ under certain conditions; type license() for details.
     @staticmethod
     def new_version():
         versions_filename = os.path.expanduser('~/.cache/Ganga/.used_versions')
+        if not os.path.exists(os.path.dirname(versions_filename)):
+            os.makedirs(os.path.dirname(versions_filename))
         if not os.path.exists(versions_filename):
             with open(versions_filename, 'w') as versions_file:
                 versions_file.write(_gangaVersion + '\n')


### PR DESCRIPTION
Bugfix to check that the `~/.cache/Ganga` folder exists at startup.

Could someone please approve this and I'll restart the 6.6.2 release (also the getMetadata PR would be really useful to have in but this one is vital).