### PR TITLE
Fix credential cache

### DIFF
--- a/python/Ganga/GPIDev/Adapters/ICredentialInfo.py
+++ b/python/Ganga/GPIDev/Adapters/ICredentialInfo.py
@@ -44,13 +44,13 @@ def cache(method):
                 time_before = -1
 
             if 'ccheck' in self.cache:
-                check_time = self.cache['cceck']
+                check_time = self.cache['ccheck']
             else:
                 check_time = time.time()
 
             # If the mtime has been changed, clear the cache
             if credential_store.enable_caching and os.path.exists(self.location):
-                if time.time() - check_time > getConfig('Credentials')['AtomicDelay']:
+                if (time.time() - check_time > getConfig('Credentials')['AtomicDelay']) or (abs(time.time() - time_before)  > getConfig('Credentials')['AtomicDelay']):
                     mtime = os.path.getmtime(self.location)
                     if mtime > self.cache['mtime']:
                         self.cache = {'mtime': mtime}

--- a/python/Ganga/GPIDev/Credentials/CredentialStore.py
+++ b/python/Ganga/GPIDev/Credentials/CredentialStore.py
@@ -315,7 +315,7 @@ class CredentialStore(GangaObject, collections.Mapping):
     def clear(self):
         # type: () -> None
         """
-        Remove all credentials in the system (without destorying them)
+        Remove all credentials in the system (without destroying them)
         """
         self.credentials = set()
 


### PR DESCRIPTION
Might fix #1141 - certainly fixes a bug that the credential cache doesn't update itself.

I also notice that the renewal command has a time limit of the last hour before expiry otherwise it doesn't do anything. That doesn't make sense to me - a casual user will type `renew()` and assume that the proxy will be valid for the next 24 hours before walking away. Are there any objections to changing that?