### PR TITLE
Remove Dirac files output with job

### DIFF
--- a/ganga/GangaCore/GPIDev/Lib/Job/Job.py
+++ b/ganga/GangaCore/GPIDev/Lib/Job/Job.py
@@ -1736,6 +1736,15 @@ class Job(GangaObject):
                 logger.debug("In that case try and skip")
                 pass
 
+            try:
+                #If the job has a method to remove the output data then use it.
+                if hasattr(self.backend, 'removeOutputData') and getConfig('Output')['AutoRemoveOutputDataWithJob']:
+                    self.backend.removeOutputData()
+            except KeyError as err:
+                logger.debug("KeyError, likely job hasn't been loaded.")
+                logger.debug("In that case try and skip")
+                pass
+
         if self._registry:
             try:
                 self._registry._remove(self, auto_removed=1)

--- a/ganga/GangaCore/__init__.py
+++ b/ganga/GangaCore/__init__.py
@@ -641,7 +641,8 @@ output_config.addOption('AutoRemoveFilesWithJob', False,
                        'if True, each outputfile of type in list AutoRemoveFileTypes will be removed when the job is')
 output_config.addOption('AutoRemoveFileTypes', [
                        'DiracFile'], 'List of outputfile types that will be auto removed when job is removed if AutoRemoveFilesWithJob is True')
-
+output_config.addOption('AutoRemoveOutputDataWithJob', False,
+                        'if True and the job backend has the removeOutputData method then the output data will be removed when the job is removed.')
 output_config.addOption('PostProcessLocationsFileName', '__postprocesslocations__',
                        'name of the file that will contain the locations of the uploaded from the WN files')
 


### PR DESCRIPTION
User request - remove output data with the job.

I'm not sure if I like this. For example if you submit a job to Condor with DiracFile output (bit odd but doable) then this won't work.