### PR TITLE
Return app.env to the Executable RTHandler

### DIFF
--- a/ganga/GangaCore/Lib/Executable/Executable.py
+++ b/ganga/GangaCore/Lib/Executable/Executable.py
@@ -235,7 +235,7 @@ class RTHandler(IRuntimeHandler):
                 prepared_exe = File(os.path.join(
                     os.path.join(shared_path, app.is_prepared.name), os.path.basename(app.exe.name)))
 
-        c = StandardJobConfig(prepared_exe, stripProxy(app).getJobObject().inputsandbox, convertIntToStringArgs(app.args), stripProxy(app).getJobObject().outputsandbox)
+        c = StandardJobConfig(prepared_exe, stripProxy(app).getJobObject().inputsandbox, convertIntToStringArgs(app.args), stripProxy(app).getJobObject().outputsandbox, app.env)
         return c
 
 


### PR DESCRIPTION
Fixes #1400 .

The application env had dropped out of the local RTHandler.