### PR TITLE
Use latest pytest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # This first line will grab the requirements from setup.py
 -e .
 
-pytest==3.2.5
+pytest
 pytest-cov
 pytest-mock
 unittest2


### PR DESCRIPTION
As we ditch python 2.6 we can use the latest pytest again.