### PR TITLE
Fix compressed dataset length

### DIFF
--- a/ganga/GangaLHCb/Lib/LHCbDataset/LHCbCompressedDataset.py
+++ b/ganga/GangaLHCb/Lib/LHCbDataset/LHCbCompressedDataset.py
@@ -169,7 +169,7 @@ class LHCbCompressedDataset(GangaDataset):
 
     def __len__(self):
         '''Redefine the __len__ function'''
-        return self.total
+        return self._totalNFiles()
 
     def __getitem__(self, i):
         '''Proivdes scripting (e.g. ds[2] returns the 3rd file) '''


### PR DESCRIPTION
I would like to merge this and release a new version straight away as this bug is pretty bad.

The old method was just returning a quantity that is not persisted so loading the object from disk would always return length 0.