### PR TITLE
Fixing some bad excpetions thrown by Ganga

### DIFF
--- a/python/Ganga/Core/GangaRepository/Registry.py
+++ b/python/Ganga/Core/GangaRepository/Registry.py
@@ -549,7 +549,7 @@ class Registry(object):
             # Cleanup after ourselves if an error occured
             # Didn't load mark as clean so it's not flushed
             if obj_id in self._objects:
-                self._objects[obj_id]._setFlushed()
+                self._objects[obj_id]._setFlushed(auto_load_deps=False)
             raise
 
     def _acquire_session_lock(self, obj):

--- a/python/Ganga/GPIDev/Base/Objects.py
+++ b/python/Ganga/GPIDev/Base/Objects.py
@@ -622,7 +622,7 @@ class ObjectMetaclass(abc.ABCMeta):
         if '_schema' not in this_dict:
             s = "Class %s must _schema (it cannot be silently inherited)" % (name,)
             logger.error(s)
-            raise ValueError(s)
+            raise GangaValueError(s)
 
         attrs_to_add = [ attr for attr, item in this_schema.allItems()]
 
@@ -1100,9 +1100,13 @@ class GangaObject(Node):
             logger.debug("_getRegistryID Exception: %s" % err)
             return None
 
-    def _setFlushed(self):
-        """Un-Set the dirty flag all of the way down the schema."""
-        if self._schema:
+    def _setFlushed(self, auto_load_deps=True):
+        """
+        Un-Set the dirty flag all of the way down the schema.
+        Args:
+            auto_load_deps (bool): Should we attempt to get objects which may be unloaded and load them via the schema?
+        """
+        if self._schema and auto_load_deps:
             for k in self._schema.allItemNames():
                 this_attr = getattr(self, k)
                 if isinstance(this_attr, Node):
@@ -1188,7 +1192,7 @@ def string_type_shortcut_filter(val, item):
     """
     if isinstance(val, type('')):
         if item is None:
-            raise ValueError('cannot apply default string conversion, probably you are trying to use it in the constructor')
+            raise GangaValueError('cannot apply default string conversion, probably you are trying to use it in the constructor')
         from Ganga.Utility.Plugin import allPlugins, PluginManagerError
         try:
             obj = allPlugins.find(item['category'], val)()
@@ -1196,7 +1200,7 @@ def string_type_shortcut_filter(val, item):
             return obj
         except PluginManagerError as err:
             logger.debug("string_type_shortcut_filter Exception: %s" % err)
-            raise ValueError(err)
+            raise GangaValueError('Cannot assign string to object, are you sure this is correct?\n%s' % err)
     return None
 
 # FIXME: change into classmethod (do they inherit?) and then change stripComponentObject to use class instead of

--- a/python/Ganga/GPIDev/Lib/Dataset/GangaDataset.py
+++ b/python/Ganga/GPIDev/Lib/Dataset/GangaDataset.py
@@ -6,6 +6,7 @@ from Ganga.GPIDev.Schema import Schema, Version, SimpleItem, GangaFileItem
 from Ganga.GPIDev.Base.Proxy import getName
 import Ganga.Utility.logging
 from Ganga.GPIDev.Adapters.IGangaFile import IGangaFile
+from Ganga.GPIDev.Base.Objects import GangaObject
 logger = Ganga.Utility.logging.getLogger()
 
 #\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\#
@@ -96,8 +97,10 @@ class GangaDataset(Dataset):
             elif hasattr(f, 'getFilenameList'):
                 filelist += f.getFilenameList()
             else:
-                logger.warning(
-                    "accessURL or getFilenameList not implemented for File '%s'" % getName(f))
+                if isinstance(f, GangaObject):
+                    logger.warning("accessURL or getFilenameList not implemented for File '%s'" % getName(f))
+                else:
+                    logger.warning("Warning, not sure how to parse file: %s" % str(f))
 
         return filelist
 

--- a/python/GangaLHCb/Lib/LHCbDataset/LHCbDataset.py
+++ b/python/GangaLHCb/Lib/LHCbDataset/LHCbDataset.py
@@ -218,6 +218,8 @@ class LHCbDataset(GangaDataset):
             _file = getDataFile(this_f)
             if _file is None:
                 _file = this_f
+            if not isinstance(_file, IGangaFile):
+                raise GangaException('Cannot extend LHCbDataset based on this object type: %s' % type(_file) )
             myName = _file.namePattern
             from GangaDirac.Lib.Files.DiracFile import DiracFile
             if isType(_file, DiracFile):


### PR DESCRIPTION
This is a short PR showing some tlc to areas of the code which throw full traces via vanilla ganga and make life difficult for lsst users trying to get used to the framework.

This fixes #1067 that I see when working with LSST people.