### PR TITLE
Another fix for new LHCbDirac - getting job info

### DIFF
--- a/ganga/GangaDirac/Lib/Server/DiracCommands.py
+++ b/ganga/GangaDirac/Lib/Server/DiracCommands.py
@@ -198,7 +198,7 @@ def getOutputDataLFNs(id, pipe_out=True):
     message = 'The outputdata LFNs could not be found.'
 
     if parameters is not None and parameters.get('OK', False):
-        parameters = parameters['Value']
+        parameters = parameters['Value'][id]
         # remove the sandbox if it has been uploaded
         sandbox = None
         if 'OutputSandboxLFN' in parameters:
@@ -230,7 +230,7 @@ def normCPUTime(id, pipe_out=True):
     parameters = dirac.getJobParameters(id)
     ncput = None
     if parameters is not None and parameters.get('OK', False):
-        parameters = parameters['Value']
+        parameters = parameters['Value'][id]
         if 'NormCPUTime(s)' in parameters:
             ncput = parameters['NormCPUTime(s)']
     return ncput


### PR DESCRIPTION
The dict for the job parameters appears to have changed. The job id is required now as it takes the form
```python
'OK': True, 'rpcStub': (('WorkloadManagement/JobMonitoring', {'skipCACheck': False, 'keepAliveLapse': 150, 'timeout': 120}), 'getJobParameters', (266710601,)), 'Value': {266710601L: {'PilotAgent': 'v9r3', 'JobWrapperPID': '124', 'CPUScalingFactor': '17.8', 'LoadAverage': '21.06', 'WallClockTime(s)': '301.049945116', 'CacheSize(kB)': '20480KB', 'MemoryUsed(kb)': '4.0', 'LastUpdateCPU(s)': '9.0', 'HostName': 'td100.pic.es', 'CPU(MHz)': '2600.000', 'CPUNormalizationFactor': '17.8', 'NormCPUTime(s)': '4014.078', 'ModelName': 'Intel(R)Xeon(R)CPUE5-2640v3@2.60GHz', 'ScaledCPUTime(s)': '5358.68902307', 'PayloadPID': '138', 'AgentLocalSE': 'PIC-ARCHIVE,PIC-BUFFER,PIC-DST,PIC-FAILOVER,PIC-RAW,PIC-RDST,PIC-USER,PIC_MC-DST', 'UploadedOutputData': '/lhcb/user/m/masmith/2019_03/266710/266710601/DVTuples.root, /lhcb/user/m/masmith/2019_03/266710/266710601/DVHistos.root', 'OK': 'True', 'LocalAccount': 'lhpilot007', 'Memory(kB)': '562720kB', 'Pilot_Reference': 'htcondorce://ce14.pic.es/4688745.8', 'OutputSandboxMissingFiles': '__postprocesslocations__, std.err', 'TotalCPUTime(s)': '225.51'}}}
```