### PR TITLE
Fix for new Dirac

### DIFF
--- a/ganga/GangaDirac/Lib/Server/DiracDefinition.py
+++ b/ganga/GangaDirac/Lib/Server/DiracDefinition.py
@@ -1,3 +1,4 @@
+__name__ = '__main__'
 import os
 import sys
 import time

--- a/ganga/GangaLHCb/Lib/Server/DiracLHCbDefinition.py
+++ b/ganga/GangaLHCb/Lib/Server/DiracLHCbDefinition.py
@@ -1,3 +1,4 @@
+__name__ = '__main__'
 import os
 import sys
 import time


### PR DESCRIPTION
I'm not entirely sure why this fixes the issue. The latest DIRAC looks for the name of the frame that calls it. I think as we fake running a module in the subprocess `exec(command)` it doesn't have a `__name__` set so DIRAC throws a `KeyError`.

So here I just hardcode a `__name__` at the start of the commands that get run in the subprocess which seems to fix it.

Can we merge this now and then I can update the DEV. Currently ganga cannot do anything with DIRAC.