### PR TITLE
set localDir of LocalFile

### DIFF
--- a/ganga/GangaCore/GPIDev/Lib/File/LocalFile.py
+++ b/ganga/GangaCore/GPIDev/Lib/File/LocalFile.py
@@ -124,7 +124,7 @@ class LocalFile(IGangaFile):
 
             d = LocalFile(base_name)
             d.compressed = self.compressed
-
+            d.localDir = sourceDir
             self.subfiles.append(d)
 
     def processWildcardMatches(self):


### PR DESCRIPTION
Sets the `localDir` of the LocalFile when setting output file locations.