### PR TITLE
Bumped panda-client version

### DIFF
--- a/python/GangaAtlas/PACKAGE.py
+++ b/python/GangaAtlas/PACKAGE.py
@@ -32,7 +32,7 @@ _external_packages = {
                      'RUCIO_APPID' : 'ganga',
                      },
 
-    'panda-client' : { 'version' : '0.5.91',
+    'panda-client' : { 'version' : '0.5.94',
                        'syspath':['lib/python2.6/site-packages'],
                        'CONFIGEXTRACTOR_PATH':'etc/panda/share',
                        'PANDA_SYS':'.',


### PR DESCRIPTION
There was a problem found recently with the panda-client library that Ganga uses in that it wasn't tarring up the user area properly in some cases. This PR bumps the panda-client version to a working version. 