### PR TITLE
Remove error handler from logging

### DIFF
--- a/ganga/GangaCore/Utility/logging/__init__.py
+++ b/ganga/GangaCore/Utility/logging/__init__.py
@@ -441,10 +441,6 @@ def _getLogger(name=None, modulename=None):
 
         _allLoggers[name] = logger
 
-        if error_handler is not None:
-            _set_formatter(error_handler, default_formatter)
-            logger.addHandler(error_handler)
-
         if name in config:
             thisConfig = config[name]
             _set_log_level(logger, thisConfig)


### PR DESCRIPTION
This removes the addition of an error handler to the loggers. It was causing some duplicates with errors:
```python
Ganga In [1]: a
ERROR    name 'a' is not defined
ERROR    name 'a' is not defined
```