### PR TITLE
Download uploaded Dirac sandboxes

### DIFF
--- a/ganga/GangaDirac/Lib/Backends/DiracBase.py
+++ b/ganga/GangaDirac/Lib/Backends/DiracBase.py
@@ -27,6 +27,7 @@ from GangaCore.GPIDev.Base.Proxy import stripProxy, isType, getName
 from GangaCore.Core.GangaThread.WorkerThreads import getQueues
 from GangaCore.Core import monitoring_component
 from GangaCore.Runtime.GPIexport import exportToGPI
+from subprocess import check_output
 configDirac = getConfig('DIRAC')
 default_finaliseOnMaster = configDirac['default_finaliseOnMaster']
 default_downloadOutputSandbox = configDirac['default_downloadOutputSandbox']
@@ -1073,7 +1074,15 @@ class DiracBase(IBackend):
                 if job.master:
                     job.master.updateMasterJobStatus()
                 raise BackendError('Dirac', 'Problem retrieving outputsandbox: %s' % str(getSandboxResult))
-
+            #If the sandbox dict includes a Succesful key then the sandbox has been download from grid storage, likely due to being oversized. Untar it and issue a warning.
+            elif getSandboxResult['Value'].get('Successful', False):
+                    try:
+                        sandbox_name = getSandboxResult['Value']['Successful'].values()[0]
+                        check_output(['tar', '-xvf', sandbox_name, '-C', output_path])
+                        check_output(['rm', sandbox_name])
+                        logger.warning('Output sandbox for job %s downloaded from grid storage due to being oversized.' % job.fqid)
+                    except CalledProcessError:
+                        logger.error('Failed to unpack output sandbox for job %s' % job.fqid)
             # finally update job to completed
             DiracBase._getStateTime(job, 'completed', completeTimeResult)
             if job.status in ['removed', 'killed']:

--- a/ganga/GangaDirac/Lib/Backends/DiracBase.py
+++ b/ganga/GangaDirac/Lib/Backends/DiracBase.py
@@ -27,7 +27,7 @@ from GangaCore.GPIDev.Base.Proxy import stripProxy, isType, getName
 from GangaCore.Core.GangaThread.WorkerThreads import getQueues
 from GangaCore.Core import monitoring_component
 from GangaCore.Runtime.GPIexport import exportToGPI
-from subprocess import check_output
+from subprocess import check_output, CalledProcessError
 configDirac = getConfig('DIRAC')
 default_finaliseOnMaster = configDirac['default_finaliseOnMaster']
 default_downloadOutputSandbox = configDirac['default_downloadOutputSandbox']

--- a/ganga/GangaDirac/Lib/Backends/DiracBase.py
+++ b/ganga/GangaDirac/Lib/Backends/DiracBase.py
@@ -1075,7 +1075,7 @@ class DiracBase(IBackend):
                     job.master.updateMasterJobStatus()
                 raise BackendError('Dirac', 'Problem retrieving outputsandbox: %s' % str(getSandboxResult))
             #If the sandbox dict includes a Succesful key then the sandbox has been download from grid storage, likely due to being oversized. Untar it and issue a warning.
-            elif getSandboxResult['Value'].get('Successful', False):
+            elif isinstance(getSandboxResult['Value'], dict) and getSandboxResult['Value'].get('Successful', False):
                     try:
                         sandbox_name = getSandboxResult['Value']['Successful'].values()[0]
                         check_output(['tar', '-xvf', sandbox_name, '-C', output_path])

--- a/ganga/GangaDirac/Lib/Server/DiracCommands.py
+++ b/ganga/GangaDirac/Lib/Server/DiracCommands.py
@@ -157,6 +157,16 @@ def getOutputSandbox(id, outputDir=os.getcwd(), unpack=True, oversized=True, noJ
             os.system('mv -f %s/* %s/. ; rm -rf %s' % (tmpdir, outputDir, tmpdir))
         
         os.system('for file in $(ls %s/*_Ganga_*.log); do ln -s ${file} %s/stdout; break; done' % (outputDir, outputDir))
+    #So the download failed. Maybe the sandbox was oversized and stored on the grid. Check in the job parameters and download it
+    else:
+        parameters = dirac.getJobParameters(id)
+        if parameters is not None and parameters.get('OK', False):
+            parameters = parameters['Value'][id]
+            if 'OutputSandboxLFN' in parameters:
+                sandbox_lfn = parameters['OutputSandboxLFN']
+                download_result = getFile(sandbox_lfn, outputDir)
+                if download_result.get('OK'):
+                    result = download_result
 
     return result
 

--- a/ganga/GangaDirac/Lib/Server/DiracCommands.py
+++ b/ganga/GangaDirac/Lib/Server/DiracCommands.py
@@ -164,10 +164,7 @@ def getOutputSandbox(id, outputDir=os.getcwd(), unpack=True, oversized=True, noJ
             parameters = parameters['Value'][id]
             if 'OutputSandboxLFN' in parameters:
                 sandbox_lfn = parameters['OutputSandboxLFN']
-                download_result = getFile(sandbox_lfn, outputDir)
-                if download_result.get('OK'):
-                    result = download_result
-
+                result = dirac.getFile(sandbox_lfn, destDir=outputDir)
     return result
 
 

--- a/ganga/GangaDirac/Lib/Server/DiracCommands.py
+++ b/ganga/GangaDirac/Lib/Server/DiracCommands.py
@@ -164,6 +164,7 @@ def getOutputSandbox(id, outputDir=os.getcwd(), unpack=True, oversized=True, noJ
             parameters = parameters['Value'][id]
             if 'OutputSandboxLFN' in parameters:
                 result = dirac.getFile(parameters['OutputSandboxLFN'], destDir=outputDir)
+                dirac.removeFile(parameters['OutputSandboxLFN'])
     return result
 
 

--- a/ganga/GangaDirac/Lib/Server/DiracCommands.py
+++ b/ganga/GangaDirac/Lib/Server/DiracCommands.py
@@ -163,8 +163,7 @@ def getOutputSandbox(id, outputDir=os.getcwd(), unpack=True, oversized=True, noJ
         if parameters is not None and parameters.get('OK', False):
             parameters = parameters['Value'][id]
             if 'OutputSandboxLFN' in parameters:
-                sandbox_lfn = parameters['OutputSandboxLFN']
-                result = dirac.getFile(sandbox_lfn, destDir=outputDir)
+                result = dirac.getFile(parameters['OutputSandboxLFN'], destDir=outputDir)
     return result
 
 


### PR DESCRIPTION
If the initial sandbox download fails this check if there is a sandbox uploaded to grid storage and downloads it.

A few questions:
- Do we want to download it automatically? It may block up the monitoring if jobs take a long time to finalise due to downloading large sandboxes.
- The sandbox is still compressed - do we want to decompress it as well?  I think we do.
- Do we want to give a warning about oversize sandboxes?
- Do we want to store the sandbox LFN?