### PR TITLE
Updated Atlas.ini to remove startup messages

### DIFF
--- a/ganga/GangaAtlas/Atlas.ini
+++ b/ganga/GangaAtlas/Atlas.ini
@@ -55,3 +55,13 @@ se_type = srmv1
 
 [defaults_Athena]
 atlas_dbrelease = LATEST
+
+[MonitoringServices]
+Athena/LCG = GangaCore.Lib.MonitoringServices.ARDADashboard.LCG.ARDADashboardLCGAthena.ARDADashboardLCGAthena,GangaCore.Lib.MonitoringServices.MSGMS.MSGMS,GangaCore.Lib.MonitoringServices.Dashboard.LCGAthenaMS.LCGAthenaMS
+Athena/CREAM = GangaCore.Lib.MonitoringServices.ARDADashboard.LCG.ARDADashboardLCGAthena.ARDADashboardLCGAthena,GangaCore.Lib.MonitoringServices.MSGMS.MSGMS,GangaCore.Lib.MonitoringServices.Dashboard.LCGAthenaMS.LCGAthenaMS
+AthenaTask/LCG = GangaCore.Lib.MonitoringServices.ARDADashboard.LCG.ARDADashboardLCGAthena.ARDADashboardLCGAthena,GangaCore.Lib.MonitoringServices.MSGMS.MSGMS,GangaCore.Lib.MonitoringServices.Dashboard.LCGAthenaMS.LCGAthenaMS
+AthenaTask/CREAM = GangaCore.Lib.MonitoringServices.ARDADashboard.LCG.ARDADashboardLCGAthena.ARDADashboardLCGAthena,GangaCore.Lib.MonitoringServices.MSGMS.MSGMS,GangaCore.Lib.MonitoringServices.Dashboard.LCGAthenaMS.LCGAthenaMS
+AMAAthena/LCG = GangaCore.Lib.MonitoringServices.ARDADashboard.LCG.ARDADashboardLCGAthena.ARDADashboardLCGAthena,GangaCore.Lib.MonitoringServices.MSGMS.MSGMS,GangaCore.Lib.MonitoringServices.Dashboard.LCGAthenaMS.LCGAthenaMS
+AMAAthena/CREAM = GangaCore.Lib.MonitoringServices.ARDADashboard.LCG.ARDADashboardLCGAthena.ARDADashboardLCGAthena,GangaCore.Lib.MonitoringServices.MSGMS.MSGMS,GangaCore.Lib.MonitoringServices.Dashboard.LCGAthenaMS.LCGAthenaMS
+AMAAthenaTask/LCG = GangaCore.Lib.MonitoringServices.ARDADashboard.LCG.ARDADashboardLCGAthena.ARDADashboardLCGAthena,GangaCore.Lib.MonitoringServices.MSGMS.MSGMS,GangaCore.Lib.MonitoringServices.Dashboard.LCGAthenaMS.LCGAthenaMS
+AMAAthenaTask/CREAM = GangaCore.Lib.MonitoringServices.ARDADashboard.LCG.ARDADashboardLCGAthena.ARDADashboardLCGAthena,GangaCore.Lib.MonitoringServices.MSGMS.MSGMS,GangaCore.Lib.MonitoringServices.Dashboard.LCGAthenaMS.LCGAthenaMS

--- a/ganga/GangaAtlas/Atlas.ini
+++ b/ganga/GangaAtlas/Atlas.ini
@@ -3,11 +3,6 @@
 RUNTIME_PATH = GangaAtlas
 SCRIPTS_PATH = GangaAtlas/scripts 
 
-[defaults_GridProxy]
-validityAtCreation = 96:00
-minValidity = 72:00
-voms = atlas
-
 # Fix to allow LSF jobs to work after setting up with certain Athena releases
 # see https://github.com/ganga-devs/ganga/issues/1098
 [defaults_LSF]
@@ -31,16 +26,6 @@ vo = atlas
 
 [defaults_LCG]
 middleware=GLITE
-
-[MonitoringServices]
-Athena/LCG = Ganga.Lib.MonitoringServices.ARDADashboard.LCG.ARDADashboardLCGAthena.ARDADashboardLCGAthena,Ganga.Lib.MonitoringServices.MSGMS.MSGMS,Ganga.Lib.MonitoringServices.Dashboard.LCGAthenaMS.LCGAthenaMS
-Athena/CREAM = Ganga.Lib.MonitoringServices.ARDADashboard.LCG.ARDADashboardLCGAthena.ARDADashboardLCGAthena,Ganga.Lib.MonitoringServices.MSGMS.MSGMS,Ganga.Lib.MonitoringServices.Dashboard.LCGAthenaMS.LCGAthenaMS
-AthenaTask/LCG = Ganga.Lib.MonitoringServices.ARDADashboard.LCG.ARDADashboardLCGAthena.ARDADashboardLCGAthena,Ganga.Lib.MonitoringServices.MSGMS.MSGMS,Ganga.Lib.MonitoringServices.Dashboard.LCGAthenaMS.LCGAthenaMS
-AthenaTask/CREAM = Ganga.Lib.MonitoringServices.ARDADashboard.LCG.ARDADashboardLCGAthena.ARDADashboardLCGAthena,Ganga.Lib.MonitoringServices.MSGMS.MSGMS,Ganga.Lib.MonitoringServices.Dashboard.LCGAthenaMS.LCGAthenaMS
-AMAAthena/LCG = Ganga.Lib.MonitoringServices.ARDADashboard.LCG.ARDADashboardLCGAthena.ARDADashboardLCGAthena,Ganga.Lib.MonitoringServices.MSGMS.MSGMS,Ganga.Lib.MonitoringServices.Dashboard.LCGAthenaMS.LCGAthenaMS
-AMAAthena/CREAM = Ganga.Lib.MonitoringServices.ARDADashboard.LCG.ARDADashboardLCGAthena.ARDADashboardLCGAthena,Ganga.Lib.MonitoringServices.MSGMS.MSGMS,Ganga.Lib.MonitoringServices.Dashboard.LCGAthenaMS.LCGAthenaMS
-AMAAthenaTask/LCG = Ganga.Lib.MonitoringServices.ARDADashboard.LCG.ARDADashboardLCGAthena.ARDADashboardLCGAthena,Ganga.Lib.MonitoringServices.MSGMS.MSGMS,Ganga.Lib.MonitoringServices.Dashboard.LCGAthenaMS.LCGAthenaMS
-AMAAthenaTask/CREAM = Ganga.Lib.MonitoringServices.ARDADashboard.LCG.ARDADashboardLCGAthena.ARDADashboardLCGAthena,Ganga.Lib.MonitoringServices.MSGMS.MSGMS,Ganga.Lib.MonitoringServices.Dashboard.LCGAthenaMS.LCGAthenaMS
 
 [Logging]
 GangaAtlas = INFO


### PR DESCRIPTION
This updates the Atlas.ini file to prevent some unnecessary error messages appearing at startup in Ganga 7