### PR TITLE
Fix Condor script

### DIFF
--- a/ganga/GangaCore/Lib/Condor/Condor.py
+++ b/ganga/GangaCore/Lib/Condor/Condor.py
@@ -144,7 +144,6 @@ class Condor(IBackend):
 
         cdfpath = self.preparejob(jobconfig, master_input_sandbox)
         status = self.submit_cdf(cdfpath)
-#        status = True
         return status
 
     def submit_cdf(self, cdfpath=""):

--- a/ganga/GangaCore/Lib/Condor/Condor.py
+++ b/ganga/GangaCore/Lib/Condor/Condor.py
@@ -287,7 +287,7 @@ class Condor(IBackend):
 
         fileList = []
         for filePath in infileList:
-            fileList.append(os.path.basename(filePath))
+            fileList.append(filePath)
 
         if job.name:
             name = job.name

--- a/ganga/GangaCore/Lib/Condor/Condor.py
+++ b/ganga/GangaCore/Lib/Condor/Condor.py
@@ -144,6 +144,7 @@ class Condor(IBackend):
 
         cdfpath = self.preparejob(jobconfig, master_input_sandbox)
         status = self.submit_cdf(cdfpath)
+#        status = True
         return status
 
     def submit_cdf(self, cdfpath=""):

--- a/ganga/GangaDirac/Lib/Files/DiracFile.py
+++ b/ganga/GangaDirac/Lib/Files/DiracFile.py
@@ -899,7 +899,7 @@ for f in glob.glob('###NAME_PATTERN###'):
                 lfn_folder = os.path.join('GangaFiles_%s' % this_date)
             lfn_base = os.path.join(DiracFile.diracLFNBase(self.credential_requirements), lfn_folder)
         else:
-            lfn_base = oa.path.join(DiracFile.diracLFNBase(self.credential_requirements), self.remoteDir)
+            lfn_base = os.path.join(DiracFile.diracLFNBase(self.credential_requirements), self.remoteDir)
 
 
         for this_file in outputFiles:


### PR DESCRIPTION
Fixes #1199 .

I *think* the issues is the taking of the `basename` that was giving a effectively `cp somefile.py /path/to/cwd/somefile.py` where really it should include the original file path to copy it to the cwd.

Needs testing. @nasfarley88 Could you try this?