### PR TITLE
Fix Condor time check

### DIFF
--- a/ganga/GangaCore/Lib/Condor/Condor.py
+++ b/ganga/GangaCore/Lib/Condor/Condor.py
@@ -738,7 +738,7 @@ class Condor(IBackend):
 
         for l in f:
             splitLine = l.split()
-            if checkstr in splitLine[0]:
+            if checkstr == splitLine[0]:
                 year = datetime.datetime.now().year
                 if datetime.datetime.strptime(str(datetime.datetime.now().year)+'/'+splitLine[2]+' '+splitLine[3], "%Y/%m/%d %H:%M:%S") > datetime.datetime.now():
                     year = year - 1


### PR DESCRIPTION
Fixes #1355 .

Using `==` instead of `in` should prevent us accidentally picking up lines with memory usage in.