### PR TITLE
Update run-athena-new.sh

### DIFF
--- a/python/GangaAtlas/Lib/Athena/run-athena-new.sh
+++ b/python/GangaAtlas/Lib/Athena/run-athena-new.sh
@@ -33,14 +33,8 @@ echo "------>  Running asetup $ATLAS_PROJECT,$ATLAS_VERSION,here..."
 source $AtlasSetup/scripts/asetup.sh $ATLAS_PROJECT,$ATLAS_VERSION,here
 
 # Now create the build directory
-echo "------>  Building using cmake..."
-mkdir __athena_build__
-cd __athena_build__
-cmake ../
-make clean
-make
-source x86_64-slc6-gcc49-opt/setup.sh
-cd ../
+echo "------>  Setup user code (if provided)..."
+source usr/*/*/InstallArea/*/setup.sh
 
 # create the input.py file to load in the input data
 echo "------>  Creating the pre/post JO files..."


### PR DESCRIPTION
Ensure user code is correctly set up, whatever the environment (the previous code assumed a particular environment) and avoid recompiling the user code (it is unnecessary).

When this change is accepted, can it please make it into a HOTFIX for 6.6.2, because at the moment we cannot use 6.6.2 to submit cmake-based user code jobs!

Thanks
Will