### PR TITLE
Save associated_files to xml

### DIFF
--- a/python/Ganga/GPIDev/Lib/File/File.py
+++ b/python/Ganga/GPIDev/Lib/File/File.py
@@ -300,10 +300,9 @@ class ShareDir(GangaObject):
 
     def getAssociatedFiles(self):
         if os.path.isfile(os.path.join(self.path(), 'associated_files.xml')):
-            fobj = open(os.path.join(self.path(), 'associated_files.xml'), "r")
-            tmpobj, errs = from_file(fobj)
-            self.associated_files = tmpobj
-            fobj.close()
+            with open(os.path.join(self.path(), 'associated_files.xml'), "r") as fobj:
+                tmpobj, errs = from_file(fobj)
+                self.associated_files = tmpobj
  
     def addAssociatedFile(self, newFile):
         self.getAssociatedFiles()

--- a/python/Ganga/GPIDev/Lib/File/File.py
+++ b/python/Ganga/GPIDev/Lib/File/File.py
@@ -299,12 +299,16 @@ class ShareDir(GangaObject):
         return self.executable or is_executable(expandfilename(self.name))
 
     def getAssociatedFiles(self):
+        """ Load the list of associated files from the saved XML. This is
+        necessary to keep the list consistent when copying jobs. """
         if os.path.isfile(os.path.join(self.path(), 'associated_files.xml')):
             with open(os.path.join(self.path(), 'associated_files.xml'), "r") as fobj:
                 tmpobj, errs = from_file(fobj)
                 self.associated_files = tmpobj
  
     def addAssociatedFile(self, newFile):
+        """ Add an associated file to the ShareDir. Use this method to save
+        it to theXML """
         self.getAssociatedFiles()
         self.associated_files.append(newFile)
         safe_save(os.path.join(self.path(), 'associated_files.xml'), self.associated_files, to_file)
@@ -318,6 +322,7 @@ class ShareDir(GangaObject):
         self.associated_files = None
 
     def listAssociatedFiles(self):
+        """ List the associated_files of the ShareDir """
         self.getAssociatedFiles()
         return self.associated_files
 

--- a/python/Ganga/GPIDev/Lib/File/File.py
+++ b/python/Ganga/GPIDev/Lib/File/File.py
@@ -12,6 +12,7 @@ from Ganga.GPIDev.Base.Proxy import stripProxy, GPIProxyObjectFactory
 from Ganga.GPIDev.Adapters.IGangaFile import IGangaFile
 from Ganga.Core.GangaRepository.VStreamer import to_file, from_file
 from Ganga.Core.GangaRepository.GangaRepositoryXML import safe_save
+from Ganga.GPIDev.Base.Objects import synchronised
 import os
 import shutil
 import uuid
@@ -298,6 +299,7 @@ class ShareDir(GangaObject):
         file are checked"""
         return self.executable or is_executable(expandfilename(self.name))
 
+    @synchronised
     def getAssociatedFiles(self):
         """ Load the list of associated files from the saved XML. This is
         necessary to keep the list consistent when copying jobs. """
@@ -305,7 +307,8 @@ class ShareDir(GangaObject):
             with open(os.path.join(self.path(), 'associated_files.xml'), "r") as fobj:
                 tmpobj, errs = from_file(fobj)
                 self.associated_files = tmpobj
- 
+
+    @synchronised 
     def addAssociatedFile(self, newFile):
         """ Add an associated file to the ShareDir. Use this method to save
         it to theXML """
@@ -313,6 +316,7 @@ class ShareDir(GangaObject):
         self.associated_files.append(newFile)
         safe_save(os.path.join(self.path(), 'associated_files.xml'), self.associated_files, to_file)
 
+    @synchronised
     def removeAssociatedFiles(self):
         """ Remove the files in the associated file list"""
         self.getAssociatedFiles()
@@ -321,6 +325,7 @@ class ShareDir(GangaObject):
                 entry.remove()
         self.associated_files = None
 
+    @synchronised
     def listAssociatedFiles(self):
         """ List the associated_files of the ShareDir """
         self.getAssociatedFiles()

--- a/python/Ganga/GPIDev/Lib/File/File.py
+++ b/python/Ganga/GPIDev/Lib/File/File.py
@@ -12,8 +12,6 @@ from Ganga.GPIDev.Base.Proxy import stripProxy, GPIProxyObjectFactory
 from Ganga.GPIDev.Adapters.IGangaFile import IGangaFile
 from Ganga.Core.GangaRepository.VStreamer import to_file, from_file
 from Ganga.Core.GangaRepository.GangaRepositoryXML import safe_save
-
-
 import os
 import shutil
 import uuid

--- a/python/Ganga/GPIDev/Lib/Registry/PrepRegistry.py
+++ b/python/Ganga/GPIDev/Lib/Registry/PrepRegistry.py
@@ -79,6 +79,16 @@ class ShareRef(GangaObject):
             self.name = {}
         return self.name
 
+    def __removeFromRef(self, dirName):
+	""" Remove the sharedir from the ShareRef"""
+        logger.debug("running increase() in prepregistry")
+        self._getSessionLock()
+
+        del self.__getName()[dirName]
+
+        self._setDirty()
+        self._releaseSessionLockAndFlush()
+
     @synchronised
     def registerForRemoval(self, shareddir):
         """
@@ -183,6 +193,7 @@ class ShareRef(GangaObject):
                 if self.__getName()[basedir] is 0:
 #                    shutil.rmtree(shareddir, ignore_errors=True)
                     shareddir.remove()
+                    self.__removeFromRef(basedir)
                     logger.info("Removed: %s" % shareddir.name)
         # if we try to decrease a shareref that doesn't exist, we just set the
         # corresponding shareref to 0

--- a/python/Ganga/GPIDev/Lib/Registry/PrepRegistry.py
+++ b/python/Ganga/GPIDev/Lib/Registry/PrepRegistry.py
@@ -79,16 +79,6 @@ class ShareRef(GangaObject):
             self.name = {}
         return self.name
 
-    def __removeFromRef(self, dirName):
-	""" Remove the sharedir from the ShareRef"""
-        logger.debug("running increase() in prepregistry")
-        self._getSessionLock()
-
-        del self.__getName()[dirName]
-
-        self._setDirty()
-        self._releaseSessionLockAndFlush()
-
     @synchronised
     def registerForRemoval(self, shareddir):
         """
@@ -193,7 +183,6 @@ class ShareRef(GangaObject):
                 if self.__getName()[basedir] is 0:
 #                    shutil.rmtree(shareddir, ignore_errors=True)
                     shareddir.remove()
-                    self.__removeFromRef(basedir)
                     logger.info("Removed: %s" % shareddir.name)
         # if we try to decrease a shareref that doesn't exist, we just set the
         # corresponding shareref to 0

--- a/python/Ganga/GPIDev/Lib/Registry/PrepRegistry.py
+++ b/python/Ganga/GPIDev/Lib/Registry/PrepRegistry.py
@@ -3,6 +3,7 @@ import shutil
 import time
 import copy
 import threading
+from Ganga.GPIDev.Lib.File import ShareDir
 from Ganga.Core.GangaRepository.Registry import Registry
 from Ganga.GPIDev.Base import GangaObject
 from Ganga.GPIDev.Base.Objects import synchronised
@@ -140,13 +141,13 @@ class ShareRef(GangaObject):
         shareddirname = os.path.join(getSharedPath(), os.path.basename(shareddir.name))
         basedir = os.path.basename(shareddirname)
         if os.path.isdir(shareddirname) and force is False:
-            if basedir not in self.__getName():
+            if shareddir not in self.__getName():
                 logger.debug('%s is not stored in the shareref metadata object...adding.' % basedir)
                 self.__getName()[basedir] = 1
             else:
                 self.__getName()[basedir] += 1
         elif not os.path.isdir(shareddirname) and force is True and basedir is not '':
-            if basedir not in self.__getName():
+            if shareddir not in self.__getName():
                 logger.debug('%s is not stored in the shareref metadata object...adding.' % basedir)
                 self.__getName()[basedir] = 1
             else:

--- a/python/Ganga/GPIDev/Lib/Registry/PrepRegistry.py
+++ b/python/Ganga/GPIDev/Lib/Registry/PrepRegistry.py
@@ -3,7 +3,6 @@ import shutil
 import time
 import copy
 import threading
-from Ganga.GPIDev.Lib.File import ShareDir
 from Ganga.Core.GangaRepository.Registry import Registry
 from Ganga.GPIDev.Base import GangaObject
 from Ganga.GPIDev.Base.Objects import synchronised
@@ -141,13 +140,13 @@ class ShareRef(GangaObject):
         shareddirname = os.path.join(getSharedPath(), os.path.basename(shareddir.name))
         basedir = os.path.basename(shareddirname)
         if os.path.isdir(shareddirname) and force is False:
-            if shareddir not in self.__getName():
+            if basedir not in self.__getName():
                 logger.debug('%s is not stored in the shareref metadata object...adding.' % basedir)
                 self.__getName()[basedir] = 1
             else:
                 self.__getName()[basedir] += 1
         elif not os.path.isdir(shareddirname) and force is True and basedir is not '':
-            if shareddir not in self.__getName():
+            if basedir not in self.__getName():
                 logger.debug('%s is not stored in the shareref metadata object...adding.' % basedir)
                 self.__getName()[basedir] = 1
             else:

--- a/python/GangaLHCb/Lib/RTHandlers/GaudiExecRTHandlers.py
+++ b/python/GangaLHCb/Lib/RTHandlers/GaudiExecRTHandlers.py
@@ -414,6 +414,11 @@ class GaudiExecDiracRTHandler(IRuntimeHandler):
         if app.getMetadata and not 'summary.xml' in outputsandbox:
             outputsandbox += ['summary.xml']
 
+        # Check a previously uploaded input is there in case of a job copy
+        if isinstance(app.uploadedInput, DiracFile):
+            if app.uploadedInput.getReplicas() == {}:
+                app.uploadedInput = None
+                logger.info("Previously uploaded cmake target missing from Dirac. Uploading it again.")
 
         if not isinstance(app.uploadedInput, DiracFile):
             generateDiracInput(app)

--- a/python/GangaLHCb/Lib/RTHandlers/GaudiExecRTHandlers.py
+++ b/python/GangaLHCb/Lib/RTHandlers/GaudiExecRTHandlers.py
@@ -269,7 +269,7 @@ def generateDiracInput(app):
     new_df = uploadLocalFile(job, os.path.basename(compressed_file), tmp_dir)
 
     app.uploadedInput = new_df
-    app.is_prepared.associated_files.append(DiracFile(lfn = new_df.lfn))
+    app.is_prepared.addAssociatedFile(DiracFile(lfn = new_df.lfn))
 
 def generateJobScripts(app, appendJobScripts):
     """
@@ -338,7 +338,7 @@ def generateDiracScripts(app):
 
     app.jobScriptArchive = new_df
 
-    app.is_prepared.associated_files.append(DiracFile(lfn=new_df.lfn))
+    app.is_prepared.addAssociatedFile(DiracFile(lfn=new_df.lfn))
 
 def uploadLocalFile(job, namePattern, localDir, should_del=True):
     """


### PR DESCRIPTION
This writes the list of `associated_files` from a `ShareDir` to an XML file in the shared directory. This means that if a job is copied and new files added, the original will know about them.

Also added to `GaudiExec` to check the existence of previously uploaded files in case users have been cleaning their grid areas between job submissions.