### PR TITLE
Set process name to Ganga

### DIFF
--- a/bin/ganga
+++ b/bin/ganga
@@ -55,6 +55,9 @@ import GangaCore.Runtime
 GangaCore.Runtime._prog = None
 import sys
 
+import prctl
+prctl.set_name('ganga')
+
 def log(level, err):
     # FIXME: for some reason self.logger.critical does not print any
     # messages here

--- a/ganga/GangaCore/test/Dockerfile
+++ b/ganga/GangaCore/test/Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:7
 LABEL maintainer "Alexander Richards <a.richards@imperial.ac.uk>"
 
-RUN yum install -y wget git python-virtualenv
+RUN yum install -y wget git python-virtualenv gcc libcap-dev
 
 WORKDIR /root
 

--- a/ganga/GangaDirac/test/Dockerfile
+++ b/ganga/GangaDirac/test/Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:7
 LABEL maintainer "Alexander Richards <a.richards@imperial.ac.uk>"
 
-RUN yum install -y wget git python-virtualenv
+RUN yum install -y wget git python-virtualenv gcc libcap-dev
 
 WORKDIR /root
 

--- a/ganga/GangaLHCb/test/Dockerfile
+++ b/ganga/GangaLHCb/test/Dockerfile
@@ -1,7 +1,7 @@
 FROM hepsw/cvmfs-lhcb:latest
 LABEL maintainer "Alexander Richards <a.richards@imperial.ac.uk>"
 
-RUN yum install -y wget git python-virtualenv glibc-devel gcc
+RUN yum install -y wget git python-virtualenv glibc-devel gcc libcap-dev
 
 WORKDIR /root
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ unittest2
 coverage
 pygments
 mock
+python-prctl


### PR DESCRIPTION
Sets the name of the process to `ganga` in `top` and `ps`.

This should be implemented at the same time as the update to `iPython 5` and the `absl-py` as it requires the installation of the `libcap-dev` library and `python-pctrl`