### PR TITLE
Bump submitting to submitted when recovering damaged jobs

### DIFF
--- a/ganga/GangaCore/GPIDev/Lib/Registry/JobRegistry.py
+++ b/ganga/GangaCore/GPIDev/Lib/Registry/JobRegistry.py
@@ -136,6 +136,8 @@ class JobRegistry(Registry):
                             _killJob(sj)
                             haveKilled = True
                     if not haveKilled:
+                        if v.status == 'submitting':
+                            v.updateStatus("submitted")
                         logger.warning("Job status re-updated after potential force-close")
                         v.updateMasterJobStatus()
                 else:


### PR DESCRIPTION
If the subjobs are `running` but the master is `submitting` the `updateMasterJobStatus` tries to update the master to `running` which is not an allowed transition. An exception is thrown and ganga exits before it starts.

This bumps the master to "submitted" before attempting to update the master job status to allow for the transition.