### PR TITLE
Fix setting application platforms for LHCb

### DIFF
--- a/ganga/GangaLHCb/Lib/RTHandlers/RTHUtils.py
+++ b/ganga/GangaLHCb/Lib/RTHandlers/RTHUtils.py
@@ -47,7 +47,7 @@ j.setAncestorDepth(###ANCESTOR_DEPTH###)
 
 
     DiracScript = DiracScript.replace('\'###EXE_LOG_FILE###\'', '\'###EXE_LOG_FILE###\', systemConfig=\'###PLATFORM###\'')
-    DiracScript = DiracScript.replace('j.setPlatform( \'ANY\' )', 'j.setDIRACPlatform()')
+    DiracScript = DiracScript.replace('j.setPlatform( \'###PLATFORM###\' )', 'j.setDIRACPlatform()')
 
     setName_str = 'j.setName(\'###NAME###\')'
     DiracScript = DiracScript.replace(setName_str, "%s\n%s" % (setName_str, DiracLHCb_Options))


### PR DESCRIPTION
In #1528 the [template for the DIRAC submission script](https://github.com/ganga-devs/ganga/commit/d65331e786b7c9073e7fe745f11e8ccbf95c587e#diff-99c765b1eb788172b420a7a55e58e926) was changed but `lhcbdiracAPI_script_template` wasn't updated to match.

This is the reason user jobs haven't been matched at various sites including `LCG.CSCS.ch`. Setting the platform in the JDL to `x86_64-centos7-gcc9-opt` (instead of `nehalem-centos7`) means it looks for worker nodes with an OS called `centos7-gcc9-opt`. Jobs are still matched to sites where singularity is useable as it bypasses the OS check.

It's probably worth adding some sanity checks here like `assert "j.setPlatform( \'###PLATFORM###\' )" in DiracScript` so this would have been caught sooner.

cc @VladimirRomanovsky 