### PR TITLE
Atlas exe use athena setup

### DIFF
--- a/ganga/GangaAtlas/Lib/Athena/Athena.py
+++ b/ganga/GangaAtlas/Lib/Athena/Athena.py
@@ -1163,7 +1163,7 @@ class Athena(IPrepareApp):
 
         # archive sources
         verbose = False
-        if self.atlas_exetype in ['EXE']: #and not self.athena_compile:  - for EXE, compilation decides what the tarball is called
+        if self.atlas_exetype in ['EXE'] and not self.useAthenaPackages: #and not self.athena_compile:  - for EXE, compilation decides what the tarball is called
             maxFileSize = config['EXE_MAXFILESIZE']
             archiveName, archiveFullName = create_tarball(self.userarea, runDir, currentDir, archiveDir, self.append_to_user_area, self.exclude_from_user_area, maxFileSize, self.useAthenaPackages, verbose, self.athena_compile )
 
@@ -1189,7 +1189,7 @@ class Athena(IPrepareApp):
 
         # Add InstallArea
         if not self.athena_compile: 
-            if not self.atlas_exetype in ['EXE']: 
+            if not self.atlas_exetype in ['EXE'] and not self.useAthenaPackages: 
                 nobuild = True
                 AthenaUtils.archiveInstallArea(self.userarea, self.grouparea, archiveName, archiveFullName, archiveDir, nobuild, verbose)
                 logger.info('Option athena_compile=%s. Adding InstallArea to %s ...', self.athena_compile, archiveFullName )

--- a/ganga/GangaAtlas/Lib/Athena/run-athena-new.sh
+++ b/ganga/GangaAtlas/Lib/Athena/run-athena-new.sh
@@ -147,6 +147,8 @@ if os.path.exists('input_files'):
             svcMgr.ByteStreamInputSvc.FullFileName = ic
         else:
             svcMgr.EventSelector.InputCollections = ic
+    except AttributeError:
+        jps.AthenaCommonFlags.FilesInput = ic
 
     if os.environ.has_key('MY_ATHENA_MAX_EVENTS') and os.environ['MY_ATHENA_MAX_EVENTS']:
         theApp.EvtMax = int(os.environ['MY_ATHENA_MAX_EVENTS'])

--- a/ganga/GangaAtlas/Lib/Athena/run-athena-new.sh
+++ b/ganga/GangaAtlas/Lib/Athena/run-athena-new.sh
@@ -248,4 +248,3 @@ cat output_files | while read filespec; do
 	fi
     done
 done
-

--- a/ganga/GangaAtlas/scripts/athena
+++ b/ganga/GangaAtlas/scripts/athena
@@ -6,7 +6,7 @@ import optparse
 import sys
 import os
 import re
-from Ganga.Core.exceptions import GangaException
+from GangaCore.Core.exceptions import GangaException
 
 usage = """
 ------------------
@@ -173,7 +173,8 @@ p.add_option('--configJEM', action='store', type='string', dest='configJEM', hel
 p.add_option('--overwriteQueuedata', action='store_true', help='Expert option: Enable overwriteQueuedata' )
 p.add_option('--overwriteQueuedataConfig', action='store', type='string', dest='overwriteQueuedataConfig', help='Expert option: Config string for overwriteQueuedata' )
 
-p.add_option('--useAthenaPackages', action='store_true', help='Enable to setup Athena env for PYARA' )
+p.add_option('--useAthenaPackages', action='store_true', help='Enable to setup Athena env for PYARA [Deprecated: is now the default. Use --noUserPackageSetup to turn off]' )
+p.add_option('--noUserPackageSetup', action='store_true', help='Disable the Athena setup of user packages for EXE jobs' )
 
 p.add_option('--transferredDS', action='store', type='string', dest='transferredDS', help='Specify a comma-separated list of patterns so that only datasets which match the given patterns are transferred when --outputlocation is set. Either \ or "" is required when a wildcard is used. If omitted, all datasets are transferred')
 
@@ -309,8 +310,9 @@ if opt.atlas_supp_stream:
 if opt.collectstats:
     j.application.collect_stats=True
 
-if opt.useAthenaPackages:
-    j.application.useAthenaPackages = True
+j.application.useAthenaPackages = True
+if opt.noUserPackageSetup:
+    j.application.useAthenaPackages = False
 if opt.useRootCore:
     j.application.useRootCore = True
 if opt.useRootCoreNoBuild:

--- a/ganga/GangaAtlas/scripts/athena
+++ b/ganga/GangaAtlas/scripts/athena
@@ -309,6 +309,8 @@ if opt.atlas_supp_stream:
 if opt.collectstats:
     j.application.collect_stats=True
 
+if opt.useAthenaPackages:
+    j.application.useAthenaPackages = True
 if opt.useRootCore:
     j.application.useRootCore = True
 if opt.useRootCoreNoBuild:
@@ -345,9 +347,6 @@ else:
                     j.application.prepare()
 	else:
 	    j.application.is_prepared=True
-
-if opt.useAthenaPackages:
-    j.application.useAthenaPackages = True
 
 if opt.cmtConfig:
     j.application.atlas_cmtconfig=opt.cmtConfig


### PR DESCRIPTION
This PR fixes some issues of `--useAthenaPackages` not working correctly for EXE jobs. It also adds a quick fix to very recent versions of Athena changing how to assign input files. In addition, the `--useAthenaPackages` option has been made the default and deprecated with an option added (`--noUserPackageSetup`) to disable as requested by Will Buttinger.