### PR TITLE
Fix stripProxy to support namedtuples

### DIFF
--- a/ganga/GangaCore/GPIDev/Base/Proxy.py
+++ b/ganga/GangaCore/GPIDev/Base/Proxy.py
@@ -290,6 +290,8 @@ def addProxy(obj):
                 return GPIProxyObjectFactory(obj)
     elif isclass(obj) and issubclass(obj, GangaObject):
         return getProxyClass(obj)
+    elif is_namedtuple_instance(obj):
+        return type(obj)(*[addProxy(_) for _ in obj])
     elif isinstance(obj, (list, tuple)):
         return type(obj)(addProxy(_) for _ in obj)
     elif isinstance(obj, dict):

--- a/ganga/GangaCore/GPIDev/Base/Proxy.py
+++ b/ganga/GangaCore/GPIDev/Base/Proxy.py
@@ -252,13 +252,22 @@ def getName(_obj):
     returnable = _getName(obj)
     return returnable
 
+def is_namedtuple_instance(obj):
+    if len(type(obj).__bases__) != 1 or not isinstance(obj, tuple):
+        return False
+    fields = getattr(obj, '_fields', None)
+    if not isinstance(fields, tuple):
+        return False
+    return all(isinstance(n, str) for n in fields)
 
 def stripProxy(obj):
     """Removes the proxy if there is one
     Args:
         obj (object): This may be an instance or a class
     """
-    if isinstance(obj, (list, tuple)):
+    if is_namedtuple_instance(obj):
+        return type(obj)(*[stripProxy(_) for _ in obj])
+    elif isinstance(obj, (list, tuple)):
         return type(obj)(stripProxy(_) for _ in obj)
     elif isinstance(obj, dict):
         return dict((k, stripProxy(v)) for k, v in obj.items())


### PR DESCRIPTION
Fixes #1325.

This hasn't been tested as I don't have time at the moment but I think it fixes this issue.

It's not clear to me why the `namedtuple` instance is being give to `stripProxy` but the issue is caused by `namedtuple` changing the `__init__` method of tuple to take multiple arguments instead of a single iterable object.

Unfortunately `namedtuple` doesn't use a base class so you have to guess the type based on it's characteristics, see [this StackOverflow answer](https://stackoverflow.com/a/2166841/2685230).