### PR TITLE
Fill in DiracEnvSource for LHCb

### DIFF
--- a/ganga/GangaLHCb/LHCb.ini
+++ b/ganga/GangaLHCb/LHCb.ini
@@ -26,6 +26,8 @@ DiracCommandFiles = ["@{GANGA_PYTHONPATH}/GangaLHCb/Lib/Server/DiracLHCbDefiniti
                      "@{GANGA_PYTHONPATH}/GangaDirac/Lib/Server/DiracCommands.py",
                      "@{GANGA_PYTHONPATH}/GangaLHCb/Lib/Server/DiracLHCbCommands.py"]
 
+DiracEnvSource = nonsense
+
 [Output]
 ForbidLegacyInput = True
 ForbidLegacyOutput = True


### PR DESCRIPTION
Put a nonsense value in LHCb.ini so LHCb users are not prompted for it.