### PR TITLE
Cache warnings

### DIFF
--- a/ganga/GangaCore/Utility/logging/__init__.py
+++ b/ganga/GangaCore/Utility/logging/__init__.py
@@ -385,7 +385,7 @@ class FlushedMemoryHandler(_MemHandler):
         The exception to this is when the MemHandler says we flush as we want to always flush then.
         """
         # Errors should be dumped in the correct place with the correct context
-        if record.levelno > logging.INFO:
+        if record.levelno > logging.WARNING:
             return True
         return (threading.currentThread().getName() == "MainThread") or \
                 _MemHandler.shouldFlush(self, record)


### PR DESCRIPTION
Fixes #1211 .

Instinctively I don't think we should cache `ERROR` but I don't feel strongly if anyone wants to cache them as well.