### PR TITLE
Supress IPython warning

### DIFF
--- a/bin/ganga
+++ b/bin/ganga
@@ -43,6 +43,10 @@ def standardSetup():
         envDir = os.path.join(envDir, 'lib/python3.6/site-packages')
         sys.path.insert(0, envDir)    
 
+        #If we are in CVMFS we want to supress the iPython warnings in case we are running inside LbEnv
+        import warnings
+        warnings..filterwarnings("ignore", message="Attempting to work in a virtualenv. If you encounter problems, please install IPython inside the virtualenv.")
+        
     #This function is needed to add the individual ganga modules to the sys path - awful hack but saved rewriting all the code. This is needed for pip installs
     pathsToAdd = filter(lambda p : 'ganga' in os.listdir(p),
                         filter(lambda x : not x=='' and os.path.isdir(x), sys.path))

--- a/bin/ganga
+++ b/bin/ganga
@@ -21,6 +21,14 @@
 from __future__ import print_function
 import sys
 
+import os
+
+if 'LBENV_SOURCED' in os.environ.keys():
+    #If we are in an LbEnv venv we want to supress the iPython warning
+    import warnings
+    warnings.filterwarnings("ignore", message="Attempting to work in a virtualenv. If you encounter problems, please install IPython inside the virtualenv.")
+        
+
 #First make sure we are using a python version above 3.0
 if sys.version_info[0] != 3 or sys.version_info[1] < 6:
     import logging
@@ -43,10 +51,7 @@ def standardSetup():
         envDir = os.path.join(envDir, 'lib/python3.6/site-packages')
         sys.path.insert(0, envDir)    
 
-        #If we are in CVMFS we want to supress the iPython warnings in case we are running inside LbEnv
-        import warnings
-        warnings..filterwarnings("ignore", message="Attempting to work in a virtualenv. If you encounter problems, please install IPython inside the virtualenv.")
-        
+
     #This function is needed to add the individual ganga modules to the sys path - awful hack but saved rewriting all the code. This is needed for pip installs
     pathsToAdd = filter(lambda p : 'ganga' in os.listdir(p),
                         filter(lambda x : not x=='' and os.path.isdir(x), sys.path))

--- a/bin/ganga
+++ b/bin/ganga
@@ -28,7 +28,6 @@ if 'LBENV_SOURCED' in os.environ.keys():
     import warnings
     warnings.filterwarnings("ignore", message="Attempting to work in a virtualenv. If you encounter problems, please install IPython inside the virtualenv.")
         
-
 #First make sure we are using a python version above 3.0
 if sys.version_info[0] != 3 or sys.version_info[1] < 6:
     import logging
@@ -50,7 +49,6 @@ def standardSetup():
         envDir = exeDir[:-3]
         envDir = os.path.join(envDir, 'lib/python3.6/site-packages')
         sys.path.insert(0, envDir)    
-
 
     #This function is needed to add the individual ganga modules to the sys path - awful hack but saved rewriting all the code. This is needed for pip installs
     pathsToAdd = filter(lambda p : 'ganga' in os.listdir(p),


### PR DESCRIPTION
LbEnv activates a virtualenv inside which we start IPython. As the IPython installation is not part of that venv it gives a warning. I think it is harmless so this supresses it.