### PR TITLE
Bump pandatools and check if it's already there

### DIFF
--- a/python/GangaAtlas/Lib/Athena/Athena.py
+++ b/python/GangaAtlas/Lib/Athena/Athena.py
@@ -29,9 +29,14 @@ from Ganga.Lib.Mergers.Merger import *
 from Ganga.Core.GangaRepository import getRegistry
 from Ganga.GPIDev.Lib.File import ShareDir, File
 from Ganga.GPIDev.Base.Proxy import GPIProxyObjectFactory, GPIProxyObject
-
-from pandatools import AthenaUtils
 from Ganga.Utility.Plugin import allPlugins
+
+# importing pandatools can fail for no obvious reason
+try:
+    from pandatools import AthenaUtils
+except:
+    logger.error("Problems loading the pandatools library. Try setting up Panda before running Ganga using 'lsetup panda'")
+    raise
 
 def mktemp(extension,name,path):
     """Create a unique file"""

--- a/python/GangaAtlas/PACKAGE.py
+++ b/python/GangaAtlas/PACKAGE.py
@@ -32,7 +32,7 @@ _external_packages = {
                      'RUCIO_APPID' : 'ganga',
                      },
 
-    'panda-client' : { 'version' : '0.5.80',
+    'panda-client' : { 'version' : '0.5.91',
                        'syspath':['lib/python2.6/site-packages'],
                        'CONFIGEXTRACTOR_PATH':'etc/panda/share',
                        'PANDA_SYS':'.',
@@ -71,6 +71,12 @@ if sys.version_info[0] == 2 and sys.version_info[1] == 7:
     for p in _external_packages['rucio-clients']['syspath']:
         new_paths.append( p.replace('2.6', '2.7') )
     _external_packages['rucio-clients']['syspath'] = new_paths
+
+# if Panda is already setup, use that
+for p in sys.path:
+    if p.find("PandaClient") > -1:
+        del _external_packages['panda-client']
+        break
 
 setup = PackageSetup(_external_packages)
 

--- a/python/GangaPanda/PACKAGE.py
+++ b/python/GangaPanda/PACKAGE.py
@@ -8,12 +8,6 @@
 """
 
 _external_packages = {
-    'panda-client' : { 'version' : '0.5.80',
-                    'syspath':['lib/python2.6/site-packages'],
-                    'CONFIGEXTRACTOR_PATH':'etc/panda/share',
-                    'PANDA_SYS':'.',
-                    'noarch':True
-    } 
 }
 
 from Ganga.Utility.Setup import PackageSetup


### PR DESCRIPTION
This update the version of PandaClient that is shipped with Ganga and also uses the currently set up version if found.