### PR TITLE
Rename Gaudi Job script to have the same prefix for all users

### DIFF
--- a/ganga/GangaLHCb/Lib/RTHandlers/GaudiExecRTHandlers.py
+++ b/ganga/GangaLHCb/Lib/RTHandlers/GaudiExecRTHandlers.py
@@ -92,7 +92,7 @@ def getScriptName(app):
         app (Job): This is the app object which contains everything useful for generating the code
     """
     job = app.getJobObject()
-    return "_".join((getConfig('Configuration')['user'], getName(app), 'Job', job.getFQID('.'), _pseudo_session_id, 'script'))+'.py'
+    return "_".join((getName(app), getConfig('Configuration')['user'], 'Job', job.getFQID('.'), _pseudo_session_id, 'script'))+'.py'
 
 
 def generateWNScript(commandline, app):


### PR DESCRIPTION
DIRAC sets the application status based on the `basename(executable_fn).split('_')[0]`. Currently for Gaudi jobs this is the user's name but this makes filtering in the DIRAC web app inconvenient (https://github.com/DIRACGrid/DIRAC/issues/4267). 

Would it be a problem to start with the application name instead?