### PR TITLE
Fix for race condition

### DIFF
--- a/python/GangaDirac/Lib/Backends/DiracBase.py
+++ b/python/GangaDirac/Lib/Backends/DiracBase.py
@@ -1076,6 +1076,10 @@ class DiracBase(IBackend):
             if monitoring_component:
                 if monitoring_component.should_stop():
                     break
+            # Job has changed underneath us don't attempt to finalize
+            if j.backend.status not in finalised_statuses:
+                j.been_queued = False
+                continue
             if not configDirac['serializeBackend']:
                 getQueues()._monitoring_threadpool.add_function(DiracBase.job_finalisation,
                                                            args=(j, finalised_statuses[j.backend.status]),


### PR DESCRIPTION
User on LHCb dast list reported:

```
ERROR    Exception raised executing 'updateMonitoringInformation' in Thread 'Backend Monitor':
Traceback (most recent call last):
  File "/cvmfs/ganga.cern.ch/Ganga/install/6.7.3/python/Ganga/Core/GangaThread/WorkerThreads/WorkerThreadPool.py", line 115, in __worker_thread
    result = item.command_input.function(*these_args, **item.command_input.kwargs)
  File "/cvmfs/ganga.cern.ch/Ganga/install/6.7.3/python/GangaDirac/Lib/Backends/DiracBase.py", line 1242, in updateMonitoringInformation
    DiracBase.monitor_dirac_running_jobs(monitor_jobs_group, finalised_statuses)
  File "/cvmfs/ganga.cern.ch/Ganga/install/6.7.3/python/GangaDirac/Lib/Backends/DiracBase.py", line 1204, in monitor_dirac_running_jobs
    DiracBase.requeue_dirac_finished_jobs(requeue_job_list, finalised_statuses)
  File "/cvmfs/ganga.cern.ch/Ganga/install/6.7.3/python/GangaDirac/Lib/Backends/DiracBase.py", line 1081, in requeue_dirac_finished_jobs
    args=(j, finalised_statuses[j.backend.status]),
KeyError: 'Checking'
```

This should fix it