### PR TITLE
Set py.test version in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # This first line will grab the requirements from setup.py
 -e .
 
-pytest
+pytest==3.2.5
 pytest-cov
 pytest-mock
 unittest2


### PR DESCRIPTION
Fixes `py.test` to 3.2.5 so the python2.6 Travis tests can run.