### PR TITLE
Fix GaudiExec use of shardir for options

### DIFF
--- a/ganga/GangaLHCb/Lib/RTHandlers/GaudiExecRTHandlers.py
+++ b/ganga/GangaLHCb/Lib/RTHandlers/GaudiExecRTHandlers.py
@@ -151,7 +151,7 @@ def prepareCommand(app):
         app (GaudiExec): This expects only the GaudiExec app
     """
 
-    all_opts_files = app.getOptsFiles()
+    all_opts_files = app.getOptsFiles(True)
     opts_names = []
     for opts_file in all_opts_files:
         if isinstance(opts_file, (LocalFile, DiracFile)):
@@ -572,7 +572,7 @@ class GaudiExecDiracRTHandler(IRuntimeHandler):
 
         # We can support inputfiles and opts_file here. Locally should be submitted once, remotely can be referenced.
 
-        all_opts_files = app.getOptsFiles()
+        all_opts_files = app.getOptsFiles(True)
 
         for opts_file in all_opts_files:
             if isinstance(opts_file, DiracFile):


### PR DESCRIPTION
Makes GaudiExec take the options from the sharedir if the application is prepared. It doesn't change the location of the options in the application schema in case the application is unprepared.