### PR TITLE
Adds Memory Profiler and CPU Profiler (#1471)

### DIFF
--- a/ganga/GangaCore/GPIDev/Base/Objects.py
+++ b/ganga/GangaCore/GPIDev/Base/Objects.py
@@ -25,6 +25,8 @@ from GangaCore.Core.exceptions import GangaValueError, GangaException
 
 from GangaCore.Utility.Plugin import allPlugins
 
+from GangaCore.Utility.Profiling import cpu_profiler, mem_profiler, call_counter
+
 def _getName(obj):
     """ Return the name of an object based on what we prioritise 
     Name is defined as the first in the list of:
@@ -687,6 +689,9 @@ class ObjectMetaclass(abc.ABCMeta):
             this_schema.createDefaultConfig()
 
 
+@call_counter
+@cpu_profiler
+@mem_profiler
 class GangaObject(Node):
     __metaclass__ = ObjectMetaclass # Change standard Python metaclass object
     _schema = None  # obligatory, specified in the derived classes

--- a/ganga/GangaCore/Utility/Profiling.py
+++ b/ganga/GangaCore/Utility/Profiling.py
@@ -1,0 +1,99 @@
+from GangaCore.Utility.Config import getConfig
+
+import os
+from memory_profiler import profile
+import cProfile
+import time
+import json
+
+# creating a timestamp
+timestr = time.strftime("-%Y%m%d-%H%M%S")
+
+# Obtaining the config from .gangarc file
+c = getConfig('Configuration')
+
+path = os.path.join(c['gangadir'], 'logs')
+
+
+# A helper function to make the directories for storing log files
+def _makedir(path):
+    try:
+        if not os.path.exists(path):
+            os.makedirs(path)
+        return path
+    except Exception as e:
+        raise e
+
+
+# creating all the necessary directories
+_makedir(path)
+cpath = _makedir(os.path.join(path, 'cpu_profile/'))
+mpath = _makedir(os.path.join(path, 'memory_profiles/'))
+ccpath = _makedir(os.path.join(path, 'call_counters/'))
+
+
+def cpu_profile(func):
+    def wrapper(*args, **kwargs):
+        # every function will have its different profile
+        datafn = cpath + func.__name__ + timestr + ".profile"
+
+        # profiling the function by passing in the function and arguments
+        prof = cProfile.Profile()
+        retval = prof.runcall(func, *args, **kwargs)
+
+        # dump the stats to a file
+        prof.dump_stats(datafn)
+        return retval
+    return wrapper
+
+
+def cpu_profiler(cls, profile_cpu=c['Profile_CPU']):
+    if not profile_cpu:
+        pass
+    else:
+        for key, value in vars(cls).iteritems():
+            if callable(value):
+                # adding cpu_profile decorator to every function of class
+                setattr(cls, key, cpu_profile(value))
+    return cls
+
+
+def mem_profiler(cls, profile_memory=c['Profile_Memory']):
+    if not profile_memory:
+        pass
+    else:
+        file_name = mpath+cls.__name__+timestr+'.log'
+        fp = open(file_name, 'w+')
+        for key, value in vars(cls).iteritems():
+            if callable(value):
+                # adding profile decorator to every function of class
+                setattr(cls, key, profile(value, stream=fp, precision=6))
+    return cls
+
+
+function_calls = {}
+
+
+def call_counts(func):
+    def wrapper(*args, **kwargs):
+        wrapper.calls += 1
+        function_calls[(wrapper.__name__)] = wrapper.calls
+        # storing the call counter for each function
+        # Need to find a more effiecient way to store
+        with open(ccpath+'call_counter_logs'+timestr+'.json', 'w') as fp:
+            json.dump(function_calls, fp, indent=4)
+        return func(*args, **kwargs)
+    wrapper.calls = 0
+    wrapper.__name__ = func.__name__
+    return wrapper
+
+
+def call_counter(cls, count_calls=c['Count_Calls']):
+    if not count_calls:
+        pass
+    else:
+        for key, value in vars(cls).iteritems():
+            if callable(value):
+                # adding call_counts decorator to every function of class
+                setattr(cls, key, call_counts(value))
+    return cls

--- a/ganga/GangaCore/__init__.py
+++ b/ganga/GangaCore/__init__.py
@@ -128,6 +128,11 @@ conf_config.addOption('autoGenerateJobWorkspace', False, 'Autogenerate workspace
 
 conf_config.addOption('NoAfsToken', False, 'Do not require an AFS token when running on an AFS filesystem. Not recommended!')
 
+conf_config.addOption('Profile_Memory', False, 'Run memory profiler on Ganga Objects')
+conf_config.addOption('Profile_CPU', False, 'Run cpu profiler on Ganga Objects')
+conf_config.addOption('Count_Calls', False, 'Run function call counters on Ganga Objects')
+
+
 # add named template options
 conf_config.addOption('namedTemplates_ext', 'tpl',
                  'The default file extension for the named template system. If a package sets up their own by calling "establishNamedTemplates" from python/Ganga/GPIDev/Lib/Job/NamedJobTemplate.py in their ini file then they can override this without needing the config option')

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ unittest2
 coverage
 pygments
 mock
+memory_profiler


### PR DESCRIPTION
* Adds Memory Profiler and CPU Profiler

The memory profiler and cpu profiler logs
are stored in the `logs` folder inside `gangadir`.

* Adds memory_profiler to requirements.txt

* Adds a decorator to count number of function calls

The log files are stores in gangadir as json objects.