### PR TITLE
Disk checker for Dirac

### DIFF
--- a/ganga/GangaCore/Core/exceptions.py
+++ b/ganga/GangaCore/Core/exceptions.py
@@ -20,6 +20,10 @@ class GangaFileError(GangaException):
     This is intended to be thrown as an IGangaFile Error during Runtime
     """
 
+class GangaDiskSpaceError(GangaException):
+    """
+    Specific for issues with running out of disk space
+    """
 
 class PluginError(GangaException):
     """

--- a/ganga/GangaCore/Runtime/Repository_runtime.py
+++ b/ganga/GangaCore/Runtime/Repository_runtime.py
@@ -9,7 +9,7 @@ from GangaCore.Utility.logging import getLogger
 from GangaCore.Utility.files import expandfilename, fullpath
 from GangaCore.Core.GangaRepository import getRegistries
 from GangaCore.Core.GangaRepository import getRegistry
-from GangaCore.Core.exceptions import GangaException
+from GangaCore.Core.exceptions import GangaException, GangaDiskSpaceError
 
 config = getConfig('Configuration')
 logger = getLogger()
@@ -86,7 +86,7 @@ def checkDiskQuota():
                 logger.error("To prevent repository corruption and data loss we won't start GangaCore.")
                 logger.error("Either set your config variable 'force_start' in .gangarc to enable starting and ignore this check.")
                 logger.error("Or, make sure you have more than %s percent free disk space on: %s" %(100-partition_critical, data_partition))
-                raise GangaException("Not Enough Disk Space!!!")
+                raise GangaDiskSpaceError("Not Enough Disk Space!!!")
         except GangaException as err:
             raise
         except Exception as err:

--- a/ganga/GangaCore/Utility/util.py
+++ b/ganga/GangaCore/Utility/util.py
@@ -3,7 +3,7 @@
 #
 # $Id: util.py,v 1.1 2008-07-17 16:41:01 moscicki Exp $
 ##########################################################################
-
+from functools import wraps
 """
  This file contains general-purpose utilities, mainly Python Cookbook recipes.
 """
@@ -256,6 +256,27 @@ def proxy(obj, *specials):
             setattr(cls, name, make_binder(unbounded_method))
         known_proxy_classes[key] = cls
     return cls(obj)
+
+#Decorator to check for disk space
+def require_disk_space(method):
+    """
+    A decorator that checks if disk space is available before executing a command
+    If no disk space is available then a GangaDiskSpaceError is raised
+    """
+    from GangaCore.Core.exceptions import GangaDiskSpaceError
+    from GangaCore.Runtime.Repository_runtime import checkDiskQuota
+    @wraps(method)
+    def ds_wrapped_method(self, *args, **kwargs):
+        raise GangaDiskSpaceError("Function cannot be run - no Disk space available!")
+
+        try:
+            checkDiskQuota()
+        except GangaDiskSpaceError as disk_err:
+            raise GangaDiskSpaceError("Function cannot be run - no Disk space available!")
+
+        return method(self, *args, **kwargs)
+
+    return ds_wrapped_method
 
 # ------------------------
 # cookbook recipe

--- a/ganga/GangaCore/Utility/util.py
+++ b/ganga/GangaCore/Utility/util.py
@@ -267,8 +267,6 @@ def require_disk_space(method):
     from GangaCore.Runtime.Repository_runtime import checkDiskQuota
     @wraps(method)
     def ds_wrapped_method(self, *args, **kwargs):
-        raise GangaDiskSpaceError("Function cannot be run - no Disk space available!")
-
         try:
             checkDiskQuota()
         except GangaDiskSpaceError as disk_err:

--- a/ganga/GangaDirac/Lib/Backends/DiracBase.py
+++ b/ganga/GangaDirac/Lib/Backends/DiracBase.py
@@ -28,6 +28,7 @@ from GangaCore.Core.GangaThread.WorkerThreads import getQueues
 from GangaCore.Core import monitoring_component
 from GangaCore.Runtime.GPIexport import exportToGPI
 from subprocess import check_output, CalledProcessError
+from GangaDirac import require_disk_space
 configDirac = getConfig('DIRAC')
 default_finaliseOnMaster = configDirac['default_finaliseOnMaster']
 default_downloadOutputSandbox = configDirac['default_downloadOutputSandbox']
@@ -711,6 +712,7 @@ class DiracBase(IBackend):
             logger.error("No peeking available for Dirac job '%i'.", self.id)
 
     @require_credential
+    @require_disk_space
     def getOutputSandbox(self, outputDir=None, unpack=True):
         """Get the outputsandbox for the job object controlling this backend
         Args:
@@ -763,6 +765,7 @@ class DiracBase(IBackend):
         else:
             outputfiles_foreach(j, DiracFile, lambda x: clearFileInfo(x))
 
+    @require_disk_space
     def getOutputData(self, outputDir=None, names=None, force=False):
         """Retrieve data stored on SE to dir (default=job output workspace).
         If names=None, then all outputdata is downloaded otherwise names should
@@ -860,6 +863,7 @@ class DiracBase(IBackend):
         except GangaDiracError as err:
             logger.error("%s" % err)
 
+    @require_disk_space
     def finaliseCompletingJobs(self, downloadSandbox=True):
         """
          A function to finalise all the subjobs in the completing state, so they are ready, before all the subjobs complete.
@@ -969,6 +973,7 @@ class DiracBase(IBackend):
         # malformed job output?
 
     @staticmethod
+    @require_disk_space
     def _internal_job_finalisation(job, updated_dirac_status):
         """
         This method performs the main job finalisation
@@ -1187,6 +1192,7 @@ class DiracBase(IBackend):
             getQueues()._monitoring_threadpool.add_function(DiracBase.finalise_jobs_thread_func, (jobSlice, downloadSandbox))
 
     @staticmethod
+    @require_disk_space
     def finalise_jobs_thread_func(jobSlice, downloadSandbox = True):
         """
         Finalise the jobs given. This downloads the output sandboxes, gets the final Dirac statuses, completion times etc.

--- a/ganga/GangaDirac/__init__.py
+++ b/ganga/GangaDirac/__init__.py
@@ -1,12 +1,13 @@
 import os
 #from multiprocessing     import cpu_count
+from functools import wraps
 from GangaCore.Utility.Config import makeConfig, getConfig
 from GangaCore.Utility.logging import getLogger
 
 from GangaCore.Utility.Config.Config import _after_bootstrap
 
 from GangaCore.GPIDev.Credentials.CredentialStore import credential_store
-
+from GangaDirac.Lib.Utilities.DiracUtilities import GangaDiracError
 logger = getLogger()
 
 if not _after_bootstrap:
@@ -123,4 +124,24 @@ def postBootstrapHook():
         credential_store[DiracProxy()]
     except KeyError:
         pass
+
+def require_disk_space(method):
+    """
+    A decorator that checks if disk space is available before executing a command
+    If no disk space is available then a GangaDiracError is raised
+    """
+
+    @wraps(method)
+    def ds_wrapped_method(self, *args, **kwargs):
+
+        is_memory_available = False
+        
+        if not is_memory_available:
+            raise GangaDiracError("No Disk space!")
+
+        return method(self, *args, **kwargs)
+
+    return ds_wrapped_method
+
+
 

--- a/ganga/GangaDirac/__init__.py
+++ b/ganga/GangaDirac/__init__.py
@@ -1,13 +1,12 @@
 import os
 #from multiprocessing     import cpu_count
-from functools import wraps
 from GangaCore.Utility.Config import makeConfig, getConfig
 from GangaCore.Utility.logging import getLogger
 
 from GangaCore.Utility.Config.Config import _after_bootstrap
 
 from GangaCore.GPIDev.Credentials.CredentialStore import credential_store
-from GangaDirac.Lib.Utilities.DiracUtilities import GangaDiracError
+
 logger = getLogger()
 
 if not _after_bootstrap:
@@ -124,24 +123,4 @@ def postBootstrapHook():
         credential_store[DiracProxy()]
     except KeyError:
         pass
-
-def require_disk_space(method):
-    """
-    A decorator that checks if disk space is available before executing a command
-    If no disk space is available then a GangaDiracError is raised
-    """
-
-    @wraps(method)
-    def ds_wrapped_method(self, *args, **kwargs):
-
-        is_memory_available = False
-        
-        if not is_memory_available:
-            raise GangaDiracError("No Disk space!")
-
-        return method(self, *args, **kwargs)
-
-    return ds_wrapped_method
-
-
 

--- a/ganga/GangaDirac/test/Unit/Backends/TestDiracBase.py
+++ b/ganga/GangaDirac/test/Unit/Backends/TestDiracBase.py
@@ -1,7 +1,7 @@
 import tempfile
 import os
 import pytest
-
+from functools import wraps
 try:
     from unittest.mock import patch, Mock
 except ImportError:
@@ -14,6 +14,7 @@ from GangaCore.Lib.Splitters import ArgSplitter
 from GangaCore.Lib.Executable import Executable
 from GangaDirac.Lib.Utilities.DiracUtilities import GangaDiracError
 from GangaCore.testlib.GangaUnitTest import load_config_files, clear_config
+from GangaCore.Core.exceptions import GangaDiskSpaceError
 
 script_template = """
 # dirac job created by ganga
@@ -58,6 +59,24 @@ def db():
     load_config_files()
     from GangaDirac.Lib.Backends.DiracBase import DiracBase
     yield DiracBase()
+    clear_config()
+
+@pytest.yield_fixture(scope='function')
+def db_full():
+    def mock_disk_space_full_decorator(f):
+        @wraps(f)
+        def decorated_function(self, *args, **kwargs):
+            raise GangaDiskSpaceError("Mock no disk space!")
+        
+            return f(self, *args, **kwargs)
+        return decorated_function
+    import GangaCore.Utility.util
+    GangaCore.Utility.util.require_disk_space = mock_disk_space_full_decorator
+    load_config_files()
+    from GangaDirac.Lib.Backends import DiracBase
+    import importlib
+    importlib.reload(DiracBase)
+    yield DiracBase.DiracBase()
     clear_config()
 
 
@@ -287,7 +306,6 @@ def test_getOutputSandbox(db, mocker):
         assert not db.getOutputSandbox(test_dir), 'didn\'t fail gracefully'
         execute.assert_called_once()
 
-
 def test_removeOutputData(db):
     from GangaDirac.Lib.Files.DiracFile import DiracFile
 
@@ -434,3 +452,64 @@ def test_getOutputDataLFNs(db):
 
         subjob = True
         assert db.getOutputDataLFNs() == ['a', 'b', 'c'] * 3
+
+def test_getOutputSandbox_diskFull(db_full, mocker):
+    mocker.patch('GangaCore.GPIDev.Credentials.credential_store')
+
+    j = Job()
+    j.id = 0
+    j.backend = db_full
+    db_full._parent = j
+    db_full.id = 1234
+
+    temp_dir = j.getOutputWorkspace().getPath()
+    with patch('GangaDirac.Lib.Backends.DiracBase.execute', return_value=True) as execute:
+        with pytest.raises(GangaDiskSpaceError) as execinfo:
+            assert not  db_full.getOutputSandbox(), 'didn\'t run'
+            assert str(execinfo.value)=='Mock no disk space!'
+
+def test_getOutputData_diskFull(db_full, tmpdir):
+    from GangaDirac.Lib.Files.DiracFile import DiracFile
+
+    j = Job()
+    j.id = 0
+    j.backend = db_full
+    db_full._parent = j
+
+    with pytest.raises(GangaDiskSpaceError) as execinfo:
+        assert not db_full.getOutputData('/false/dir')
+        assert str(execinfo.value)=='Mock no disk space!'
+
+    #######################
+    class TestFile(object):
+        def __init__(self, lfn, namePattern):
+            self.lfn = lfn
+            self.namePattern = namePattern
+
+        def get(self):
+            self.check = 42
+
+    test_files = [TestFile('a', 'alpha'), TestFile('', 'delta'),
+                  TestFile('b', 'beta'), TestFile('', 'bravo'),
+                  TestFile('c', 'charlie'), TestFile('', 'foxtrot')]
+
+    #######################
+
+    def fake_outputfiles_iterator(job, file_type):
+        assert isinstance(job, Job)
+        if subjob:
+            assert job.master is not None
+        else:
+            assert job.master is None
+            assert file_type == DiracFile
+        return test_files
+
+    with patch('GangaDirac.Lib.Backends.DiracBase.outputfiles_iterator', fake_outputfiles_iterator):
+
+        # master jobs
+        #######################
+        subjob = False
+        with pytest.raises(GangaDiskSpaceError) as execinfo:
+            assert not db_full.getOutputData() == ['a', 'b', 'c']
+            assert str(execinfo.value)=='Mock no disk space!'
+


### PR DESCRIPTION
Fixes #1682 

Add a decorator to check the available disk space before running the function.

I have wrapped everything in `DiracBase.py` that does downloading. If the check fails then an exception is raised and the job ends up in the failed state.

The message is hopefully clear enough so that users know to use `j.backend.reset()` to push the job back to `submitted` and then finalise again. Would it be preferable to leave it in completing instead?

Do we want this decorator in GangaCore for general usage?

Also this doesn't work if the `gangadir` is on EOS but users shouldn't be using that anyway.