### PR TITLE
Small monitoring fix

### DIFF
--- a/ganga/GangaCore/Core/MonitoringComponent/Local_GangaMC_Service.py
+++ b/ganga/GangaCore/Core/MonitoringComponent/Local_GangaMC_Service.py
@@ -470,7 +470,7 @@ def get_jobs_in_bunches(jobList_fromset, blocks_of_size=5, stripProxies=True):
 
 
 class JobRegistry_Monitor(GangaThread):
-
+    """Job monitoring service thread."""
     
     uPollRate = 1.
     minPollRate = 1.

--- a/ganga/GangaCore/Core/MonitoringComponent/Local_GangaMC_Service.py
+++ b/ganga/GangaCore/Core/MonitoringComponent/Local_GangaMC_Service.py
@@ -361,8 +361,9 @@ class UpdateDict(object):
         entry.jobSet = set()
         entry.timeoutCounter = entry.timeoutCounterMax
 
-    def timeoutCheck(self):
-        for backend, entry in self.table.items():
+    @staticmethod
+    def timeoutCheck(thisDict):
+        for backend, entry in thisDict.table.items():
             # timeoutCounter is reset to its max value ONLY by a successful update action.
             #
             # Initial value and subsequent resets by timeoutCheck() will set the timeoutCounter
@@ -470,7 +471,7 @@ def get_jobs_in_bunches(jobList_fromset, blocks_of_size=5, stripProxies=True):
 
 class JobRegistry_Monitor(GangaThread):
 
-    """Job monitoring service thread."""
+    
     uPollRate = 1.
     minPollRate = 1.
     global_count = 0
@@ -504,11 +505,11 @@ class JobRegistry_Monitor(GangaThread):
         # Add credential checking to monitoring loop
         for afsToken in credential_store.get_all_matching_type(AfsToken()):
             log.debug("Setting callback hook for %s" % afsToken.location)
-            self.setCallbackHook(self.makeCredCheckJobInsertor(afsToken), {}, True, timeout=config['creds_poll_rate'])
+            self.setCallbackHook(JobRegistry_Monitor.makeCredCheckJobInsertor, {'thisMonitor': self, 'credObj': afsToken}, True, timeout=config['creds_poll_rate'])
 
         # Add low disk-space checking to monitoring loop
         log.debug("Setting callback hook for disk space checking")
-        self.setCallbackHook(self.diskSpaceCheckJobInsertor, {}, True, timeout=config['diskspace_poll_rate'])
+        self.setCallbackHook(JobRegistry_Monitor.diskSpaceCheckJobInsertor, {'thisMonitor': self}, True, timeout=config['diskspace_poll_rate'])
 
         # synch objects
         # main loop mutex
@@ -545,6 +546,10 @@ class JobRegistry_Monitor(GangaThread):
             log.debug("Monitoring Loop is alive")
             # synchronize the main loop since we can get disable requests
             with self.__mainLoopCond:
+
+                log.debug("steps: %s" % str(self.steps))
+                log.debug("%s" % str(self.registry_slice))
+
                 log.debug("Monitoring loop __mainLoopCond")
                 log.debug('Monitoring loop lock acquired. Running loop')
                 # we are blocked here while the loop is disabled
@@ -562,6 +567,8 @@ class JobRegistry_Monitor(GangaThread):
 
                 log.debug("Launching Monitoring Step")
                 self.__monStep()
+
+                log.debug("Finished Step")
 
                 # delay here the monitoring steps according to the
                 # configuration
@@ -624,14 +631,22 @@ class JobRegistry_Monitor(GangaThread):
                 log.debug("Running monitoring callback hook function %s(**%s)" %(cbHookFunc, cbHookEntry.argDict))
                 #self.callbackHookDict[cbHookFunc][0](**cbHookEntry.argDict)
                 try:
-                    self.callbackHookDict[cbHookFunc][0](**cbHookEntry.argDict)
+                    if 'self' in cbHookEntry.argDict:
+                        _argDict = copy.copy(cbHookEntry.argDict)
+                        __self = _argDict['self']
+                        del _argDict['self']
+                        (self.callbackHookDict[cbHookFunc][0])(self=__self, **(_argDict))
+                    else:
+                        (self.callbackHookDict[cbHookFunc][0])(**(cbHookEntry.argDict))
                 except Exception as err:
-                    log.debug("Caught Unknown Callback Exception")
-                    log.debug("Callback %s" % str(err))
+                    log.error("Caught Unknown Callback Exception")
+                    log.error("Callback:\n %s" % str(err))
                 cbHookEntry._lastRun = time.time()
 
         log.debug("\n\nRunning runClientCallbacks")
         self.runClientCallbacks()
+
+        log.debug("Finished runClientCallbacks")
 
         self.__updateTimeStamp = time.time()
         self.__sleepCounter = config['base_poll_rate']
@@ -696,9 +711,9 @@ class JobRegistry_Monitor(GangaThread):
                     log.warning('runMonitoring: jobs argument must be a registry slice such as a result of jobs.select() or jobs[i1:i2]')
                     return False
 
-                self.registry_slice = m_jobs
+                #self.registry_slice = m_jobs
                 #log.debug("m_jobs: %s" % str(m_jobs))
-                self.makeUpdateJobStatusFunction()
+                self.makeUpdateJobStatusFunction(jobSlice=m_jobs)
 
             log.debug("Enable Loop, Clear Iterators and setCallbackHook")
             # enable mon loop
@@ -708,7 +723,7 @@ class JobRegistry_Monitor(GangaThread):
             # enable job list iterators
             self.stopIter.clear()
             # Start backend update timeout checking.
-            self.setCallbackHook(self.updateDict_ts.timeoutCheck, {}, True)
+            self.setCallbackHook(UpdateDict.timeoutCheck, {'thisDict': self.updateDict_ts}, True)
 
             log.debug("Waking up Main Loop")
             # wake up the mon loop
@@ -746,7 +761,7 @@ class JobRegistry_Monitor(GangaThread):
             self.stopIter.clear()
             log.debug('Monitoring loop enabled')
             # Start backend update timeout checking.
-            self.setCallbackHook(self.updateDict_ts.timeoutCheck, {}, True)
+            self.setCallbackHook(UpdateDict.timeoutCheck, {'thisDict': self.updateDict_ts}, True)
             self.__mainLoopCond.notifyAll()
 
         return True
@@ -891,6 +906,8 @@ class JobRegistry_Monitor(GangaThread):
         func_name = getName(func)
         log.debug('Setting Callback hook function %s.' % func_name)
         log.debug('arg dict: %s' % str(argDict))
+        #if 'self' not in argDict:
+        #    argDict['self'] = self
         if func_name in self.callbackHookDict:
             log.debug('Replacing existing callback hook function %s with %s' % (str(self.callbackHookDict[func_name]), func_name))
         self.callbackHookDict[func_name] = [func, CallbackHookEntry(argDict=argDict, enabled=enabled, timeout=timeout)]
@@ -938,16 +955,20 @@ class JobRegistry_Monitor(GangaThread):
         else:
             log.error("%s not found in client callback dictionary." % getName(clientFunc))
 
-    def __defaultActiveBackendsFunc(self):
+    def __defaultActiveBackendsFunc(self, jobSlice=None):
         log.debug("__defaultActiveBackendsFunc")
         active_backends = {}
         # FIXME: this is not thread safe: if the new jobs are added then
         # iteration exception is raised
-        fixed_ids = self.registry_slice.ids()
+        if jobSlice is not None:
+            fixed_ids = jobSlice.ids()
+        else:
+            fixed_ids = self.registry_slice.ids()
         #log.debug("Registry: %s" % str(self.registry_slice))
         log.debug("Running over fixed_ids: %s" % str(fixed_ids))
         for i in fixed_ids:
             try:
+                # This is safe as it's addressing a job which _better_ be in the job repo
                 j = stripProxy(self.registry_slice(i))
 
                 job_status = lazyLoadJobStatus(j)
@@ -1092,10 +1113,14 @@ class JobRegistry_Monitor(GangaThread):
         log.debug("Finishing _checkBackend")
         return
 
-    def _checkActiveBackends(self, activeBackendsFunc):
+    @staticmethod
+    def _checkActiveBackends(thisMonitor, activeBackendsFunc, jobSlice):
 
         log.debug("calling function _checkActiveBackends")
-        activeBackends = activeBackendsFunc()
+        if jobSlice is None:
+            activeBackends = activeBackendsFunc()
+        else:
+            activeBackends = activeBackendsFunc(jobSlice=jobSlice)
 
         summary = '{'
         for this_backend, these_jobs in activeBackends.iteritems():
@@ -1121,13 +1146,13 @@ class JobRegistry_Monitor(GangaThread):
             #       of the particular backend is satisfied.
             #       This requires backends to hold relevant information on its
             #       credential requirements.
-            #log.debug("addEntry: %s, %s, %s, %s" % (str(backendObj), str(self._checkBackend), str(jList), str(pRate)))
-            self.updateDict_ts.addEntry(backendObj, self._checkBackend, jList, pRate)
+            #log.debug("addEntry: %s, %s, %s, %s" % (str(backendObj), str(thisMonitor._checkBackend), str(jList), str(pRate)))
+            thisMonitor.updateDict_ts.addEntry(backendObj, thisMonitor._checkBackend, jList, pRate)
             summary = str([stripProxy(x).getFQID('.') for x in jList])
             log.debug("jList: %s" % str(summary))
 
 
-    def makeUpdateJobStatusFunction(self, makeActiveBackendsFunc=None):
+    def makeUpdateJobStatusFunction(self, makeActiveBackendsFunc=None, jobSlice=None):
         log.debug("makeUpdateJobStatusFunction")
         if makeActiveBackendsFunc is None:
             makeActiveBackendsFunc = self.__defaultActiveBackendsFunc
@@ -1135,30 +1160,29 @@ class JobRegistry_Monitor(GangaThread):
         if self.updateJobStatus is not None:
             self.removeCallbackHook(self.updateJobStatus)
         self.updateJobStatus = self._checkActiveBackends
-        self.setCallbackHook(self._checkActiveBackends, {'activeBackendsFunc': makeActiveBackendsFunc}, True)
+        self.setCallbackHook(self._checkActiveBackends, {'thisMonitor': self, 'activeBackendsFunc': makeActiveBackendsFunc, 'jobSlice': jobSlice}, True)
         log.debug("Returning")
         return self.updateJobStatus
 
-    def makeCredCheckJobInsertor(self, credObj):
-        def credCheckJobInsertor():
-            def cb_Success():
-                self.enableCallbackHook(credCheckJobInsertor)
+    @staticmethod
+    def makeCredCheckJobInsertor(thisMonitor, credObj):
+        def cb_Success():
+            thisMonitor.enableCallbackHook(credCheckJobInsertor)
 
-            def cb_Failure():
-                self.enableCallbackHook(credCheckJobInsertor)
-                self._handleError('%s checking failed!' % getName(credObj), getName(credObj), False)
+        def cb_Failure():
+            thisMonitor.enableCallbackHook(credCheckJobInsertor)
+            thisMonitor._handleError('%s checking failed!' % getName(credObj), getName(credObj), False)
 
-            log.debug('Inserting %s checking function to Qin.' % getName(credObj))
-            _action = JobAction(function=self.makeCredChecker(credObj),
-                                callback_Success=cb_Success,
-                                callback_Failure=cb_Failure)
-            self.disableCallbackHook(credCheckJobInsertor)
-            try:
-                Qin.put(_action)
-            except Exception as err:
-                log.debug("makeCred Err: %s" % str(err))
-                cb_Failure("Put _action failure: %s" % str(_action), "unknown", True )
-        return credCheckJobInsertor
+        log.debug('Inserting %s checking function to Qin.' % getName(credObj))
+        _action = JobAction(function=thisMonitor.makeCredChecker(credObj),
+                            callback_Success=cb_Success,
+                            callback_Failure=cb_Failure)
+        thisMonitor.disableCallbackHook(credCheckJobInsertor)
+        try:
+            Qin.put(_action)
+        except Exception as err:
+           log.debug("makeCred Err: %s" % str(err))
+           cb_Failure("Put _action failure: %s" % str(_action), "unknown", True )
 
     def makeCredChecker(self, credObj):
         def credChecker():
@@ -1175,22 +1199,23 @@ class JobRegistry_Monitor(GangaThread):
                 return True
         return credChecker
 
-    def diskSpaceCheckJobInsertor(self):
+    @staticmethod
+    def diskSpaceCheckJobInsertor(thisMonitor):
         """
         Inserts the disk space checking task in the monitoring task queue
         """
         def cb_Success():
-            self.enableCallbackHook(self.diskSpaceCheckJobInsertor)
+            thisMonitor.enableCallbackHook(thisMonitor.diskSpaceCheckJobInsertor)
 
         def cb_Failure():
-            self.disableCallbackHook(self.diskSpaceCheckJobInsertor)
-            self._handleError('Available disk space checking failed and it has been disabled!', 'DiskSpaceChecker', False)
+            thisMonitor.disableCallbackHook(thisMonitor.diskSpaceCheckJobInsertor)
+            thisMonitor._handleError('Available disk space checking failed and it has been disabled!', 'DiskSpaceChecker', False)
 
         log.debug('Inserting disk space checking function to Qin.')
         _action = JobAction(function=Coordinator._diskSpaceChecker,
                             callback_Success=cb_Success,
                             callback_Failure=cb_Failure)
-        self.disableCallbackHook(self.diskSpaceCheckJobInsertor)
+        thisMonitor.disableCallbackHook(thisMonitor.diskSpaceCheckJobInsertor)
         try:
             Qin.put(_action)
         except Exception as err:

--- a/ganga/GangaCore/test/GPI/FileTests/TestLocalFileClient.py
+++ b/ganga/GangaCore/test/GPI/FileTests/TestLocalFileClient.py
@@ -44,10 +44,13 @@ class TestLocalFileClient(GangaUnitTest):
             j.remove()
 
     @classmethod
-    def tearDownClass(cls):
+    def tearDownTest(cls):
         """ Cleanup the current temp objects """
         for file_ in TestLocalFileClient._managed_files:
-            os.unlink(file_)
+            if os.path.isfile(file_):
+                os.unlink(file_)
+            else:
+                print("ERROR REMOVING FILE: '%s'" % str(file_))
         TestLocalFileClient._managed_files = []
 
     def test_a_testClientSideSubmit(self):

--- a/ganga/GangaCore/test/GPI/FileTests/TestMassStorageClient.py
+++ b/ganga/GangaCore/test/GPI/FileTests/TestMassStorageClient.py
@@ -54,17 +54,20 @@ class TestMassStorageClient(GangaUnitTest):
             j.remove()
 
     @classmethod
-    def setUpClass(cls):
+    def setUpTest(cls):
         """ This creates a safe place to put the files into 'mass-storage' """
         cls.outputFilePath = tempfile.mkdtemp()
         cls.MassStorageTestConfig['uploadOptions']['path'] = cls.outputFilePath
 
     @classmethod
-    def tearDownClass(cls):
+    def tearDownTest(cls):
         """ Cleanup the current temp objects """
 
         for file_ in cls._managed_files:
-            os.unlink(file_)
+            if os.path.isfile(file_):
+                os.unlink(file_)
+            else:
+                print("ERROR REMOVING FILE: '%s'" % str(file_))
         cls._managed_files = []
 
         shutil.rmtree(cls.outputFilePath, ignore_errors=True)

--- a/ganga/GangaCore/test/GPI/FileTests/TestMassStorageGetPut.py
+++ b/ganga/GangaCore/test/GPI/FileTests/TestMassStorageGetPut.py
@@ -54,24 +54,32 @@ class TestMassStorageGetPut(GangaUnitTest):
             j.remove()
 
     @classmethod
-    def setUpClass(cls):
+    def setUpTest(cls):
         """ This creates a safe place to put the files into 'mass-storage' """
         cls.outputFilePath = tempfile.mkdtemp()
         cls.MassStorageTestConfig['uploadOptions']['path'] = cls.outputFilePath
 
     @classmethod
-    def tearDownClass(cls):
+    def tearDownTest(cls):
         """ Cleanup the current temp objects """
 
-        for file_ in cls._temp_files:
-            os.unlink(file_)
-        cls._temp_files = []
-
-        for file_ in cls._managed_files:
-            os.unlink(os.path.join(cls.outputFilePath, file_.namePattern))
-        cls._managed_files = []
-
-        shutil.rmtree(cls.outputFilePath, ignore_errors=True)
+	pass
+#        for file_ in cls._temp_files:
+#            if os.path.isfile(file_):
+#                os.unlink(file_)
+#            else:
+#                print("ERROR REMOVING FILE: '%s'" % str(file_))
+#        cls._temp_files = []
+#
+#        for file_ in cls._managed_files:
+#            file__  = os.path.join(cls.outputFilePath, file_.namePattern)
+#            if os.path.isfile(file__):
+#                os.unlink(file__)
+#            else:
+#                print("ERROR REMOVING FILE: '%s'" % str(file__))
+#        cls._managed_files = []
+#
+#        shutil.rmtree(cls.outputFilePath, ignore_errors=True)
 
     def test_a_test_put(self):
         """Test that a job can be submitted with inputfiles in the input"""
@@ -104,6 +112,7 @@ class TestMassStorageGetPut(GangaUnitTest):
 
         # Test in the case that the files don't have a parent or a localDir
         for file_ in self._managed_files:
+            print("file_: %s" % file_)
             file_.localDir = ''
             try:
                 assert file_.localDir == ''
@@ -119,6 +128,7 @@ class TestMassStorageGetPut(GangaUnitTest):
             file_.localDir = tmpdir
             print("localDir: %s" % file_.localDir)
             file_.get()
+            print("file_: %s" % str(file_))
             assert os.path.isfile(os.path.join(tmpdir, file_.namePattern))
             file_.localDir = ''
             assert file_.localDir == ''

--- a/ganga/GangaCore/test/GPI/FileTests/TestMassStorageInput.py
+++ b/ganga/GangaCore/test/GPI/FileTests/TestMassStorageInput.py
@@ -52,16 +52,19 @@ class TestMassStorageClientInput(GangaUnitTest):
             j.remove()
 
     @classmethod
-    def setUpClass(cls):
+    def setUpTest(cls):
         """ This creates a safe place to put the files into 'mass-storage' """
         cls.outputFilePath = tempfile.mkdtemp()
         cls.MassStorageTestConfig['uploadOptions']['path'] = cls.outputFilePath
 
     @classmethod
-    def tearDownClass(cls):
+    def tearDownTest(cls):
         """ Cleanup the current temp objects """ 
         for file_ in cls._managed_files:
-            os.unlink(file_)
+            if os.path.isfile(file_):
+                os.unlink(file_)
+            else:
+                print("ERROR REMOVING FILE: '%s'" % str(file_))
         cls._managed_files = []
 
         shutil.rmtree(cls.outputFilePath, ignore_errors=True)

--- a/ganga/GangaCore/test/GPI/FileTests/TestMassStorageWN.py
+++ b/ganga/GangaCore/test/GPI/FileTests/TestMassStorageWN.py
@@ -56,16 +56,19 @@ class TestMassStorageWN(GangaUnitTest):
             j.remove()
 
     @classmethod
-    def setUpClass(cls):
+    def setUpTest(cls):
         """ This creates a safe place to put the files into 'mass-storage' """
         cls.outputFilePath = tempfile.mkdtemp()
         cls.MassStorageTestConfig['uploadOptions']['path'] = cls.outputFilePath
 
     @classmethod
-    def tearDownClass(cls):
+    def tearDownTest(cls):
         """ Cleanup the current temp objects """
         for file_ in cls._managed_files:
-            os.unlink(file_)
+            if os.path.isfile(file_):
+                os.unlink(file_)
+            else:
+                print("ERROR REMOVING FILE: '%s'" % str(file_))
         cls._managed_files = []
 
         shutil.rmtree(cls.outputFilePath, ignore_errors=True)

--- a/ganga/GangaCore/testlib/GangaUnitTest.py
+++ b/ganga/GangaCore/testlib/GangaUnitTest.py
@@ -303,6 +303,8 @@ class GangaUnitTest(unittest.TestCase):
         TODO, would it be better to move the folder first, then remove it incase of broken locks etc,?
         """
         shutil.rmtree(cls.gangadir(), ignore_errors=True)
+        if hasattr(cls, 'setUpTest'):
+            cls.setUpTest()
 
     def setUp(self, extra_opts=[]):
         """
@@ -345,4 +347,7 @@ class GangaUnitTest(unittest.TestCase):
             shutil.rmtree(cls._test_dir, ignore_errors=True)
         cls._test_dir = ''
         cls._test_args = {}
+
+        if hasattr(cls, 'tearDownTest'):
+            cls.tearDownTest()
 

--- a/ganga/GangaDirac/Lib/Backends/DiracBase.py
+++ b/ganga/GangaDirac/Lib/Backends/DiracBase.py
@@ -313,11 +313,7 @@ class DiracBase(IBackend):
             upperlimit = (i+1)*nPerProcess
             if upperlimit > len(rjobs) :
                 upperlimit = len(rjobs)
-
-            if (upperlimit-1) == 0:
-                logger.info("Submitting job")
-            else:
-                logger.info("Submitting subjobs")
+            logger.info("Submitting subjobs %s to %s" % (i*nPerProcess, upperlimit-1))
 
             try:
                 #Either do the submission in parallel with threads or sequentially
@@ -330,11 +326,7 @@ class DiracBase(IBackend):
                     time.sleep(1.)
             finally:
                 shutil.rmtree(tmp_dir, ignore_errors = True)
-                    
-            if (upperlimit-1) == 0:
-                logger.info("Submitted job")
-            else:
-                logger.info("Submitted subjobs")
+            logger.info("Submitting subjobs %s to %s" % (i*nPerProcess, upperlimit-1))                    
 
         for i in rjobs:
             if i.status in ["new", "failed"]:
@@ -367,22 +359,11 @@ class DiracBase(IBackend):
 
         input_sandbox += self._addition_sandbox_content(subjobconfig)
 
-        lfns = []
-
         ## Add LFN to the inputfiles section of the file
         if j.master:
             for this_file in j.master.inputfiles:
                 if isType(this_file, DiracFile):
-                    lfns.append('LFN:'+str(this_file.lfn))
-        for this_file in j.inputfiles:
-            if isType(this_file, DiracFile):
-                lfns.append('LFN:'+str(this_file.lfn))
-
-        # Make sure we only add unique LFN
-        input_sandbox += set(lfns)
-
-        # Remove duplicates incase the LFN have also been added by any prior step
-        input_sandbox = list(set(input_sandbox))
+                    input_sandbox.append('LFN:'+str(this_file.lfn))        
 
         logger.debug("dirac_script: %s" % str(subjobconfig.getExeString()))
         logger.debug("sandbox_cont:\n%s" % str(input_sandbox))

--- a/ganga/GangaDirac/Lib/Backends/DiracBase.py
+++ b/ganga/GangaDirac/Lib/Backends/DiracBase.py
@@ -326,7 +326,7 @@ class DiracBase(IBackend):
                     time.sleep(1.)
             finally:
                 shutil.rmtree(tmp_dir, ignore_errors = True)
-
+                    
             logger.info("Submitted subjobs %s to %s" % (i*nPerProcess, upperlimit-1))
 
         for i in rjobs:

--- a/ganga/GangaDirac/Lib/Backends/DiracBase.py
+++ b/ganga/GangaDirac/Lib/Backends/DiracBase.py
@@ -326,7 +326,7 @@ class DiracBase(IBackend):
                     time.sleep(1.)
             finally:
                 shutil.rmtree(tmp_dir, ignore_errors = True)
-            logger.info("Submitting subjobs %s to %s" % (i*nPerProcess, upperlimit-1))                    
+            logger.info("Submitted subjobs %s to %s" % (i*nPerProcess, upperlimit-1))
 
         for i in rjobs:
             if i.status in ["new", "failed"]:
@@ -363,7 +363,7 @@ class DiracBase(IBackend):
         if j.master:
             for this_file in j.master.inputfiles:
                 if isType(this_file, DiracFile):
-                    input_sandbox.append('LFN:'+str(this_file.lfn))        
+                    input_sandbox.append('LFN:'+str(this_file.lfn))
 
         logger.debug("dirac_script: %s" % str(subjobconfig.getExeString()))
         logger.debug("sandbox_cont:\n%s" % str(input_sandbox))

--- a/ganga/GangaDirac/Lib/Backends/DiracBase.py
+++ b/ganga/GangaDirac/Lib/Backends/DiracBase.py
@@ -313,7 +313,11 @@ class DiracBase(IBackend):
             upperlimit = (i+1)*nPerProcess
             if upperlimit > len(rjobs) :
                 upperlimit = len(rjobs)
-            logger.info("Submitting subjobs %s to %s" % (i*nPerProcess, upperlimit-1))
+
+            if (upperlimit-1) == 0:
+                logger.info("Submitting job")
+            else:
+                logger.info("Submitting subjobs")
 
             try:
                 #Either do the submission in parallel with threads or sequentially
@@ -327,7 +331,10 @@ class DiracBase(IBackend):
             finally:
                 shutil.rmtree(tmp_dir, ignore_errors = True)
                     
-            logger.info("Submitted subjobs %s to %s" % (i*nPerProcess, upperlimit-1))
+            if (upperlimit-1) == 0:
+                logger.info("Submitted job")
+            else:
+                logger.info("Submitted subjobs")
 
         for i in rjobs:
             if i.status in ["new", "failed"]:
@@ -360,11 +367,22 @@ class DiracBase(IBackend):
 
         input_sandbox += self._addition_sandbox_content(subjobconfig)
 
+        lfns = []
+
         ## Add LFN to the inputfiles section of the file
         if j.master:
             for this_file in j.master.inputfiles:
                 if isType(this_file, DiracFile):
-                    input_sandbox.append('LFN:'+str(this_file.lfn))
+                    lfns.append('LFN:'+str(this_file.lfn))
+        for this_file in j.inputfiles:
+            if isType(this_file, DiracFile):
+                lfns.append('LFN:'+str(this_file.lfn))
+
+        # Make sure we only add unique LFN
+        input_sandbox += set(lfns)
+
+        # Remove duplicates incase the LFN have also been added by any prior step
+        input_sandbox = list(set(input_sandbox))
 
         logger.debug("dirac_script: %s" % str(subjobconfig.getExeString()))
         logger.debug("sandbox_cont:\n%s" % str(input_sandbox))

--- a/ganga/GangaDirac/Lib/Backends/DiracBase.py
+++ b/ganga/GangaDirac/Lib/Backends/DiracBase.py
@@ -326,6 +326,7 @@ class DiracBase(IBackend):
                     time.sleep(1.)
             finally:
                 shutil.rmtree(tmp_dir, ignore_errors = True)
+
             logger.info("Submitted subjobs %s to %s" % (i*nPerProcess, upperlimit-1))
 
         for i in rjobs:


### PR DESCRIPTION
This fixes a minor bug in `runMonitoring`.

When a user executed this method it had the ability to stall the main monitoring thread and then in cases of it being disabled it wouldn't correctly become enabled again after executing this method.

Additionally I've moved the callbacks to use static methods which call instances which makes the code a little easier to follow and from some quick testing improves the stability of the monitoring because it's not trying to track the global `self` state automatically through the monitoring.