### PR TITLE
Add config check to MassStorageFile

### DIFF
--- a/python/Ganga/GPIDev/Lib/File/MassStorageFile.py
+++ b/python/Ganga/GPIDev/Lib/File/MassStorageFile.py
@@ -64,9 +64,7 @@ class MassStorageFile(IGangaFile):
         super(MassStorageFile, self).__init__()
         self._setNamePath(_namePattern=namePattern, _localDir=localDir)
         self.locations = []
-
         self.shell = Shell.Shell()
-
 
     def __setattr__(self, attr, value):
         """

--- a/python/Ganga/GPIDev/Lib/File/MassStorageFile.py
+++ b/python/Ganga/GPIDev/Lib/File/MassStorageFile.py
@@ -102,7 +102,7 @@ class MassStorageFile(IGangaFile):
 
     def _checkConfig(self):
         """
-        Check that the MassStorageFile configuration is correct by trying to make the default path
+        Check that the MassStorageFile configuration is correct
         """
         if not getConfig('Output')[_getName(self)]['uploadOptions']['path'] :
             raise GangaException('Unable to create MassStorageFile. Check your configuration!')

--- a/python/Ganga/GPIDev/Lib/File/MassStorageFile.py
+++ b/python/Ganga/GPIDev/Lib/File/MassStorageFile.py
@@ -65,6 +65,8 @@ class MassStorageFile(IGangaFile):
         self.locations = []
 
         self.shell = Shell.Shell()
+        self._checkConfig()
+
 
     def __setattr__(self, attr, value):
         """
@@ -98,6 +100,14 @@ class MassStorageFile(IGangaFile):
             self.namePattern = _namePattern
             self.localDir = _localDir
 
+    def _checkConfig(self):
+        """
+        Check that the MassStorageFile configuration is correct by trying to make the default path
+        """
+        try:
+            self._mkdir(getConfig('Output')[_getName(self)]['uploadOptions']['path'], False)
+        except GangaException:
+            raise GangaException('Unable to create MassStorageFile. Check your configuration!')
 
     def _on_attribute__set__(self, obj_type, attrib_name):
         # This is defining the object as uncopyable from outputfiles... do we want this mechanism still?

--- a/python/Ganga/GPIDev/Lib/File/MassStorageFile.py
+++ b/python/Ganga/GPIDev/Lib/File/MassStorageFile.py
@@ -60,12 +60,12 @@ class MassStorageFile(IGangaFile):
             namePattern (str): is the pattern of the output file that has to be written into mass storage
             localDir (str): This is the optional local directory of a file to be uploaded to mass storage
         """
+        self._checkConfig()
         super(MassStorageFile, self).__init__()
         self._setNamePath(_namePattern=namePattern, _localDir=localDir)
         self.locations = []
 
         self.shell = Shell.Shell()
-        self._checkConfig()
 
 
     def __setattr__(self, attr, value):
@@ -104,9 +104,7 @@ class MassStorageFile(IGangaFile):
         """
         Check that the MassStorageFile configuration is correct by trying to make the default path
         """
-        try:
-            self._mkdir(getConfig('Output')[_getName(self)]['uploadOptions']['path'], False)
-        except GangaException:
+        if not getConfig('Output')[_getName(self)]['uploadOptions']['path'] :
             raise GangaException('Unable to create MassStorageFile. Check your configuration!')
 
     def _on_attribute__set__(self, obj_type, attrib_name):

--- a/python/Ganga/__init__.py
+++ b/python/Ganga/__init__.py
@@ -699,7 +699,7 @@ protoByExperiment = {'atlas': 'root://eosatlas.cern.ch',
                      'undefined': 'root://eos.cern.ch'}
 defaultMassStorageProto = protoByExperiment[groupname]
 
-prefix = '/afs/cern.ch/project/eos/installation/%s/bin/eos.select ' % groupname
+prefix = '/usr/bin/eos '
 massStorageUploadOptions = {'mkdir_cmd': prefix + 'mkdir', 'cp_cmd':
                             prefix + 'cp', 'ls_cmd': prefix + 'ls', 'path': massStoragePath}
 

--- a/python/Ganga/__init__.py
+++ b/python/Ganga/__init__.py
@@ -3,7 +3,7 @@ import os
 import re
 import inspect
 import getpass
-
+import commands
 from Ganga.Utility.ColourText import ANSIMarkup, overview_colours
 
 
@@ -732,7 +732,6 @@ protoByExperiment = {'atlas': 'root://eosatlas.cern.ch',
                      'undefined': 'root://eos.cern.ch'}
 defaultMassStorageProto = protoByExperiment[groupname]
 
-import commands
 eosinstalled, prefix = commands.getstatusoutput('which eos')
 if not eosinstalled == 0:
     prefix = ''

--- a/python/Ganga/__init__.py
+++ b/python/Ganga/__init__.py
@@ -699,14 +699,14 @@ protoByExperiment = {'atlas': 'root://eosatlas.cern.ch',
                      'undefined': 'root://eos.cern.ch'}
 defaultMassStorageProto = protoByExperiment[groupname]
 
-prefix = '/usr/bin/eos '
-
 import commands
-massStorageUploadOptions = {'mkdir_cmd': prefix + 'mkdir', 'cp_cmd':
-                            prefix + 'cp', 'ls_cmd': prefix + 'ls', 'path': ''}
-if commands.getstatusoutput('which %s' % prefix)[0] == 0 :
-    massStorageUploadOptions = {'mkdir_cmd': prefix + 'mkdir', 'cp_cmd':
-                            prefix + 'cp', 'ls_cmd': prefix + 'ls', 'path': massStoragePath}
+eosinstalled, prefix = commands.getstatusoutput('which eos')
+if not eosinstalled == 0:
+    prefix = ''
+    massStoragePath = ''    
+
+massStorageUploadOptions = {'mkdir_cmd': prefix + ' mkdir', 'cp_cmd':
+                            prefix + ' cp', 'ls_cmd': prefix + ' ls', 'path': massStoragePath}
 
 massStorageFileExt = docstr_Ext % ('Mass Storage', 'EOS')
 

--- a/python/Ganga/__init__.py
+++ b/python/Ganga/__init__.py
@@ -700,7 +700,12 @@ protoByExperiment = {'atlas': 'root://eosatlas.cern.ch',
 defaultMassStorageProto = protoByExperiment[groupname]
 
 prefix = '/usr/bin/eos '
+
+import commands
 massStorageUploadOptions = {'mkdir_cmd': prefix + 'mkdir', 'cp_cmd':
+                            prefix + 'cp', 'ls_cmd': prefix + 'ls', 'path': ''}
+if commands.getstatusoutput('which %s' % prefix)[0] == 0 :
+    massStorageUploadOptions = {'mkdir_cmd': prefix + 'mkdir', 'cp_cmd':
                             prefix + 'cp', 'ls_cmd': prefix + 'ls', 'path': massStoragePath}
 
 massStorageFileExt = docstr_Ext % ('Mass Storage', 'EOS')

--- a/python/Ganga/testlib/GangaUnitTest.py
+++ b/python/Ganga/testlib/GangaUnitTest.py
@@ -92,27 +92,12 @@ def start_ganga(gangadir_for_test, extra_opts=[], extra_args=None):
 
     #Sort out eos
 
-    ## FIXME Sometimes the wrong user is set gere for the unittests, I've added this to correct for it - rcurrie
-    import pwd
-    try:
-        pwd_nam = pwd.getpwnam(user)
-    except:
-        import getpass
-        user = getpass.getuser()
-    pwd_nam = pwd.getpwnam(user)
-
-    import grp
-    groupid = grp.getgrgid(pwd_nam.pw_gid).gr_name
-    groupnames = {'z5': 'lhcb.old', 'zp': 'atlas', 'zh': 'cms', 'vl': 'na62'}
-    groupname = groupnames.get(groupid, 'undefined')
-
     from Ganga.Utility.Config import getConfig
     outputConfig = getConfig('Output')
-    prefix = '/afs/cern.ch/project/eos/installation/%s/bin/eos.select ' % groupname
-    outputConfig['MassStorageFile']['uploadOptions']['cp_cmd'] = prefix + ' cp'
-    outputConfig['MassStorageFile']['uploadOptions']['ls_cmd'] = prefix + ' ls'
-    outputConfig['MassStorageFile']['uploadOptions']['mkdir_cmd'] = prefix + ' mkdir'
-
+    outputConfig['MassStorageFile']['uploadOptions']['cp_cmd'] = 'cp'
+    outputConfig['MassStorageFile']['uploadOptions']['ls_cmd'] = 'ls'
+    outputConfig['MassStorageFile']['uploadOptions']['mkdir_cmd'] = 'mkdir'
+    outputConfig['MassStorageFile']['uploadOptions']['path'] = '/tmp'
 
     default_opts = [
         ('Configuration', 'RUNTIME_PATH', 'GangaTest'),
@@ -125,8 +110,6 @@ def start_ganga(gangadir_for_test, extra_opts=[], extra_args=None):
         ('Queues', 'NumWorkerThreads', 2),
         ('Output', 'MassStorageFile', outputConfig['MassStorageFile'])
     ]
-
-    outputConfig['MassStorageFile']['uploadOptions']['mkdir_cmd'] = prefix + ' mkdir'
 
     # FIXME Should we need to add the ability to load from a custom .ini file
     # to configure tests without editting this?

--- a/python/Ganga/testlib/GangaUnitTest.py
+++ b/python/Ganga/testlib/GangaUnitTest.py
@@ -123,7 +123,7 @@ def start_ganga(gangadir_for_test, extra_opts=[], extra_args=None):
         ('Configuration', 'lockingStrategy', 'FIXED'),
         ('TestingFramework', 'ReleaseTesting', True),
         ('Queues', 'NumWorkerThreads', 2),
-        ('outputFile', 'MassStorageFile', outputConfig['MassStorageFile']['uploadOptions'])
+        ('outputFile', 'MassStorageFile', outputConfig['MassStorageFile'])
     ]
 
     outputConfig['MassStorageFile']['uploadOptions']['mkdir_cmd'] = prefix + ' mkdir'

--- a/python/Ganga/testlib/GangaUnitTest.py
+++ b/python/Ganga/testlib/GangaUnitTest.py
@@ -123,7 +123,7 @@ def start_ganga(gangadir_for_test, extra_opts=[], extra_args=None):
         ('Configuration', 'lockingStrategy', 'FIXED'),
         ('TestingFramework', 'ReleaseTesting', True),
         ('Queues', 'NumWorkerThreads', 2),
-        ('outputFile', 'MassStorageFile', outputConfig['MassStorageFile'])
+        ('Output', 'MassStorageFile', outputConfig['MassStorageFile'])
     ]
 
     outputConfig['MassStorageFile']['uploadOptions']['mkdir_cmd'] = prefix + ' mkdir'

--- a/python/Ganga/testlib/GangaUnitTest.py
+++ b/python/Ganga/testlib/GangaUnitTest.py
@@ -1,5 +1,4 @@
 from __future__ import print_function
-
 import sys
 import shutil
 import os.path
@@ -67,12 +66,14 @@ def start_ganga(gangadir_for_test, extra_opts=[], extra_args=None):
         extra_opts (list): A list of tuples which are used to pass command line style options to Ganga
     """
 
+
     import Ganga.PACKAGE
     Ganga.PACKAGE.standardSetup()
 
     # End taken from the ganga binary
 
     import Ganga.Runtime
+    from Ganga.Utility.Config import getConfig
     from Ganga.Utility.logging import getLogger
     logger = getLogger()
 
@@ -91,8 +92,6 @@ def start_ganga(gangadir_for_test, extra_opts=[], extra_args=None):
     # They can be overridden by extra_opts
 
     #Sort out eos
-
-    from Ganga.Utility.Config import getConfig
     outputConfig = getConfig('Output')
     outputConfig['MassStorageFile']['uploadOptions']['cp_cmd'] = 'cp'
     outputConfig['MassStorageFile']['uploadOptions']['ls_cmd'] = 'ls'

--- a/python/Ganga/testlib/GangaUnitTest.py
+++ b/python/Ganga/testlib/GangaUnitTest.py
@@ -103,7 +103,7 @@ def start_ganga(gangadir_for_test, extra_opts=[], extra_args=None):
 
     import grp
     groupid = grp.getgrgid(pwd_nam.pw_gid).gr_name
-    groupnames = {'z5': 'lhcb', 'zp': 'atlas', 'zh': 'cms', 'vl': 'na62'}
+    groupnames = {'z5': 'lhcb.old', 'zp': 'atlas', 'zh': 'cms', 'vl': 'na62'}
     groupname = groupnames.get(groupid, 'undefined')
 
     from Ganga.Utility.Config import getConfig


### PR DESCRIPTION
Fixes #1069 .

Checks that it can make/ls the default MassStoragePath to check the user configs. Also updated the default path for eos to `/usr/bin/eos`