### PR TITLE
Use old dirac-install script

### DIFF
--- a/ganga/GangaDirac/test/Dockerfile
+++ b/ganga/GangaDirac/test/Dockerfile
@@ -16,7 +16,7 @@ RUN virtualenv venv && \
 
 RUN mkdir dirac_ui &&\
     cd dirac_ui &&\
-    wget -np -O dirac-install https://raw.githubusercontent.com/DIRACGrid/DIRAC/1ecf22f24509afd2dec9999114db104e1e776b9c/Core/scripts/dirac-install.py &&\
+    wget -np -O dirac-install https://raw.githubusercontent.com/DIRACGrid/DIRAC/rel-v6r19/Core/scripts/dirac-install.py &&\
     chmod u+x dirac-install &&\
     ./dirac-install -r v6r19p4 -i 27 -g v13r0
 

--- a/ganga/GangaDirac/test/Dockerfile
+++ b/ganga/GangaDirac/test/Dockerfile
@@ -16,7 +16,7 @@ RUN virtualenv venv && \
 
 RUN mkdir dirac_ui &&\
     cd dirac_ui &&\
-    wget -np -O dirac-install https://raw.githubusercontent.com/DIRACGrid/DIRAC/integration/Core/scripts/dirac-install.py &&\
+    wget -np -O dirac-install https://raw.githubusercontent.com/DIRACGrid/DIRAC/1ecf22f24509afd2dec9999114db104e1e776b9c/Core/scripts/dirac-install.py &&\
     chmod u+x dirac-install &&\
     ./dirac-install -r v6r19p4 -i 27 -g v13r0
 


### PR DESCRIPTION
New dirac-install script requires non-standard python package six to be already installed. Either use old version of script like this PR does or we will need to to a local install to the docker container until this is fixed upstream.