### PR TITLE
Check for failure in Condor status check

### DIFF
--- a/ganga/GangaCore/Lib/Condor/Condor.py
+++ b/ganga/GangaCore/Lib/Condor/Condor.py
@@ -575,7 +575,8 @@ class Condor(IBackend):
             tmpList = infoString.split()
             id, host, status, cputime = ("", "", "", "")
             if 3 == len(tmpList):
-                id, status, cputime = tmpList
+                if not 'Failure' in tmpList[0]:
+                    id, status, cputime = tmpList
             if 4 == len(tmpList):
                 id, host, status, cputime = tmpList
             if id:


### PR DESCRIPTION
Fixes #1354 .

Sometimes there is an authentication error in the query - it is intermittent (not a sign of something fatal) but it puts something odd in the status field. This just checks that it has not returned failure.