### PR TITLE
Fix the enable monitoring warning.

### DIFF
--- a/ganga/GangaCore/Runtime/Repository_runtime.py
+++ b/ganga/GangaCore/Runtime/Repository_runtime.py
@@ -148,7 +148,7 @@ def bootstrap():
         # Just print this from 1 repo only so chose the zeorth, nothing special
         logger.warning("%i other concurrent sessions:\n * %s" % (len(other_sessions), "\n * ".join(other_sessions)))
         logger.warning("Multiple Ganga sessions detected. The Monitoring Thread is being disabled.")
-        logger.warning("Type 'enableMonitoring' to restart")
+        logger.warning("Type 'enableMonitoring()' to restart")
         setConfigOption('PollThread', 'autostart', False)
 
     return retval


### PR DESCRIPTION
The existing code asks users to simply `Type 'enableMonitoring'` to re-enable the monitoring loop which could be clearer since if they follow it literally they will get the following:

```python
Ganga In [1]: enableMonitoring                                                                                                                                                                                                                
Ganga Out [1]: <function GangaCore.Core.InternalServices.Coordinator.enableMonitoringService()>
```

This PR updates the warning to say `Type 'enableMonitoring()'`