### PR TITLE
Move logging flush to pre-prompt hook

### DIFF
--- a/ganga/GangaCore/Runtime/bootstrap.py
+++ b/ganga/GangaCore/Runtime/bootstrap.py
@@ -1218,8 +1218,6 @@ under certain conditions; type license() for details.
         import IPython
 
         # Based on examples/Embedding/embed_class_long.py from the IPython source tree
-        from IPython.core.displayhook import DisplayHook
-
         # First we set up the prompt
         from traitlets.config.loader import Config
         
@@ -1236,7 +1234,7 @@ under certain conditions; type license() for details.
         from IPython.terminal.embed import InteractiveShellEmbed
 
         ipshell = InteractiveShellEmbed(config=cfg, banner1=banner, exit_msg=exit_msg)
-        ipshell.events.register("post_execute", ganga_prompt)
+        ipshell.events.register("pre_execute", ganga_prompt)
 
         # Add our custom error handler to ignore stack traces for GangaExceptions
         ipshell.set_custom_exc((Exception,), error_handler)

--- a/ganga/GangaCore/Runtime/bootstrap.py
+++ b/ganga/GangaCore/Runtime/bootstrap.py
@@ -53,9 +53,7 @@ class GangaPrompt(Prompts):
 
     def in_prompt_tokens(self, cli = None):
         from datetime import datetime
-        from GangaCore.Utility.logging import flushAtIPythonPrompt
-        __flushCmd = flushAtIPythonPrompt()
-        return [(Token.Prompt,  str(__flushCmd)+'['+str(datetime.now().strftime("%H:%M:%S"))+']\nGanga In ['.format(GangaPrompt.environment)),
+        return [(Token.Prompt, '['+str(datetime.now().strftime("%H:%M:%S"))+']\nGanga In ['.format(GangaPrompt.environment)),
                 (Token.PromptNum, str(self.shell.execution_count)),
                 (Token.Prompt, ']: ')]
 
@@ -1220,6 +1218,7 @@ under certain conditions; type license() for details.
         import IPython
 
         # Based on examples/Embedding/embed_class_long.py from the IPython source tree
+        from IPython.core.displayhook import DisplayHook
 
         # First we set up the prompt
         from traitlets.config.loader import Config
@@ -1263,6 +1262,9 @@ under certain conditions; type license() for details.
 
     @staticmethod
     def ganga_prompt(_=None):
+        #Flush the logging
+        from GangaCore.Utility.logging import flushAtIPythonPrompt
+        flushAtIPythonPrompt()
 
         try:
             from GangaCore.GPIDev.Credentials import get_needed_credentials

--- a/ganga/GangaCore/Runtime/bootstrap.py
+++ b/ganga/GangaCore/Runtime/bootstrap.py
@@ -1218,6 +1218,7 @@ under certain conditions; type license() for details.
         import IPython
 
         # Based on examples/Embedding/embed_class_long.py from the IPython source tree
+
         # First we set up the prompt
         from traitlets.config.loader import Config
         
@@ -1234,7 +1235,7 @@ under certain conditions; type license() for details.
         from IPython.terminal.embed import InteractiveShellEmbed
 
         ipshell = InteractiveShellEmbed(config=cfg, banner1=banner, exit_msg=exit_msg)
-        ipshell.events.register("pre_execute", ganga_prompt)
+        ipshell.events.register("post_execute", ganga_prompt)
 
         # Add our custom error handler to ignore stack traces for GangaExceptions
         ipshell.set_custom_exc((Exception,), error_handler)


### PR DESCRIPTION
For some reason IPython reprints the input prompt for every key stroke. This means the loggers are getting flushed in the middle of typing commands - very annoying.

Here I have moved the flushing to the post execute hook (it could equally well be in the pre-prompt one). The problem is that a cell now needs to be executed for the logging to be printed - just hitting return on an empty cell does nothing. I am not sure how to change that behaviour.