### PR TITLE
Add master job's DiracFiles inputfiles to input sandbox

### DIFF
--- a/ganga/GangaLHCb/Lib/RTHandlers/GaudiExecRTHandlers.py
+++ b/ganga/GangaLHCb/Lib/RTHandlers/GaudiExecRTHandlers.py
@@ -509,7 +509,6 @@ class GaudiExecDiracRTHandler(IRuntimeHandler):
         for opts_file in all_opts_files:
             if isinstance(opts_file, DiracFile):
                 inputsandbox += ['LFN:'+opts_file.lfn]
-
         # Sort out inputfiles we support
         for file_ in job.inputfiles:
             if isinstance(file_, DiracFile):
@@ -535,6 +534,11 @@ class GaudiExecDiracRTHandler(IRuntimeHandler):
 
         inputsandbox += ['LFN:'+app.uploadedInput.lfn]
         inputsandbox += ['LFN:'+app.jobScriptArchive.lfn]
+
+        #Now add in the missing DiracFiles from the master job
+        for file_ in master_job.inputfiles:
+            if isinstance(file_, DiracFile):
+                inputsandbox += ['LFN:'+file_.lfn]
 
         logger.debug("Input Sand: %s" % inputsandbox)
 


### PR DESCRIPTION
This fixes a bug that DiracFiles in the `inputfiles` for GaudiExec jobs get ignored. It is because in the master prepare when the sandbox gets made it only gathers together the local ones in order to tar them up, so the remote ones get forgotten about.