### PR TITLE
Fix job removal

### DIFF
--- a/ganga/GangaCore/GPIDev/Lib/Job/Job.py
+++ b/ganga/GangaCore/GPIDev/Lib/Job/Job.py
@@ -1731,8 +1731,6 @@ class Job(GangaObject):
                 if hasattr(self.application, 'is_prepared') and self.application.__getattribute__('is_prepared'):
                     if self.application.is_prepared is not True:
                         self.application.decrementShareCounter(self.application.is_prepared)
-                        for _ in self.subjobs:
-                            self.application.decrementShareCounter(self.application.is_prepared)
             except KeyError as err:
                 logger.debug("KeyError, likely job hasn't been loaded.")
                 logger.debug("In that case try and skip")


### PR DESCRIPTION
Fixes #1426 .

For some reason every subjob was decrementing the shareref counter when a job gets remove so the sharedir was getting deleted.