### PR TITLE
Fixing the missing LFN from input sandbox for exe

### DIFF
--- a/ganga/GangaDirac/Lib/Backends/DiracBase.py
+++ b/ganga/GangaDirac/Lib/Backends/DiracBase.py
@@ -317,7 +317,7 @@ class DiracBase(IBackend):
             if (upperlimit-1) == 0:
                 logger.info("Submitting job")
             else:
-                logger.info("Submitting subjobs")
+                logger.info("Submitting subjobs %s to %s" % (i*nPerProcess, upperlimit-1))
 
             try:
                 #Either do the submission in parallel with threads or sequentially
@@ -334,7 +334,7 @@ class DiracBase(IBackend):
             if (upperlimit-1) == 0:
                 logger.info("Submitted job")
             else:
-                logger.info("Submitted subjobs")
+                logger.info("Submitted subjobs %s to %s" % (i*nPerProcess, upperlimit-1))
 
         for i in rjobs:
             if i.status in ["new", "failed"]:

--- a/ganga/GangaDirac/Lib/Backends/DiracBase.py
+++ b/ganga/GangaDirac/Lib/Backends/DiracBase.py
@@ -313,7 +313,11 @@ class DiracBase(IBackend):
             upperlimit = (i+1)*nPerProcess
             if upperlimit > len(rjobs) :
                 upperlimit = len(rjobs)
-            logger.info("Submitting subjobs %s to %s" % (i*nPerProcess, upperlimit-1))
+
+            if (upperlimit-1) == 0:
+                logger.info("Submitting job")
+            else:
+                logger.info("Submitting subjobs")
 
             try:
                 #Either do the submission in parallel with threads or sequentially
@@ -327,7 +331,10 @@ class DiracBase(IBackend):
             finally:
                 shutil.rmtree(tmp_dir, ignore_errors = True)
                     
-            logger.info("Submitted subjobs %s to %s" % (i*nPerProcess, upperlimit-1))
+            if (upperlimit-1) == 0:
+                logger.info("Submitted job")
+            else:
+                logger.info("Submitted subjobs")
 
         for i in rjobs:
             if i.status in ["new", "failed"]:
@@ -360,11 +367,22 @@ class DiracBase(IBackend):
 
         input_sandbox += self._addition_sandbox_content(subjobconfig)
 
+        lfns = []
+
         ## Add LFN to the inputfiles section of the file
         if j.master:
             for this_file in j.master.inputfiles:
                 if isType(this_file, DiracFile):
-                    input_sandbox.append('LFN:'+str(this_file.lfn))
+                    lfns.append('LFN:'+str(this_file.lfn))
+        for this_file in j.inputfiles:
+            if isType(this_file, DiracFile):
+                lfns.append('LFN:'+str(this_file.lfn))
+
+        # Make sure we only add unique LFN
+        input_sandbox += set(lfns)
+
+        # Remove duplicates incase the LFN have also been added by any prior step
+        input_sandbox = list(set(input_sandbox))
 
         logger.debug("dirac_script: %s" % str(subjobconfig.getExeString()))
         logger.debug("sandbox_cont:\n%s" % str(input_sandbox))


### PR DESCRIPTION
This should fix #1297 

Hopefully this doesn't mess with other areas of the code too strongly but this fixes the strange job status update messages during submission as well as fixing the rendered JDL.


If people feel strongly this is the wrong approach to this as it's a little ugly then the best approach is to work out again exactly where an LFN is added, whether all of the splitters correctly copy the inputdata/sandbox from parent to subjobs etc.

Although this is a nicer approach I think the fix I'm suggesting is a little more pragmatic as it gets all of the Dirac inputfiles from the parent and subjob and afterwards removed duplicates before constructing the JDL. 

I've tested this with:
```
j=Job(backend=Dirac(),inputfiles=[DiracFile('LFN://some/lfn/file')],inputdata=GangaDataset([DiracFile('LFN://some/other/lfn')]),splitter=ArgSplitter(args=[[_,] for _ in range(3) ]));j.submit()
```

which correctly rendered a JDL with inputdata and inputfiles correctly separated.