### PR TITLE
Ganga swan integration

### DIFF
--- a/ganga/GangaCore/Core/GangaRepository/GangaRepositoryXML.py
+++ b/ganga/GangaCore/Core/GangaRepository/GangaRepositoryXML.py
@@ -12,6 +12,8 @@ import errno
 import copy
 import threading
 
+from GangaCore import GANGA_SWAN_INTEGRATION
+
 from GangaCore.Core.GangaRepository.SessionLock import SessionLockManager, dry_run_unix_locks
 from GangaCore.Core.GangaRepository.FixedLock import FixedLockManager
 
@@ -831,7 +833,8 @@ class GangaRepositoryLocal(GangaRepository):
                     new_idx_subset = True
 
                 if not old_idx_subset and not new_idx_subset:
-                    logger.warning("Incorrect index cache of '%s' object #%s was corrected!" % (self.registry.name, this_id))
+                    if not GANGA_SWAN_INTEGRATION:
+                        logger.warning("Incorrect index cache of '%s' object #%s was corrected!" % (self.registry.name, this_id))
                     logger.debug("old cache: %s\t\tnew cache: %s" % (obj._index_cache, new_idx_cache))
                     self.unlock([this_id])
             else:

--- a/ganga/GangaCore/Core/GangaRepository/SessionLock.py
+++ b/ganga/GangaCore/Core/GangaRepository/SessionLock.py
@@ -24,6 +24,7 @@ try:
 except ImportError:
     import pickle
 
+from GangaCore import GANGA_SWAN_INTEGRATION
 from GangaCore.Utility.logging import getLogger
 
 from GangaCore.Utility.Config.Config import getConfig, ConfigError
@@ -572,13 +573,17 @@ class SessionLockManager(object):
             # possible)
             fd = None
             try:
-                fd = os.open(self.fn, os.O_RDWR)
-                if not self.afs:
-                    fcntl.lockf(fd, fcntl.LOCK_EX)
-                os.write(fd, pickle.dumps(self.locked))
-                if not self.afs:
-                    fcntl.lockf(fd, fcntl.LOCK_UN)
-                os.fsync(fd)
+                if not GANGA_SWAN_INTEGRATION:
+                    fd = os.open(self.fn, os.O_RDWR)
+                    if not self.afs:
+                        fcntl.lockf(fd, fcntl.LOCK_EX)
+                    os.write(fd, pickle.dumps(self.locked))
+                    if not self.afs:
+                        fcntl.lockf(fd, fcntl.LOCK_UN)
+                    os.fsync(fd)
+                else:
+                    # Don't lock for sharing to other sessions.
+                    pass
             finally:
                 if fd is not None:
                     os.close(fd)
@@ -692,7 +697,9 @@ class SessionLockManager(object):
         if self.locked and max(self.locked) >= newcount:
             newcount = max(self.locked) + 1
         ids = range(newcount, newcount + n)
-        self.locked.update(ids)
+        if not GANGA_SWAN_INTEGRATION:
+            # If sharing sessions don't update id to locked.
+            self.locked.update(ids)
         self.count = newcount + n
         self.cnt_write()
         self.session_write()
@@ -734,7 +741,9 @@ class SessionLockManager(object):
             slocked.update(self.session_read(sf))
         #logger.debug( "locked: %s" % slocked)
         ids.difference_update(slocked)
-        self.locked.update(ids)
+        if not GANGA_SWAN_INTEGRATION:
+            # If sharing sessions don't update id to locked.
+            self.locked.update(ids)
         #logger.debug( "stored_lock: %s" % self.locked)
         self.session_write()
         #logger.debug( "list: %s" % list(ids))

--- a/ganga/GangaCore/Core/MonitoringComponent/Local_GangaMC_Service.py
+++ b/ganga/GangaCore/Core/MonitoringComponent/Local_GangaMC_Service.py
@@ -4,6 +4,7 @@ import time
 import copy
 from contextlib import contextmanager
 
+from GangaCore import GANGA_SWAN_INTEGRATION
 from GangaCore.Core.GangaThread import GangaThread
 from GangaCore.Core.GangaRepository import RegistryKeyError, RegistryLockError
 from GangaCore.Core.exceptions import CredentialRenewalError
@@ -523,6 +524,9 @@ class JobRegistry_Monitor(GangaThread):
 
         self._runningNow = False
 
+        if GANGA_SWAN_INTEGRATION:
+            self.newly_discovered_jobs = []
+
     def isEnabled( self, useRunning = True ):
         if useRunning:
             return self.enabled or self.__isInProgress() and not self.steps
@@ -541,6 +545,16 @@ class JobRegistry_Monitor(GangaThread):
         log.debug("Starting run method")
 
         while self.alive:
+            if GANGA_SWAN_INTEGRATION:
+                # Monitor Jobs from other sessions
+                new_jobs = stripProxy(self.registry_slice).objects.repository.update_index(True, True)
+                self.newly_discovered_jobs = list(set(self.newly_discovered_jobs) | set(new_jobs))
+                for i in self.newly_discovered_jobs:
+                    j = stripProxy(self.registry_slice(i))
+                    job_status = lazyLoadJobStatus(j)
+                    if job_status in ['new']:
+                        stripProxy(self.registry_slice).objects.repository.load([i])
+
             checkHeartBeat(JobRegistry_Monitor.global_count)
             log.debug("Monitoring Loop is alive")
             # synchronize the main loop since we can get disable requests
@@ -636,6 +650,18 @@ class JobRegistry_Monitor(GangaThread):
         self.__updateTimeStamp = time.time()
         self.__sleepCounter = config['base_poll_rate']
 
+    
+    def reloadJob(self, i):
+        """
+        Reload a Job from disk.
+        Parameters:
+        i: Job ID
+        Return:
+            True, if Job is successfully reloaded from disk.
+        """
+        stripProxy(self.registry_slice).objects.repository.load([i])
+        return True
+
     def runMonitoring(self, jobs=None, steps=1, timeout=300):
         """
         Enable/Run the monitoring loop and wait for the monitoring steps completion.
@@ -651,6 +677,17 @@ class JobRegistry_Monitor(GangaThread):
         """
 
         log.debug("runMonitoring")
+
+        if GANGA_SWAN_INTEGRATION:
+            # Detect New Jobs from other sessions.
+            new_jobs = stripProxy(self.registry_slice).objects.repository.update_index(True, True)
+            self.newly_discovered_jobs = list(set(self.newly_discovered_jobs) | set(new_jobs))
+            # Only load jobs from disk which are in new state currently.
+            for i in self.newly_discovered_jobs:
+                j = stripProxy(self.registry_slice(i))
+                job_status = lazyLoadJobStatus(j)
+                if job_status in ['new']:
+                    stripProxy(self.registry_slice).objects.repository.load([i])
 
         if not isType(steps, int) and steps < 0:
             log.warning("The number of monitor steps should be a positive (non-zero) integer")
@@ -941,6 +978,12 @@ class JobRegistry_Monitor(GangaThread):
     def __defaultActiveBackendsFunc(self):
         log.debug("__defaultActiveBackendsFunc")
         active_backends = {}
+        
+        if GANGA_SWAN_INTEGRATION:
+            # Detect new Jobs from other sessions
+            new_jobs = stripProxy(self.registry_slice).objects.repository.update_index(True, True)
+            self.newly_discovered_jobs = list(set(self.newly_discovered_jobs) | set(new_jobs))
+
         # FIXME: this is not thread safe: if the new jobs are added then
         # iteration exception is raised
         fixed_ids = self.registry_slice.ids()
@@ -951,6 +994,12 @@ class JobRegistry_Monitor(GangaThread):
                 j = stripProxy(self.registry_slice(i))
 
                 job_status = lazyLoadJobStatus(j)
+                
+                if GANGA_SWAN_INTEGRATION:
+                    # Load those Jobs from disk which are in new state to check if they are submitted
+                    # in other sessions
+                    if job_status in ['new']:
+                        stripProxy(self.registry_slice).objects.repository.load([i])
 
                 if job_status in ['submitted', 'running'] or (j.master and (job_status in ['submitting'])):
                     if self.enabled is True and self.alive is True:

--- a/ganga/GangaCore/Core/__init__.py
+++ b/ganga/GangaCore/Core/__init__.py
@@ -24,6 +24,7 @@ def bootstrap(reg_slice, interactive_session, my_interface=None):
             it to GangaCore.GPI
     """
     # Must do some Ganga imports here to avoid circular importing
+    from GangaCore import GANGA_SWAN_INTEGRATION
     from GangaCore.Core.MonitoringComponent.Local_GangaMC_Service import JobRegistry_Monitor
     from GangaCore.Utility.Config import getConfig
     from GangaCore.Runtime.GPIexport import exportToInterface
@@ -55,3 +56,5 @@ def bootstrap(reg_slice, interactive_session, my_interface=None):
         my_interface = GangaCore.GPI
 
     exportToInterface(my_interface, 'runMonitoring', monitoring_component.runMonitoring, 'Functions')
+    if GANGA_SWAN_INTEGRATION:
+        exportToInterface(my_interface, 'reloadJob', monitoring_component.reloadJob, 'Functions')

--- a/ganga/GangaCore/__init__.py
+++ b/ganga/GangaCore/__init__.py
@@ -6,6 +6,9 @@ import getpass
 import commands
 from GangaCore.Utility.ColourText import ANSIMarkup, overview_colours
 
+# Global Variable to enable Job Sharing mechanism required in GANGA SWAN INTEGRATION.
+# If environment variable GANGA_SWAN_INTEGRATION is present enable this mechanism.
+GANGA_SWAN_INTEGRATION = "GANGA_SWAN_INTEGRATION" in os.environ
 
 # Global Functions
 def getLCGRootPath():


### PR DESCRIPTION
Enable Ganga to share Jobs between multiple session such that one Ganga session can submit the Job and other session can monitor the same job and completes it.

Now there can be 2 sessions, Session-1 with Monitoring Enabled and Session-2 with Monitoring Disabled.

So, if user submits a Job in [2], the monitoring loop in [1] will pick the Job and update it. Now if a user wish to see the Job update in [2], he/she can run reloadJob(job_id) in [2] and the Job with id job_id will update from disk.

These changes can be enabled by creating an environment variable named `GANGA_SWAN_INTEGRATION`.