### PR TITLE
Update VFT_make_ana.py

### DIFF
--- a/ganga/GangaND280/ND280RecoValidation/VFT_make_ana.py
+++ b/ganga/GangaND280/ND280RecoValidation/VFT_make_ana.py
@@ -117,7 +117,7 @@ class VFT_make_ana(IPrepareApp):
 
         if self.run_pdf:
           args.append('&&')
-          args.append('$ND280ANALYSISTOOLSROOT/macros/grtf/pdfgen/make_pdf.py')
+          args.append('${ND280ANALYSISTOOLSROOT:-${RECONUTILSROOT}}/macros/grtf/pdfgen/make_pdf.py')
 
           if not 'ana_output' in [self.pdf_rdp, self.pdf_mcp, self.pdf_oldrdp, self.pdf_oldmcp]:
             raise ApplicationConfigurationError('None of the pdf inputs is set to use the make_ana.py output. Please set "pdf_rdp", "pdf_mcp", "pdf_oldrdp", or "pdf_oldmcp" to the value "ana_output"')


### PR DESCRIPTION
Fixes #1248 

The "grtf" macros are possibly moved from nd280AnalysisTools into reconUtils.