### PR TITLE
DIRAC resubmit bugfix

### DIFF
--- a/python/GangaDirac/Lib/Backends/DiracBase.py
+++ b/python/GangaDirac/Lib/Backends/DiracBase.py
@@ -472,7 +472,7 @@ class DiracBase(IBackend):
 
     def resubmit(self):
         """Resubmit a DIRAC job"""
-        if self.blockSubmit:
+        if self.blockSubmit and j.master.getInputWorkspace().getPath(), 'dirac-script-0.py'):
             return self._blockResubmit()
         else:
             return self._resubmit()

--- a/python/GangaDirac/Lib/Backends/DiracBase.py
+++ b/python/GangaDirac/Lib/Backends/DiracBase.py
@@ -472,8 +472,13 @@ class DiracBase(IBackend):
 
     def resubmit(self):
         """Resubmit a DIRAC job"""
-        if self.blockSubmit and j.master.getInputWorkspace().getPath(), 'dirac-script-0.py'):
-            return self._blockResubmit()
+        if self.blockSubmit:
+            if self.getJobObject().master and os.path.exists(os.path.join(self.getJobObject().master.getInputWorkspace().getPath(), 'dirac-script-0.py')):
+                return self._blockResubmit()
+            elif os.path.exists(os.path.join(self.getJobObject().getInputWorkspace().getPath(), 'dirac-script-0.py')):
+                return self._blockResubmit()
+            else:
+                return self._resubmit()
         else:
             return self._resubmit()
 

--- a/python/GangaDirac/Lib/Backends/DiracBase.py
+++ b/python/GangaDirac/Lib/Backends/DiracBase.py
@@ -472,10 +472,11 @@ class DiracBase(IBackend):
 
     def resubmit(self):
         """Resubmit a DIRAC job"""
+        j = self.getJobObject()
         if self.blockSubmit:
-            if self.getJobObject().master and os.path.exists(os.path.join(self.getJobObject().master.getInputWorkspace().getPath(), 'dirac-script-0.py')):
+            if j.master and os.path.exists(os.path.join(j.master.getInputWorkspace().getPath(), 'dirac-script-0.py')):
                 return self._blockResubmit()
-            elif os.path.exists(os.path.join(self.getJobObject().getInputWorkspace().getPath(), 'dirac-script-0.py')):
+            elif os.path.exists(os.path.join(j.getInputWorkspace().getPath(), 'dirac-script-0.py')):
                 return self._blockResubmit()
             else:
                 return self._resubmit()

--- a/python/GangaDirac/Lib/Backends/DiracBase.py
+++ b/python/GangaDirac/Lib/Backends/DiracBase.py
@@ -235,7 +235,7 @@ class DiracBase(IBackend):
         """
         #If you want to go slowly use the regular master_submit:
         if not self.blockSubmit:
-            return IBackend.master_submit(self, subjobconfigs, masterjobconfig, keep_joing, parallel_submit)
+            return IBackend.master_submit(self, subjobconfigs, masterjobconfig, keep_going, parallel_submit)
 
         #Otherwise use the block submit. Much of this is copied from IBackend
         logger.debug("SubJobConfigs: %s" % len(subjobconfigs))
@@ -472,14 +472,8 @@ class DiracBase(IBackend):
 
     def resubmit(self):
         """Resubmit a DIRAC job"""
-        j = self.getJobObject()
         if self.blockSubmit:
-            if j.master and os.path.exists(os.path.join(j.master.getInputWorkspace().getPath(), 'dirac-script-0.py')):
-                return self._blockResubmit()
-            elif os.path.exists(os.path.join(j.getInputWorkspace().getPath(), 'dirac-script-0.py')):
-                return self._blockResubmit()
-            else:
-                return self._resubmit()
+            return self._blockResubmit()
         else:
             return self._resubmit()
 
@@ -561,6 +555,10 @@ class DiracBase(IBackend):
         for fileName in os.listdir(scriptDir):
             if fnmatch.fnmatch(fileName, 'dirac-script-*.py'):
                 diracScriptFiles.append(fileName)
+
+        #Did we find any of the new style dirac scripts? If not try the old way as the job may have been submitted with an old ganga version.
+        if diracScriptFiles == []:
+            return self._resubmit()
 
         new_script_filename = ''
 


### PR DESCRIPTION
There is a slight bug in that jobs submitted to DIRAC with old ganga versions cannot be resubmitted with the latest - the `blockSubmit` attribute gets added with the default `true` to these old jobs so it tries to resubmit with the wrong method.

The fix just checks for the existence of the new-style `dirac-script-0.py` to confirm the job was originally submitted with `blockSubmit`, otherwise reverting to the old resubmit code.