### PR TITLE
Path to singularity

### DIFF
--- a/ganga/GangaCore/Lib/Virtualization/Singularity.py
+++ b/ganga/GangaCore/Lib/Virtualization/Singularity.py
@@ -66,7 +66,7 @@ class Singularity(IVirtualization):
     If the singularity binary is not available in the PATH on the remote node - or has a different name, 
     it is possible to give the name of it like
 
-      j.virtualization.binary='/cvmfs/atlas.cern.ch/repo/containers/sw/singularity/x86_64-el7/current/bin/singularity'
+      j.virtualization.binary='/cvmfs/oasis.opensciencegrid.org/mis/singularity/current/bin/singularity'
 
     """
     _name = 'Singularity'

--- a/ganga/GangaCore/Lib/Virtualization/Singularity.py
+++ b/ganga/GangaCore/Lib/Virtualization/Singularity.py
@@ -97,6 +97,12 @@ class Singularity(IVirtualization):
 
         extra = extra + """
 print("Using singularity")
+
+import stat
+if not ( ('XDG_RUNTIME_DIR' in runenv) and os.path.isdir(runenv['XDG_RUNTIME_DIR']) and (stat.S_IMODE(os.stat(runenv['XDG_RUNTIME_DIR']).st_mode) == 0o700) ):
+    os.mkdir('.xdg', 0o700)
+    runenv['XDG_RUNTIME_DIR'] = os.path.join(os.getcwd(), '.xdg')
+           
 options = []
 if virtualization_user:
     runenv["SINGULARITY_DOCKER_USERNAME"] = virtualization_user
@@ -113,7 +119,7 @@ if execmd[0].startswith('./'):
 
         if sandbox:
             extra = extra + """
-runenv['SINGULARITY_CACHEDIR']=path.join(getcwd(),'.singularity','cache')
+runenv['SINGULARITY_CACHEDIR']=os.path.join(os.getcwd(),'.singularity','cache')
 for i in range(3):
     try:
         buildcommand = [virtualization_binary, 'build', '--sandbox', 'singularity_sandbox' , virtualization_image]

--- a/ganga/GangaCore/Lib/Virtualization/Singularity.py
+++ b/ganga/GangaCore/Lib/Virtualization/Singularity.py
@@ -69,7 +69,10 @@ class Singularity(IVirtualization):
     _schema.datadict['image'] = SimpleItem(defvalue="",
                                            typelist=[str,'GangaCore.GPIDev.Adapters.IGangaFile.IGangaFile'],
                                            doc='Link to the container image. This can either be a singularity URL or a GangaFile object')
-
+    _schema.datadict['binary'] = SimpleItem(defvalue="singularity",
+                                            typelist=[str],
+                                            doc='The virtualization binary itself. Can be an absolute path if required.')
+    
     def modify_script(self, script, sandbox=False):
         """Overides parent's modify_script function
                     Arguments other than self:
@@ -85,6 +88,7 @@ class Singularity(IVirtualization):
         extra = extra + 'virtualization_password = ' + repr(self.tokenpassword) + '\n'
         extra = extra + 'virtualization_mounts = ' + repr(self.mounts) + '\n'
         extra = extra + 'virtualization_options = ' + repr(self.options) + '\n'
+        extra = extra + 'virtualization_binary = ' + repr(self.binary) + '\n'
 
         extra = extra + """
 print("Using singularity")
@@ -107,19 +111,19 @@ if execmd[0].startswith('./'):
 runenv['SINGULARITY_CACHEDIR']=path.join(getcwd(),'.singularity','cache')
 for i in range(3):
     try:
-        buildcommand = ['singularity', 'build', '--sandbox', 'singularity_sandbox' , virtualization_image]
+        buildcommand = [virtualization_binary, 'build', '--sandbox', 'singularity_sandbox' , virtualization_image]
         rc = subprocess.call(buildcommand, env=runenv, shell=False)
         if rc==0:
             break
     except Exception as x:
         print('Exception occured in downloading Singularity image: ' + str(buildcommand))
         print('Err was: ' + str(x))
-execmd = ['singularity', '-q', 'exec', '--bind', 
+execmd = [virtualization_binary, '-q', 'exec', '--bind', 
           workdir+":"+"/work_dir", "--no-home"] + options + ['singularity_sandbox'] + execmd   
 """
         else:
             extra = extra + """
-execmd = ['singularity', '-q', 'exec', '--bind',
+execmd = [virtualization_binary, '-q', 'exec', '--bind',
           workdir+":"+"/work_dir", "--no-home"] + options + [virtualization_image] + execmd   
 
 """

--- a/ganga/GangaCore/Lib/Virtualization/Singularity.py
+++ b/ganga/GangaCore/Lib/Virtualization/Singularity.py
@@ -26,10 +26,9 @@ class Singularity(IVirtualization):
     The container can also be provided as a Docker image from a repository. The 
     default repository is Docker hub.
 
-
       j.virtualization = Singularity("docker://gitlab-registry.cern.ch/lhcb-core/lbdocker/centos7-build:v3")
 
-      j.virtualization = Docker("docker://fedora:latest")   
+      j.virtualization = Singularity("docker://fedora:latest")   
 
     Another option is to provide a `GangaFile` Object which points to a 
     singularity file. In that case the singularity image file will be copied to 
@@ -40,7 +39,7 @@ class Singularity(IVirtualization):
       imagefile = SharedFile('myimage.sif', locations=['/my/full/path/myimage.sif'])
       j.virtualization = Singularity(image= imagefile)
 
-    while a second example is with an image located in he Dirac Storage 
+    while a second example is with an image located in the Dirac Storage 
     Element. This will be effective when using the Dirac backend.
 
       imagefile = DiracFile('myimage.sif', lfn=['/some/lfn/path'])
@@ -55,7 +54,7 @@ class Singularity(IVirtualization):
       j.virtualization.tokenpassword = 'gftrh84dgel-245^ghHH'
 
     Directories can be mounted from the host to the container using key-value 
-    pairs to the mounts option. If the directory is not vailable on the host, a 
+    pairs to the mounts option. If the directory is not available on the host, a 
     warning will be written to stderr of the job and no mount will be attempted.
 
       j.virtualization.mounts = {'/cvmfs':'/cvmfs'}
@@ -63,6 +62,12 @@ class Singularity(IVirtualization):
     By default the container is started in singularity with the `--nohome` 
     option. Extra options can be provided through the `options` attribute. See 
     the Singularity documentation for what is possible.
+
+    If the singularity binary is not available in the PATH on the remote node - or has a different name, 
+    it is possible to give the name of it like
+
+      j.virtualization.binary='/cvmfs/atlas.cern.ch/repo/containers/sw/singularity/x86_64-el7/current/bin/singularity'
+
     """
     _name = 'Singularity'
     _schema = IVirtualization._schema.inherit_copy()


### PR DESCRIPTION
This change will allow a user to specify where to find the singularity binary. An example is 
```
j.virtualization.binary='/cvmfs/atlas.cern.ch/repo/containers/sw/singularity/x86_64-el7/current/bin/singularity'
```
