### PR TITLE
Py3 ganga swan integration

### DIFF
--- a/python/Ganga/Core/GangaRepository/GangaRepositoryXML.py
+++ b/python/Ganga/Core/GangaRepository/GangaRepositoryXML.py
@@ -12,6 +12,7 @@ import errno
 import copy
 import threading
 
+from Ganga import GANGA_SWAN_INTEGRATION
 from Ganga.Core.GangaRepository.SessionLock import SessionLockManager, dry_run_unix_locks
 from Ganga.Core.GangaRepository.FixedLock import FixedLockManager
 
@@ -831,7 +832,8 @@ class GangaRepositoryLocal(GangaRepository):
                     new_idx_subset = True
 
                 if not old_idx_subset and not new_idx_subset:
-                    logger.warning("Incorrect index cache of '%s' object #%s was corrected!" % (self.registry.name, this_id))
+                    if not GANGA_SWAN_INTEGRATION:
+                        logger.warning("Incorrect index cache of '%s' object #%s was corrected!" % (self.registry.name, this_id))
                     logger.debug("old cache: %s\t\tnew cache: %s" % (obj._index_cache, new_idx_cache))
                     self.unlock([this_id])
             else:

--- a/python/Ganga/Core/MonitoringComponent/Local_GangaMC_Service.py
+++ b/python/Ganga/Core/MonitoringComponent/Local_GangaMC_Service.py
@@ -4,6 +4,7 @@ import time
 import copy
 from contextlib import contextmanager
 
+from Ganga import GANGA_SWAN_INTEGRATION
 from Ganga.Core.GangaThread import GangaThread
 from Ganga.Core.GangaRepository import RegistryKeyError, RegistryLockError
 from Ganga.Core.exceptions import CredentialRenewalError
@@ -522,6 +523,8 @@ class JobRegistry_Monitor(GangaThread):
         self.stopIter.set()
 
         self._runningNow = False
+        if GANGA_SWAN_INTEGRATION:
+            self.newly_discovered_jobs = []
 
     def isEnabled( self, useRunning = True ):
         if useRunning:
@@ -541,6 +544,16 @@ class JobRegistry_Monitor(GangaThread):
         log.debug("Starting run method")
 
         while self.alive:
+            if GANGA_SWAN_INTEGRATION:
+                # Monitor Jobs from other sessions
+                new_jobs = stripProxy(self.registry_slice).objects.repository.update_index(True, True)
+                self.newly_discovered_jobs = list(set(self.newly_discovered_jobs) | set(new_jobs))
+                for i in self.newly_discovered_jobs:
+                    j = stripProxy(self.registry_slice(i))
+                    job_status = lazyLoadJobStatus(j)
+                    if job_status in ['new']:
+                        stripProxy(self.registry_slice).objects.repository.load([i])
+
             checkHeartBeat(JobRegistry_Monitor.global_count)
             log.debug("Monitoring Loop is alive")
             # synchronize the main loop since we can get disable requests
@@ -636,6 +649,16 @@ class JobRegistry_Monitor(GangaThread):
         self.__updateTimeStamp = time.time()
         self.__sleepCounter = config['base_poll_rate']
 
+    def reloadJob(self, i):
+            """
+            Reload a Job from disk.
+            Parameters:
+            i: Job ID
+            Return:
+                True, if Job is successfully reloaded from disk.
+            """
+            stripProxy(self.registry_slice).objects.repository.load([i])
+
     def runMonitoring(self, jobs=None, steps=1, timeout=300):
         """
         Enable/Run the monitoring loop and wait for the monitoring steps completion.
@@ -651,6 +674,17 @@ class JobRegistry_Monitor(GangaThread):
         """
 
         log.debug("runMonitoring")
+
+        if GANGA_SWAN_INTEGRATION:
+            # Detect New Jobs from other sessions.
+            new_jobs = stripProxy(self.registry_slice).objects.repository.update_index(True, True)
+            self.newly_discovered_jobs = list(set(self.newly_discovered_jobs) | set(new_jobs))
+            # Only load jobs from disk which are in new state currently.
+            for i in self.newly_discovered_jobs:
+                j = stripProxy(self.registry_slice(i))
+                job_status = lazyLoadJobStatus(j)
+                if job_status in ['new']:
+                    stripProxy(self.registry_slice).objects.repository.load([i])
 
         if not isType(steps, int) and steps < 0:
             log.warning("The number of monitor steps should be a positive (non-zero) integer")
@@ -941,6 +975,12 @@ class JobRegistry_Monitor(GangaThread):
     def __defaultActiveBackendsFunc(self):
         log.debug("__defaultActiveBackendsFunc")
         active_backends = {}
+
+        if GANGA_SWAN_INTEGRATION:
+            # Detect new Jobs from other sessions
+            new_jobs = stripProxy(self.registry_slice).objects.repository.update_index(True, True)
+            self.newly_discovered_jobs = list(set(self.newly_discovered_jobs) | set(new_jobs))
+
         # FIXME: this is not thread safe: if the new jobs are added then
         # iteration exception is raised
         fixed_ids = self.registry_slice.ids()
@@ -952,6 +992,12 @@ class JobRegistry_Monitor(GangaThread):
 
                 job_status = lazyLoadJobStatus(j)
 
+                if GANGA_SWAN_INTEGRATION:
+                    # Load those Jobs from disk which are in new state to check if they are submitted
+                    # in other sessions
+                    if job_status in ['new']:
+                        stripProxy(self.registry_slice).objects.repository.load([i])
+                        
                 if job_status in ['submitted', 'running'] or (j.master and (job_status in ['submitting'])):
                     if self.enabled is True and self.alive is True:
                         backend_obj = lazyLoadJobBackend(j)

--- a/python/Ganga/Core/__init__.py
+++ b/python/Ganga/Core/__init__.py
@@ -24,6 +24,7 @@ def bootstrap(reg_slice, interactive_session, my_interface=None):
             it to Ganga.GPI
     """
     # Must do some Ganga imports here to avoid circular importing
+    from Ganga import GANGA_SWAN_INTEGRATION
     from Ganga.Core.MonitoringComponent.Local_GangaMC_Service import JobRegistry_Monitor
     from Ganga.Utility.Config import getConfig
     from Ganga.Runtime.GPIexport import exportToInterface
@@ -55,3 +56,5 @@ def bootstrap(reg_slice, interactive_session, my_interface=None):
         my_interface = Ganga.GPI
 
     exportToInterface(my_interface, 'runMonitoring', monitoring_component.runMonitoring, 'Functions')
+    if GANGA_SWAN_INTEGRATION:
+        exportToInterface(my_interface, 'reloadJob', monitoring_component.reloadJob, 'Functions')

--- a/python/Ganga/__init__.py
+++ b/python/Ganga/__init__.py
@@ -5,7 +5,9 @@ import inspect
 import getpass
 import subprocess
 from Ganga.Utility.ColourText import ANSIMarkup, overview_colours
-
+# Global Variable to enable Job Sharing mechanism required in GANGA SWAN INTEGRATION.
+# If environment variable GANGA_SWAN_INTEGRATION is present enable this mechanism.
+GANGA_SWAN_INTEGRATION = "GANGA_SWAN_INTEGRATION" in os.environ
 
 # Global Functions
 def getLCGRootPath():


### PR DESCRIPTION
This PR is for the Python3 version of https://github.com/ganga-devs/ganga/pull/1308 for `ganga_python3` branch.

Enable Ganga to share Jobs between multiple session such that one Ganga session can submit the Job and another session can monitor the same job and completes it.

Now there can be 2 sessions, Session-1 with Monitoring Enabled and Session-2 with Monitoring Disabled.

So, if the user submits a Job in [2], the monitoring loop in [1] will pick the Job and update it. Now if a user wishes to see the Job update in [2], he/she can run reloadJob(job_id) in [2] and the Job with id job_id will update from disk.

These changes can be enabled by creating an environment variable named `GANGA_SWAN_INTEGRATION`.