### PR TITLE
Extras for CVMFS virtualenv

### DIFF
--- a/bin/ganga
+++ b/bin/ganga
@@ -32,11 +32,16 @@ def standardSetup():
     """   
     import os.path
 
-    # insert the path to Ganga itself - this is required for the installation on CVMFS
+    # insert the path to Ganga itself - this is required for the installations without pip 
     exeDir = os.path.abspath(os.path.normpath(os.path.dirname(os.path.realpath(__file__))))
     gangaDir = os.path.join(os.path.dirname(exeDir), 'ganga' )
-
     sys.path.insert(0, gangaDir)
+
+    #On CVMFS we need to point to the site-packages directory as we don't start the virtualenv
+    if exeDir.startswith('/cvmfs/ganga.cern.ch', 0, 20):
+        envDir = exeDir[:-3]
+        envDir = os.path.join(envDir, 'lib/python2.7/site-packages')
+        sys.path.insert(0, envDir)    
 
     #This function is needed to add the individual ganga modules to the sys path - awful hack but saved rewriting all the code. This is needed for pip installs
     pathsToAdd = filter(lambda p : 'ganga' in os.listdir(p), filter(lambda x : not x=='' and os.path.isdir(x), sys.path))

--- a/bin/ganga
+++ b/bin/ganga
@@ -21,6 +21,12 @@
 from __future__ import print_function
 import sys
 
+#First make sure we are using a python version between 2.7 and 3
+if sys.version_info[0] != 2 or sys.version_info[1] < 7:
+    import logging
+    logging.error("Ganga does not support python version %s.%s.%s. Make sure you have a python version 2.7.x in your path" % (sys.version_info[0], sys.version_info[1], sys.version_info[2]))
+    sys.exit(-1)
+
 def standardSetup():
     """Function to perform standard setup for Ganga.
     """   


### PR DESCRIPTION
Some extra things for installing on CVMFS.
The first is to check that the user has python 2.7.
The second adds the virtualenvs site-packages directory to the path to access the requirements.