### PR TITLE
Fix preprocessor import for Notebook submission.

### DIFF
--- a/ganga/GangaCore/Lib/Notebook/wrapperNotebookTemplate.py.template
+++ b/ganga/GangaCore/Lib/Notebook/wrapperNotebookTemplate.py.template
@@ -12,7 +12,7 @@ if __name__ == '__main__':
     print('Unique identifier : ','###UUID###')
     
     from IPython import nbformat
-    from IPython.nbconvert.preprocessors import ExecutePreprocessor
+    from nbconvert.preprocessors import ExecutePreprocessor
 
     files = os.listdir(os.getcwd())
 


### PR DESCRIPTION
This PR fixes #1260 

Replaced
https://github.com/ganga-devs/ganga/blob/cb18fa716605ac219e3f2ec354b05ab12adef7bc/ganga/GangaCore/Lib/Notebook/wrapperNotebookTemplate.py.template#L15

with 

```python
from nbconvert.preprocessors import ExecutePreprocessor
```