### PR TITLE
Add EXE support and fix issues with user packages

### DIFF
--- a/python/GangaAtlas/Lib/Athena/Athena.py
+++ b/python/GangaAtlas/Lib/Athena/Athena.py
@@ -1154,13 +1154,25 @@ class Athena(IPrepareApp):
         if self.atlas_exetype in ['EXE']: #and not self.athena_compile:  - for EXE, compilation decides what the tarball is called
             maxFileSize = config['EXE_MAXFILESIZE']
             archiveName, archiveFullName = create_tarball(self.userarea, runDir, currentDir, archiveDir, self.append_to_user_area, self.exclude_from_user_area, maxFileSize, self.useAthenaPackages, verbose, self.athena_compile )
-        else:
-            archiveName = ""
+
             if AthenaUtils.useCMake():
                 self.useCMake = True
-                archiveName,archiveFullName = AthenaUtils.archiveWithCpack(True,tmpDir,True)
+        else:
+            # compilation determines whether to send the sources across as well
+            archiveName = ""
+            if self.athena_compile:
+                if AthenaUtils.useCMake():
+                    self.useCMake = True
+                    archiveName,archiveFullName = AthenaUtils.archiveWithCpack(True,tmpDir,True)
 
-            archiveName, archiveFullName = AthenaUtils.archiveSourceFiles(self.userarea, runDir, currentDir, archiveDir, verbose, self.glue_packages, config['dereferenceSymLinks'], archiveName=archiveName)
+                archiveName, archiveFullName = AthenaUtils.archiveSourceFiles(self.userarea, runDir, currentDir, archiveDir, verbose, self.glue_packages, config['dereferenceSymLinks'], archiveName=archiveName)
+            else:
+                if AthenaUtils.useCMake():
+                    self.useCMake = True
+                    archiveName,archiveFullName = AthenaUtils.archiveWithCpack(False,tmpDir,True)
+
+                archiveName, archiveFullName = AthenaUtils.archiveJobOFiles(self.userarea, runDir, currentDir, archiveDir, verbose, archiveName=archiveName)
+
         logger.info('Creating %s ...', archiveFullName )
 
         # Add InstallArea

--- a/python/GangaAtlas/Lib/Athena/AthenaLocalRTHandler.py
+++ b/python/GangaAtlas/Lib/Athena/AthenaLocalRTHandler.py
@@ -426,11 +426,14 @@ class AthenaLocalRTHandler(IRuntimeHandler):
         inputbox = [File(os.path.join(os.path.dirname(__file__),'athena-utility.sh'))]
         if app.atlas_exetype in ['PYARA','ARES','ROOT','EXE']:
 
-            for option_file in app.option_file:
-                athena_options += ' ' + os.path.basename(option_file.name)
-                inputbox += [ File(option_file.name) ]
+            if app.command_line:
+                athena_options = app.command_line
+            else:
+                for option_file in app.option_file:
+                    athena_options += ' ' + os.path.basename(option_file.name)
+                    inputbox += [ File(option_file.name) ]
 
-            athena_options += ' %s ' % app.options
+                athena_options += ' %s ' % app.options
 
         else:
             for option_file in app.option_file:
@@ -506,6 +509,10 @@ class AthenaLocalRTHandler(IRuntimeHandler):
             'GANGA_VERSION' : configSystem['GANGA_VERSION'],
             'DQ2_SETUP_SCRIPT': configDQ2['setupScript']
         }
+
+        # athena compile flag
+        if app.athena_compile:
+            environment['ATHENA_COMPILE'] = 'True'
 
         # Set athena architecture: 32 or 64 bit
         environment['ATLAS_ARCH'] = '32'


### PR DESCRIPTION
This PR does the following:

* Adds EXE/ROOT/PYARA support into CMake releases
* Fixes issues with hardcoded architecture path
* Only does compilation if requested

Fixes #1053.

Could this be reviewed ASAP please so it can go out for a tutorial this week? Thanks!