### PR TITLE
Remove treat_as_inputfiles for inputdata

### DIFF
--- a/ganga/GangaCore/GPIDev/Lib/Dataset/GangaDataset.py
+++ b/ganga/GangaCore/GPIDev/Lib/Dataset/GangaDataset.py
@@ -19,7 +19,6 @@ class GangaDataset(Dataset):
     schema = {}
     docstr = 'List of File objects'
     schema['files'] = GangaFileItem(defvalue=[], sequence=1, doc="list of file objects that will be the inputdata for the job")
-    schema['treat_as_inputfiles'] = SimpleItem(defvalue=False, doc="Treat the inputdata as inputfiles, i.e. copy the inputdata to the WN")
     _schema = Schema(Version(3, 0), schema)
     _category = 'datasets'
     _name = "GangaDataset"

--- a/ganga/GangaCore/GPIDev/Lib/File/OutputFileManager.py
+++ b/ganga/GangaCore/GPIDev/Lib/File/OutputFileManager.py
@@ -84,7 +84,7 @@ def getInputFilesPatterns(job):
     # if GangaDataset is used, check if they want the inputfiles transferred
     inputfiles_list = copy.deepcopy(job.inputfiles if job.inputfiles else [])
     from GangaCore.GPIDev.Lib.Dataset.GangaDataset import GangaDataset
-    if not job.subjobs and job.inputdata and isType(job.inputdata, GangaDataset) and job.inputdata.treat_as_inputfiles:
+    if not job.subjobs and job.inputdata and isType(job.inputdata, GangaDataset):
         inputfiles_list += job.inputdata.files
 
     if job.virtualization and isinstance(job.virtualization.image, IGangaFile):
@@ -204,7 +204,7 @@ def getWNCodeForDownloadingInputFiles(job, indent):
         Args: job(Job) This is the job which we're testing for inputfiles """
         if job.inputfiles is not None and len(job.inputfiles) != 0:
             return True
-        if job.inputdata is not None and isinstance(job.inputdata, GangaDataset) and job.inputdata.treat_as_inputfiles:
+        if job.inputdata is not None and isinstance(job.inputdata, GangaDataset):
             return True
         if job.virtualization and isinstance(job.virtualization.image, IGangaFile):
             return True
@@ -229,10 +229,10 @@ def getWNCodeForDownloadingInputFiles(job, indent):
         inputfiles_list = job.inputfiles
 
     if job.inputdata:
-        if job.inputdata and isType(job.inputdata, GangaDataset) and job.inputdata.treat_as_inputfiles:
+        if job.inputdata and isType(job.inputdata, GangaDataset):
             inputfiles_list += job.inputdata.files
     elif job.master is not None:
-        if job.master.inputdata and isType(job.master.inputdata, GangaDataset) and job.master.inputdata.treat_as_inputfiles:
+        if job.master.inputdata and isType(job.master.inputdata, GangaDataset):
             inputfiles_list += job.master.inputdata.files
 
     if job.virtualization and isinstance(job.virtualization.image, IGangaFile):

--- a/ganga/GangaCore/GPIDev/Lib/Tasks/CoreTransform.py
+++ b/ganga/GangaCore/GPIDev/Lib/Tasks/CoreTransform.py
@@ -110,8 +110,6 @@ class CoreTransform(ITransform):
                     unit.name = "Unit %d" % len(self.units)
                     unit.inputdata = GangaDataset(
                         files=filelist[fid:fid + self.files_per_unit])
-                    unit.inputdata.treat_as_inputfiles = self.inputdata[
-                        0].treat_as_inputfiles
 
                     fid += self.files_per_unit
 
@@ -161,6 +159,5 @@ class CoreTransform(ITransform):
         unit = CoreUnit()
         unit.name = "Unit %d" % len(self.units)
         unit.inputdata = GangaDataset(files=flist)
-        unit.inputdata.treat_as_inputfiles = self.chaindata_as_inputfiles
 
         return unit

--- a/ganga/GangaCore/Lib/Splitters/GangaDatasetSplitter.py
+++ b/ganga/GangaCore/Lib/Splitters/GangaDatasetSplitter.py
@@ -58,7 +58,6 @@ class GangaDatasetSplitter(ISplitter):
         while fid < filesToRun:
             j = self.createSubjob(job)
             j.inputdata = masterType()
-            j.inputdata.treat_as_inputfiles = job.inputdata.treat_as_inputfiles
             for sf in full_list[fid:fid + self.files_per_subjob]:
                 j.inputdata.files.append(sf)
 

--- a/ganga/GangaCore/test/GPI/TutorialTests.py
+++ b/ganga/GangaCore/test/GPI/TutorialTests.py
@@ -526,7 +526,6 @@ j.submit()
         trf1.outputfiles = [LocalFile("*.txt")]
         d = GangaDataset()
         d.files = [LocalFile("*.txt")]
-        d.treat_as_inputfiles = True
         trf1.addInputData(d)
         trf1.files_per_unit = 1
         trf1.submit_with_threads = True

--- a/ganga/GangaLHCb/Lib/LHCbDataset/LHCbCompressedDataset.py
+++ b/ganga/GangaLHCb/Lib/LHCbDataset/LHCbCompressedDataset.py
@@ -88,7 +88,6 @@ class LHCbCompressedDataset(GangaDataset):
     schema['XMLCatalogueSlice'] = GangaFileItem(defvalue=None, doc='Use contents of file rather than generating catalog.')
     schema['persistency'] = SimpleItem(defvalue=None, typelist=['str', 'type(None)'], doc='Specify the dataset persistency technology')
     schema['credential_requirements'] = ComponentItem('CredentialRequirement', defvalue=None)
-    schema['treat_as_inputfiles'] = SimpleItem(defvalue=False, doc="Treat the inputdata as inputfiles, i.e. copy the inputdata to the WN")
     schema['depth'] = SimpleItem(defvalue = 0, doc='Depth')
     _schema = Schema(Version(3, 0), schema)
     _category = 'datasets'

--- a/ganga/GangaLHCb/Lib/LHCbDataset/LHCbDataset.py
+++ b/ganga/GangaLHCb/Lib/LHCbDataset/LHCbDataset.py
@@ -46,7 +46,6 @@ class LHCbDataset(GangaDataset):
     docstr = 'Specify the dataset persistency technology'
     schema['persistency'] = SimpleItem(
         defvalue=None, typelist=['str', 'type(None)'], doc=docstr)
-    schema['treat_as_inputfiles'] = SimpleItem(defvalue=False, doc="Treat the inputdata as inputfiles, i.e. copy the inputdata to the WN")
 
     _schema = Schema(Version(3, 0), schema)
     _category = 'datasets'


### PR DESCRIPTION
Removes code related to treat_as_inputfiles from all the `.py` files.