### PR TITLE
Fix autoDBtags

### DIFF
--- a/ganga/GangaLHCb/Lib/RTHandlers/GaudiExecRTHandlers.py
+++ b/ganga/GangaLHCb/Lib/RTHandlers/GaudiExecRTHandlers.py
@@ -69,7 +69,7 @@ def getAutoDBTags(job):
         if app in job.application.directory:
             prefix = app
     inputsandbox = []
-    ddb, conddb = execute('getDBtags("{0}")'.format(job.inputdata[0].lfn)) # take the tags only from the first file
+    ddb, conddb = execute('getDBtagsFromLFN("{0}")'.format(job.inputdata[0].lfn)) # take the tags only from the first file
     tagOpts = 'from Configurables import ' + prefix +'\n' 
     tagOpts += prefix + '().DDDBtag = ' + "'" + ddb + "'\n"
     tagOpts += prefix + '().CondDBtag = ' + "'" + conddb + "'"


### PR DESCRIPTION
This was failing for files that are the result of a merge step in the production.

Now if the last step is a merge we look at the parent production step for the tags.