### PR TITLE
Update 'ShutdownManager.py' To Conditionally Run 'stop_gui()'

### DIFF
--- a/ganga/GangaCore/Core/InternalServices/ShutdownManager.py
+++ b/ganga/GangaCore/Core/InternalServices/ShutdownManager.py
@@ -58,11 +58,12 @@ def _unprotected_ganga_exitfuncs():
     setConfigOption('Configuration', 'DiskIOTimeout', 1)
 
     # Stop GUIServerThread
-    from GangaGUI.start import stop_gui
-    try:
-        stop_gui()
-    except Exception as err:
-        logger.exception("Exception raised while stopping GUI: {}".format(err))
+    from GangaGUI.start import stop_gui, gui_server
+    if gui_server is not None:
+        try:
+            stop_gui()
+        except Exception as err:
+            logger.exception("Exception raised while stopping GUI: {}".format(err))
 
     # Stop the monitoring loop from iterating further
     if monitoring_component is not None:

--- a/ganga/GangaGUI/start.py
+++ b/ganga/GangaGUI/start.py
@@ -44,7 +44,7 @@ def stop_gui():
         if gui_server.shutdown():
             gui_server = None
         else:
-            raise Exception("Error in shutting down the server.")
+            raise Exception("Error in shutting down the GUI server.")
 
 
 # Use this for starting the server for development purposes

--- a/ganga/GangaGUI/start.py
+++ b/ganga/GangaGUI/start.py
@@ -25,6 +25,9 @@ class GUIServerThread(GangaThread):
     def shutdown(self):
         res = requests.post("http://localhost:{port}/shutdown".format(port=self.port))
         logger.info("{} - {}".format(res.status_code, res.text))
+        if res.status_code == 200:
+            return True
+        return False
 
 
 def start_gui(host: str = "localhost", port: int = 5000):
@@ -38,7 +41,10 @@ def stop_gui():
     """Stop GUI Flask App on a GangaThread"""
     global gui_server
     if gui_server is not None:
-        gui_server.shutdown()
+        if gui_server.shutdown():
+            gui_server = None
+        else:
+            raise Exception("Error in shutting down the server.")
 
 
 # Use this for starting the server for development purposes


### PR DESCRIPTION
This provides a fix by adding a conditional check to only run `stop_gui()` function is the GUIServerThread is running when shutting down Ganga.