### PR TITLE
Speed up Dirac submission

### DIFF
--- a/python/GangaDirac/Lib/Backends/DiracBase.py
+++ b/python/GangaDirac/Lib/Backends/DiracBase.py
@@ -281,6 +281,9 @@ class DiracBase(IBackend):
                 sjScript = sjScript.replace("output(result)", "resultdict.update({sjNo : result['Value']})")
                 if nSubjobs !=0 :
                     sjScript = sjScript.replace("from DIRAC.Core.Base.Script import parseCommandLine\nparseCommandLine()\n", "\n")
+                    sjScript = re.sub("from .*DIRAC\.Interfaces\.API.Dirac.* import Dirac.*","",sjScript)
+                    sjScript = re.sub("from .*DIRAC\.Interfaces\.API\..*Job import .*Job","",sjScript)
+                    sjScript = re.sub("dirac = Dirac.*\(\)","",sjScript)
                 masterScript += "\nsjNo=\'%s\'" % fqid
                 masterScript += sjScript
                 nSubjobs +=1

--- a/python/GangaDirac/Lib/Backends/DiracBase.py
+++ b/python/GangaDirac/Lib/Backends/DiracBase.py
@@ -273,11 +273,10 @@ class DiracBase(IBackend):
             masterScript = 'resultdict = {}\n'
             for sc, sj in zip(subjobconfigs[i*nPerProcess:(i+1)*nPerProcess], rjobs[i*nPerProcess:(i+1)*nPerProcess]):
                 #Add in the script for each subjob
-                b = stripProxy(sj.backend)
                 sj.updateStatus('submitting')
                 fqid = sj.getFQID('.')
                 #Change the output of the job script for our own ends. This is a bit of a hack but it saves having to rewrite every RTHandler
-                sjScript = b._job_script(sc, master_input_sandbox)
+                sjScript = self._job_script(sc, master_input_sandbox)
                 sjScript = sjScript.replace("output(result)", "resultdict.update({sjNo : result['Value']})")
                 if nSubjobs !=0 :
                     sjScript = sjScript.replace("from DIRAC.Core.Base.Script import parseCommandLine\nparseCommandLine()\n", "\n")

--- a/python/GangaDirac/Lib/Backends/DiracBase.py
+++ b/python/GangaDirac/Lib/Backends/DiracBase.py
@@ -22,7 +22,6 @@ from GangaDirac.Lib.Credentials.DiracProxy import DiracProxy
 from Ganga.Utility.ColourText import getColour
 from Ganga.Utility.Config import getConfig
 from Ganga.Utility.logging import getLogger, log_user_exception
-from Ganga.Utility.logic import implies
 from Ganga.GPIDev.Credentials import require_credential, credential_store, needed_credentials
 from Ganga.GPIDev.Base.Proxy import stripProxy, isType, getName
 from Ganga.Core.GangaThread.WorkerThreads import getQueues

--- a/python/GangaDirac/Lib/Backends/DiracBase.py
+++ b/python/GangaDirac/Lib/Backends/DiracBase.py
@@ -275,7 +275,7 @@ class DiracBase(IBackend):
                     masterScript += sjScript
 
                 masterScript += '\noutput(resultdict)\n'
-                dirac_script_filename = '/afs/cern.ch/user/m/masmith/mytest_dirac-script-%s.py' % i
+                dirac_script_filename = os.path.join(self.getJobObject().getInputWorkspace().getPath(),'dirac-script-%s.py') % i
                 with open(dirac_script_filename, 'w') as f:
                     f.write(masterScript)
                 getQueues()._monitoring_threadpool.add_function(self._hyperspeed_submit, (dirac_script_filename))
@@ -307,7 +307,7 @@ class DiracBase(IBackend):
             masterScript += sjScript
 
         masterScript += '\noutput(resultdict)\n'
-        dirac_script_filename = '/afs/cern.ch/user/m/masmith/mytest_dirac-script.py'
+        dirac_script_filename = os.path.join(self.getJobObject().getInputWorkspace().getPath(), 'dirac-script.py')
         with open(dirac_script_filename, 'w') as f:
             f.write(masterScript)
 

--- a/python/GangaDirac/Lib/Backends/DiracBase.py
+++ b/python/GangaDirac/Lib/Backends/DiracBase.py
@@ -96,8 +96,8 @@ class DiracBase(IBackend):
         'settings': SimpleItem(defvalue={'CPUTime': 2 * 86400},
                                doc='Settings for DIRAC job (e.g. CPUTime, BannedSites, etc.)'),
         'credential_requirements': ComponentItem('CredentialRequirement', defvalue=DiracProxy),
-        'hyperspeed_submit' : SimpleItem(defvalue=True, 
-                               doc='Shall we use the experimental hyperspeed submission?'),
+        'block_submit' : SimpleItem(defvalue=True, 
+                               doc='Shall we use the experimental block submission?'),
     })
     _exportmethods = ['getOutputData', 'getOutputSandbox', 'removeOutputData',
                       'getOutputDataLFNs', 'getOutputDataAccessURLs', 'peek', 'reset', 'debug']
@@ -183,8 +183,8 @@ class DiracBase(IBackend):
         return []
 
     @require_credential
-    def _hyperspeed_submit(self, myscript):
-        '''Submit the job via the Dirac server but do it at hyperspeed!
+    def _block_submit(self, myscript):
+        '''Submit a block of jobs via the Dirac server in one go.
         Args:
             dirac_script (str): filename of the JDL which is to be submitted to DIRAC
         '''
@@ -230,7 +230,7 @@ class DiracBase(IBackend):
         """
         from Ganga.Utility.logging import log_user_exception
 
-        if not self.hyperspeed_submit:
+        if not self.block_submit:
             return IBackend.master_submit(self, subjobconfigs, masterjobconfig, keep_joing, parallel_submit)
 
         logger.debug("SubJobConfigs: %s" % len(subjobconfigs))
@@ -282,9 +282,9 @@ class DiracBase(IBackend):
             logger.info("Submitting subjobs %s to %s" % (i*nPerProcess, upperlimit))
             #Either do the submission in parallel or sequentially
             if parallel_submit:
-                getQueues()._monitoring_threadpool.add_function(self._hyperspeed_submit, (dirac_script_filename))
+                getQueues()._monitoring_threadpool.add_function(self._block_submit, (dirac_script_filename))
             else:
-                self._hyperspeed_submit(dirac_script_filename)
+                self._block_submit(dirac_script_filename)
 
             def subjob_status_check(rjobs):
                 has_submitted = True

--- a/python/GangaDirac/Lib/Backends/DiracBase.py
+++ b/python/GangaDirac/Lib/Backends/DiracBase.py
@@ -209,7 +209,7 @@ class DiracBase(IBackend):
             raise BackendError('Dirac', err_msg)
 
         #Now put the list of Dirac IDs into the subjobs and get them monitored:
-        if len(result.keys())>1:
+        if len(j.subjobs)>0:
             for jobNo in result.keys():
                 sjNo = jobNo.split('.')[1]
                 j.subjobs[int(sjNo)].backend.id = result[jobNo]
@@ -221,7 +221,6 @@ class DiracBase(IBackend):
             j.updateStatus('submitted')
             j.time.timenow('submitted')
             stripProxy(j.info).increment()
-
         #Check that everything got submitted ok
         if len(result.keys()) != lenSubjobs:
             raise BackendError("Some subjobs failed to submit! Check their status!")
@@ -233,7 +232,6 @@ class DiracBase(IBackend):
         we can submit several subjobs in the same process. Therefore for each subjob we collect the code for
        the dirac-script into one large file that we then execute.
         """
-        from Ganga.Utility.logging import log_user_exception
         #If you want to go slowly use the regular master_submit:
         if not self.blockSubmit:
             return IBackend.master_submit(self, subjobconfigs, masterjobconfig, keep_joing, parallel_submit)
@@ -308,7 +306,6 @@ class DiracBase(IBackend):
                         has_submitted = False
                         break
                 return has_submitted
-
             while not subjob_status_check(rjobs):
                 import time
                 time.sleep(1.)

--- a/python/GangaDirac/Lib/Backends/DiracBase.py
+++ b/python/GangaDirac/Lib/Backends/DiracBase.py
@@ -157,7 +157,7 @@ class DiracBase(IBackend):
         dirac_cmd = """execfile(\'%s\')""" % dirac_script
 
         try:
-            result = execute(dirac_cmd, cred_req=self.credential_requirements, return_raw_dict = True)
+            result = execute(dirac_cmd, cred_req=self.credential_requirements)
         except GangaDiracError as err:
 
             err_msg = 'Error submitting job to Dirac: %s' % str(err)

--- a/python/GangaDirac/Lib/Backends/DiracBase.py
+++ b/python/GangaDirac/Lib/Backends/DiracBase.py
@@ -158,7 +158,6 @@ class DiracBase(IBackend):
 
         try:
             result = execute(dirac_cmd, cred_req=self.credential_requirements, return_raw_dict = True)
-            print result
         except GangaDiracError as err:
 
             err_msg = 'Error submitting job to Dirac: %s' % str(err)

--- a/python/GangaDirac/Lib/Backends/DiracBase.py
+++ b/python/GangaDirac/Lib/Backends/DiracBase.py
@@ -14,7 +14,7 @@ from collections import defaultdict
 from Ganga.GPIDev.Schema import Schema, Version, SimpleItem, ComponentItem
 from Ganga.GPIDev.Adapters.IBackend import IBackend, group_jobs_by_backend_credential
 from Ganga.GPIDev.Lib.Job.Job import Job
-from Ganga.Core.exceptions import GangaFileError, BackendError, IncompleteJobSubmissionError
+from Ganga.Core.exceptions import GangaFileError, GangaKeyError, BackendError, IncompleteJobSubmissionError
 from GangaDirac.Lib.Backends.DiracUtils import result_ok, get_job_ident, get_parametric_datasets, outputfiles_iterator, outputfiles_foreach, getAccessURLs
 from GangaDirac.Lib.Files.DiracFile import DiracFile
 from GangaDirac.Lib.Utilities.DiracUtilities import GangaDiracError, execute

--- a/python/GangaDirac/Lib/Backends/DiracBase.py
+++ b/python/GangaDirac/Lib/Backends/DiracBase.py
@@ -211,13 +211,18 @@ class DiracBase(IBackend):
             raise BackendError('Dirac', err_msg)
 
         #Now put the list of Dirac IDs into the subjobs and get them monitored:
-        for jobNo in result.keys():
-            sjNo = str(jobNo).split('.')[1]
-            j.subjobs[int(sjNo)].backend.id = result[jobNo]
-            j.subjobs[int(sjNo)].updateStatus('submitted')
+        if len(result.keys())>1:
+            for jobNo in result.keys():
+                sjNo = jobNo.split('.')[1]
+                j.subjobs[int(sjNo)].backend.id = result[jobNo]
+                j.subjobs[int(sjNo)].updateStatus('submitted')
+                j.time.timenow('submitted')
+                stripProxy(j.subjobs[int(sjNo)].info).increment()
+        else:
+            j.backend.id = result[result.keys()[0]]
+            j.updateStatus('submitted')
             j.time.timenow('submitted')
-            stripProxy(j.subjobs[int(sjNo)].info).increment()
-
+            stripProxy(j.info).increment()
         return type(self.id) == int
 
     def master_submit(self, rjobs, subjobconfigs, masterjobconfig, keep_going=False, parallel_submit=False):

--- a/python/GangaDirac/Lib/RTHandlers/DiracRTHScript.py.template
+++ b/python/GangaDirac/Lib/RTHandlers/DiracRTHScript.py.template
@@ -28,4 +28,6 @@ j.setParametricInputData(###PARAMETRIC_INPUTDATA###)
 # submit the job to dirac
 j.setPlatform( 'ANY' )
 result = dirac.submit(j)
-output(result)
+#output(result)
+diracid = result['Value']
+resultdict.update({sjNo : diracid})

--- a/python/GangaDirac/Lib/RTHandlers/DiracRTHScript.py.template
+++ b/python/GangaDirac/Lib/RTHandlers/DiracRTHScript.py.template
@@ -5,7 +5,6 @@ parseCommandLine()
 ###DIRAC_IMPORT###
 ###DIRAC_JOB_IMPORT###
 dirac = ###DIRAC_OBJECT###
-
 j = ###JOB_OBJECT###
 
 # default commands added by ganga

--- a/python/GangaDirac/Lib/RTHandlers/DiracRTHScript.py.template
+++ b/python/GangaDirac/Lib/RTHandlers/DiracRTHScript.py.template
@@ -5,6 +5,7 @@ parseCommandLine()
 ###DIRAC_IMPORT###
 ###DIRAC_JOB_IMPORT###
 dirac = ###DIRAC_OBJECT###
+
 j = ###JOB_OBJECT###
 
 # default commands added by ganga
@@ -28,6 +29,4 @@ j.setParametricInputData(###PARAMETRIC_INPUTDATA###)
 # submit the job to dirac
 j.setPlatform( 'ANY' )
 result = dirac.submit(j)
-#output(result)
-diracid = result['Value']
-resultdict.update({sjNo : diracid})
+output(result)

--- a/python/GangaDirac/__init__.py
+++ b/python/GangaDirac/__init__.py
@@ -92,6 +92,8 @@ if not _after_bootstrap:
     configDirac.addOption('proxyInitCmd', 'dirac-proxy-init', 'Configurable which sets the default proxy init command for DIRAC')
     configDirac.addOption('proxyInfoCmd', 'dirac-proxy-info', 'Configurable which sets the default proxy init command for DIRAC')
 
+    configDirac.addOption('maxSubjobsPerProcess', 500, 'Set the maximum number of subjobs to be submitted per process.')
+
 def standardSetup():
 
     import PACKAGE

--- a/python/GangaDirac/__init__.py
+++ b/python/GangaDirac/__init__.py
@@ -92,7 +92,7 @@ if not _after_bootstrap:
     configDirac.addOption('proxyInitCmd', 'dirac-proxy-init', 'Configurable which sets the default proxy init command for DIRAC')
     configDirac.addOption('proxyInfoCmd', 'dirac-proxy-info', 'Configurable which sets the default proxy init command for DIRAC')
 
-    configDirac.addOption('maxSubjobsPerProcess', 500, 'Set the maximum number of subjobs to be submitted per process.')
+    configDirac.addOption('maxSubjobsPerProcess', 100, 'Set the maximum number of subjobs to be submitted per process.')
 
 def standardSetup():
 


### PR DESCRIPTION
Fixes #1129 .
This just puts each submission into the same process. Currently goes from 130s to 23s (of which it looks like 16s are other overheads so only 7s for the subjob submission) for 23 subjobs.

Needs tidying and potentially new script templates although that will also affect RTHandlers.