### PR TITLE
Hard-code LHCbDirac platform for gcc49

### DIFF
--- a/python/GangaLHCb/Utility/LHCbDIRACenv.py
+++ b/python/GangaLHCb/Utility/LHCbDIRACenv.py
@@ -17,7 +17,7 @@ def select_dirac_version(wildcard):
     Find the LHCbDIRAC version that should be used based on the confuguration
     system. Wildcards can be used and soflinks are dereferenced.
     """
-    cmd = 'lb-run -l LHCbDIRAC'
+    cmd = 'lb-run -c x86_64-slc6-gcc49-opt -l LHCbDIRAC'
     out = execute(cmd)
     if out == '':
         raise PluginError("Can't find any LHCbDirac versions from '%s'" % cmd)
@@ -35,19 +35,21 @@ def select_dirac_version(wildcard):
 def store_dirac_environment():
     """Store the LHCbDIRAC environment in a cache file."""
 
-    platform_env_var = 'CMTCONFIG'
-    try:
-        platform = os.environ[platform_env_var]
-    except KeyError:
-        logger.error("Environment variable %s is missing. Can't cache LHCbDIRAC environment.", platform_env_var)
-        raise PluginError
+#    platform_env_var = 'CMTCONFIG'
+#    try:
+#        platform = os.environ[platform_env_var]
+#    except KeyError:
+#        logger.error("Environment variable %s is missing. Can't cache LHCbDIRAC environment.", platform_env_var)
+#        raise PluginError
+    #While LHCbDirac is only available for gcc49 we shall unfortunately hard-code the platform.
+    platform = 'x86_64-slc6-gcc49-opt'
 
     wildcard = Ganga.Utility.Config.getConfig('LHCb')['LHCbDiracVersion']
     diracversion = select_dirac_version(wildcard)
     fdir = join(expanduser("~/.cache/Ganga/GangaLHCb"), platform)
     fname = join(fdir, diracversion)
     if not exists(fname) or not getsize(fname):
-        cmd = 'lb-run LHCBDIRAC {version} python -c "import os; print(dict(os.environ))"'.format(version=diracversion)
+        cmd = 'lb-run -c x86_64-slc6-gcc49-opt LHCBDIRAC {version} python -c "import os; print(dict(os.environ))"'.format(version=diracversion)
         env = execute(cmd)
         if isinstance(env, str):
             try:


### PR DESCRIPTION
Currently this is the only platform LHCbDirac is available on. This just allows people to submit jobs with Ganga from any platform.

Note: #1054 has actually been fixed by a change to LbScripts.