### PR TITLE
Default leave Dirac output sandbox compressed

### DIFF
--- a/ganga/GangaDirac/Lib/Backends/DiracBase.py
+++ b/ganga/GangaDirac/Lib/Backends/DiracBase.py
@@ -97,7 +97,7 @@ class DiracBase(IBackend):
         'credential_requirements': ComponentItem('CredentialRequirement', defvalue=DiracProxy),
         'blockSubmit' : SimpleItem(defvalue=True, 
                                    doc='Shall we use the block submission?'),
-        'unpackOutputSandbox' : SimpleItem(defvalue=False,
+        'unpackOutputSandbox' : SimpleItem(defvalue=True,
                                            doc='Should the output sandbox be unpacked when downloaded.')
     })
     _exportmethods = ['getOutputData', 'getOutputSandbox', 'removeOutputData',

--- a/ganga/GangaDirac/Lib/Server/DiracCommands.py
+++ b/ganga/GangaDirac/Lib/Server/DiracCommands.py
@@ -149,7 +149,11 @@ def getOutputSandbox(id, outputDir=os.getcwd(), unpack=True, oversized=True, noJ
     noJobDir: should we create a folder with the DIRAC job ID?
     output: should I output the Dirac output or should I return a python object (False)
     unpack: should the sandbox be untarred when downloaded'''
-    result = dirac.getOutputSandbox(id, outputDir, oversized, noJobDir, unpack)
+    #We have to catch a type error in case an old DIRAC version is being used which didn't have the unpack option.
+    try:
+        result = dirac.getOutputSandbox(id, outputDir, oversized, noJobDir, unpack)
+    except TypeError:
+        result = dirac.getOutputSandbox(id, outputDir, oversized, noJobDir)
     if result is not None and result.get('OK', False):
 
         if not noJobDir:


### PR DESCRIPTION
Now set the default to leave DIRAC sandboxes compressed. Is that what we want (probably for LHCb but maybe not others) or should we make it configurable?

Also wrap the dirac command in a try/except in case an old version of DIRAC is used which doesn't have this option.