### PR TITLE
Temporarily remove proxy stuff for Atlas

### DIFF
--- a/python/GangaAtlas/Lib/ATLASDataset/DQ2Dataset.py
+++ b/python/GangaAtlas/Lib/ATLASDataset/DQ2Dataset.py
@@ -6,7 +6,7 @@
 ###############################################################################
 # A DQ2 dataset
 
-import sys, os, re, urllib, commands, imp, threading, time, fnmatch
+import sys, os, re, urllib, commands, imp, threading, time, fnmatch, getpass
 
 from Ganga.GPIDev.Lib.Dataset import Dataset
 from Ganga.GPIDev.Schema import *
@@ -2023,25 +2023,27 @@ class DQ2OutputDownloader(MTRunner):
 logger = getLogger()
 
 # New for DQ2 client 2.3.0
-from Ganga.GPIDev.Credentials_old import GridProxy
-gridProxy = GridProxy()
-if not gridProxy.isValid():
-    gridProxy.create()
+#from Ganga.GPIDev.Credentials_old import GridProxy
+#gridProxy = GridProxy()
+#if not gridProxy.isValid():
+#    gridProxy.create()
 
-username = gridProxy.identity(safe=True)
+#username = gridProxy.identity(safe=True)
 # Note: Allow missing nickname as if we can't create a proxy for some reason, we still want to start Ganga
-nickname = getNickname(allowMissingNickname=True)
-if nickname:
-    username = nickname
-os.environ['RUCIO_ACCOUNT'] = username
+#nickname = getNickname(allowMissingNickname=True)
+#if nickname:
+#    username = nickname
+os.environ['RUCIO_ACCOUNT'] = getpass.getuser()
 logger.debug("Using RUCIO_ACCOUNT = %s " %(os.environ['RUCIO_ACCOUNT'])) 
 
 # Again, if we don't have a valid proxy, don't attempt to create DQ2 object as it will just fail
-if gridProxy.isValid():
-    from dq2.clientapi.DQ2 import DQ2
-    dq2=DQ2(force_backend='rucio')
-else:
-    dq2 = None
+#if gridProxy.isValid():
+#    from dq2.clientapi.DQ2 import DQ2
+#    dq2=DQ2(force_backend='rucio')
+#else:
+#    dq2 = None
+
+dq2 = None
 
 from threading import Lock
 dq2_lock = Lock()

--- a/python/GangaAtlas/Lib/Athena/AthenaLocalRTHandler.py
+++ b/python/GangaAtlas/Lib/Athena/AthenaLocalRTHandler.py
@@ -394,16 +394,9 @@ class AthenaLocalRTHandler(IRuntimeHandler):
             jobid = "%d" % job.id
 
         # Generate output dataset name
-        if job.outputdata:
-            if job.outputdata._name=='DQ2OutputDataset':
-                dq2_datasetname = job.outputdata.datasetname
-                dq2_isGroupDS = job.outputdata.isGroupDS
-                dq2_groupname = job.outputdata.groupname
-            else:
-                dq2_datasetname = ''
-                dq2_isGroupDS = False
-                dq2_groupname = ''
-            self.output_datasetname, self.output_lfn = dq2outputdatasetname(dq2_datasetname, jobid, dq2_isGroupDS, dq2_groupname)
+        dq2_datasetname = ''
+        dq2_isGroupDS = False
+        dq2_groupname = ''
 
         # Expand Athena jobOptions
         if not app.option_file and not app.command_line:

--- a/python/GangaAtlas/Lib/Athena/DQ2JobSplitter.py
+++ b/python/GangaAtlas/Lib/Athena/DQ2JobSplitter.py
@@ -19,8 +19,8 @@ from GangaAtlas.Lib.ATLASDataset import DQ2Dataset
 from GangaAtlas.Lib.ATLASDataset.DQ2Dataset import *
 from Ganga.Utility.Config import getConfig, makeConfig, ConfigError
 
-from Ganga.GPIDev.Credentials_old import GridProxy
-gridProxy = GridProxy()
+#from Ganga.GPIDev.Credentials_old import GridProxy
+#gridProxy = GridProxy()
 
 logger = getLogger()
 


### PR DESCRIPTION
As Ganga is almost entirely used for local submission in Atlas at the moment and I've been having serious problems getting the proxy stuff working correctly, I've decided to temporarily 'deactivate' the proxy parts in GangaAtlas until I can get a chance to properly fix them. This should allow Ganga to be used efficiently where it's most needed in Atlas.