### PR TITLE
Extend @add_config Functionality

### DIFF
--- a/ganga/GangaCore/Utility/Config/__init__.py
+++ b/ganga/GangaCore/Utility/Config/__init__.py
@@ -1,5 +1,5 @@
 
-from .Config import getConfig, makeConfig, ConfigError, setSessionValuesFromFiles, allConfigs, setConfigOption, expandConfigPath, config_scope, setSessionValue, setUserValue
+from .Config import getConfig, makeConfig, ConfigError, setSessionValuesFromFiles, allConfigs, setConfigOption, expandConfigPath, config_scope, setSessionValue, setUserValue, setUserValueForTest
 import os.path
 
 ## from Config import getConfigDict

--- a/ganga/GangaCore/test/GPI/TestAddConfigForTest.py
+++ b/ganga/GangaCore/test/GPI/TestAddConfigForTest.py
@@ -1,0 +1,26 @@
+from GangaCore.testlib.decorators import add_config
+from GangaCore.Utility.Config import getConfig
+
+# Case 1: Config Section exists & given option also exists -> Outcome expected: Should change the value of the option.
+@add_config([('Configuration', 'user', 'test')])
+def test_add_config_1(gpi):
+    c = getConfig('Configuration')
+    assert c['user'] == 'test'
+
+# Case 2: Config Section exists BUT (.is_open=False) & given option does NOT exists -> Outcome expected: Should not add option to the config.
+@add_config([('Configuration', 'TestOption', 'TestValue')])
+def test_add_config_2(gpi):
+    try:
+        c = getConfig('Configuration')
+        c['TestOption'] == 'TestValue'
+        assert False, "Should throw an Error"
+    except:
+        assert True
+    
+# Case 3: Config Section does NOT exists -> Outcome expected: Should create a config section with (.is_open=True) & add option to it.
+@add_config([('TestSection', 'TestOption', 'TestValue')])
+def test_add_config_3(gpi):
+    c = getConfig('TestSection')
+    assert c['TestOption'] == 'TestValue'
+
+#TODO Add test case with Config Section (.is_open=True) & option does NOT exist.

--- a/ganga/GangaCore/test/GPI/TestAddConfigForTest.py
+++ b/ganga/GangaCore/test/GPI/TestAddConfigForTest.py
@@ -1,5 +1,5 @@
 from GangaCore.testlib.decorators import add_config
-from GangaCore.Utility.Config import getConfig
+from GangaCore.Utility.Config import getConfig, ConfigError
 
 # Case 1: Config Section exists & given option also exists -> Outcome expected: Should change the value of the option.
 @add_config([('Configuration', 'user', 'test')])
@@ -13,8 +13,8 @@ def test_add_config_2(gpi):
     try:
         c = getConfig('Configuration')
         c['TestOption'] == 'TestValue'
-        assert False, "Should throw an Error"
-    except:
+        assert False, "Should throw an ConfigError"
+    except ConfigError:
         assert True
     
 # Case 3: Config Section does NOT exists -> Outcome expected: Should create a config section with (.is_open=True) & add option to it.

--- a/ganga/GangaCore/testlib/GangaUnitTest.py
+++ b/ganga/GangaCore/testlib/GangaUnitTest.py
@@ -132,12 +132,12 @@ def start_ganga(gangadir_for_test, extra_opts=[], extra_args=None):
     GangaCore.Runtime._prog.parseOptions()
 
     # For all the default and extra options, we set the session value
-    from GangaCore.Utility.Config import setUserValue
+    from GangaCore.Utility.Config import setUserValue, setUserValueForTest
 
     for opts in default_opts, extra_opts:
         for opt in opts:
             try:
-                setUserValue(*opt)
+                setUserValueForTest(*opt)
             except Exception as err:
                 print("Error Setting: %s" % str(opt))
                 print("Err: %s" % err)
@@ -183,7 +183,7 @@ def start_ganga(gangadir_for_test, extra_opts=[], extra_args=None):
     for opts in default_opts, extra_opts:
         for opt in opts:
             try:
-                setUserValue(*opt)
+                setUserValueForTest(*opt)
             except Exception as err:
                 print("Error Setting: %s" % str(opt))
                 print("Err: %s" % err)


### PR DESCRIPTION
Modified @add_config functionality such that now user can externally define config sections which can be used during Tests.

**Problem:** @add_config decorator was unable to create custom config sections which can be used while performing the tests

## **Plausible Solution:**

### **Findings:**

- `pytest` uses `gpi` fixture to create a ganga.GPI namespace with few modified configurations to perform the tests. 

- @add_decorator : adds `_config_values` attribute to the function passed to it and stores the passed configuration values in it.

**Example:** 
```
@add_config([('Configuration', 'user', 'test')])
def test_add_config(gpi):
    assert gpi.config['Configuration'].user == 'test'
```
When executed will add `_config_values` to the function `test_add_config(gpi)` like:
```
print(test_add_config._config_values)
# Output: {('Configuration', 'user'): 'test'}
```

So now when `pytest` is run, the `gpi` fixture takes the values from `_config_values`, converts them into list of 3 tuples. This list is then passed to `start_ganga` function as `extra_opts`

These `extra_opts` are then iterated and each 3 tuple is passed to a function `setUserValue`.

Function `setUserValue`: takes in 3 tuple (config_name, option_name, value) and checks if config_name (config section) exists in config, If it:
- exists, and option_name also exists then modifies the option_name.
- exists but option_name does NOT exist, then if (.is_open=True) then new option is added to the section
- exists but option_name does NOT exist, then if (.is_open=False) then nothing is changed
- rest all remaining config are stored in a dictionary which is not used later to makeConfig
- `.is_open` attribute decides if options are allowed to be added to that specific section.

After this is done, Ganga is bootstrapped and the test is ran in the testing ganga.GPI namespace. After the test is finished all the configuration is changed back to normal hence none of the changed configuration remains.

### **Modification**

Function `setUserValue` to `setUserValueForTest`: takes in 3 tuple (config_name, option_name, value) and checks if config_name (config section) exists in config, If it:
- exists, and option_name also exists then modifies the option_name.
- exists but option_name does NOT exist, then if (.is_open=True) then new option is added to the section
- exists but option_name does NOT exist, then if (.is_open=False) then nothing is changed
- does NOT exist then created the section using `makeConfigForTest` and adds the option.

Function `makeConfig` to `makeConfigForTest`: takes in all the same arguments as `makeConfig` but just the bootstrap restriction is removed as config whose sections are to be created for testing purposes can be done after bootstrapping too.

**Results**
`pytest` were created to confirm the functionality.
<img width="1421" alt="Screenshot 2020-03-09 at 4 06 53 AM" src="https://user-images.githubusercontent.com/47035057/76172418-9da77f00-61bb-11ea-828f-7b4d69c957ad.png">

After the `pytest`, persistence of modified configuration was tested in normal ganga GPI
<img width="1421" alt="Screenshot 2020-03-09 at 4 08 13 AM" src="https://user-images.githubusercontent.com/47035057/76172423-be6fd480-61bb-11ea-88a1-969a473602f4.png">
and the configuration did NOT exists.

### **Location**
**@add_config**
https://github.com/ganga-devs/ganga/blob/f79c9597443512b67ab451ce3e536c4751094b45/ganga/GangaCore/testlib/decorators.py#L4
**gpi**
https://github.com/ganga-devs/ganga/blob/f79c9597443512b67ab451ce3e536c4751094b45/ganga/GangaCore/testlib/fixtures.py#L34
**start_ganga**
https://github.com/ganga-devs/ganga/blob/f79c9597443512b67ab451ce3e536c4751094b45/ganga/GangaCore/testlib/GangaUnitTest.py#L62
**setUserValue**
https://github.com/ganga-devs/ganga/blob/f79c9597443512b67ab451ce3e536c4751094b45/ganga/GangaCore/Utility/Config/Config.py#L930
**makeConfig**
https://github.com/ganga-devs/ganga/blob/f79c9597443512b67ab451ce3e536c4751094b45/ganga/GangaCore/Utility/Config/Config.py#L180