### PR TITLE
Hide the compressed filesets in LHCbCompressedDataset

### DIFF
--- a/ganga/GangaCore/GPIDev/Lib/GangaList/GangaList.py
+++ b/ganga/GangaCore/GPIDev/Lib/GangaList/GangaList.py
@@ -127,6 +127,10 @@ class GangaList(GangaObject):
         self._is_a_ref = False
         super(GangaList, self).__init__()
 
+    def setPrintSummary(self):
+        '''Set the summary print'''
+        setattr(self, 'printSummary', True)
+
     # convenience methods
     @staticmethod
     def is_list(obj):
@@ -600,8 +604,13 @@ class GangaList(GangaObject):
         schema_entry = self.findSchemaParentSchemaEntry(parent)
 
         if parent is None:
-            full_print(self, out)
-            return
+            if hasattr(self, 'printSummary'):
+                self_len = len(self)
+                out.write(decorateListEntries(self_len, getName(type(self[0]))))
+                return
+            else:
+                full_print(self, out)
+                return
 
         if schema_entry:
             self_len = len(self)

--- a/ganga/GangaLHCb/Lib/LHCbDataset/LHCbCompressedDataset.py
+++ b/ganga/GangaLHCb/Lib/LHCbDataset/LHCbCompressedDataset.py
@@ -139,7 +139,7 @@ class LHCbCompressedDataset(GangaDataset):
             if isType(files[0], LHCbCompressedFileSet):
                     self.addSet.extend(files)
 
-        #self.files._setParent(self)
+        self.files._setParent(self)
         self.persistency = persistency
         self.current = 0
         logger.debug("Dataset Created")
@@ -269,7 +269,7 @@ class LHCbCompressedDataset(GangaDataset):
         LHCbDataset, DiracFile or a list of string of LFNs'''
 
         if isType(other, LHCbCompressedDataset):
-            self._getFileSets().extend(other.files)
+            self._getFileSets().extend(other._getFileSets())
         elif isType(other, GangaLHCb.Lib.LHCbDataset.LHCbDataset):
             lfns = other.getLFNs()
             self._getFileSets().append(LHCbCompressedFileSet(lfns))

--- a/ganga/GangaLHCb/Lib/LHCbDataset/LHCbCompressedDataset.py
+++ b/ganga/GangaLHCb/Lib/LHCbDataset/LHCbCompressedDataset.py
@@ -52,7 +52,7 @@ class LHCbCompressedFileSet(GangaObject):
                 self.lfn_prefix = commonpath
                 self.suffixes = suffixes
             else:
-                self.files.append(files)
+                self._getFileSets().append(files)
 
     def __len__(self):
         return len(self.suffixes)
@@ -102,44 +102,44 @@ class LHCbCompressedDataset(GangaDataset):
 
     def __init__(self, files=None, metadata = None, persistency=None, depth=0, fromRef=False):
         super(LHCbCompressedDataset, self).__init__()
-        self.files = []
+        setattr(self, 'files', [])
         #if files is an LHCbDataset
 
         if files and isType(files, GangaLHCb.Lib.LHCbDataset.LHCbDataset):
             newset = LHCbCompressedFileSet(files.getLFNs())
-            self.files.append(newset)
+            self.addSet(newset)
         #if files is an LHCbCompressedDataset
         if files and isType(files, LHCbCompressedDataset):
-            self.files.extend(files.files)
+            self.addSet(files.files)
         #if files is just a string
         if files and isType(files, str):
             newset = LHCbCompressedFileSet(files)
-            self.files.append(newset)
+            self.addSet(newset)
         #if files is a single DiracFile
         if files and isType(files, DiracFile):
             newset = LHCbCompressedFileSet(files.lfn)
-            self.files.append(newset)
+            self.addSet(newset)
         #if files is a single LHCbCompressedFileSet
         if files and isType(files, LHCbCompressedFileSet):
-            self.files.append(files)
+            self.addSet(files)
         #if files is a list
         if files and isType(files, [list, GangaList]):
             #Is it a list of strings? Then it may have been produced from the BKQuery so pass along the metadata as well
             if isType(files[0], str):
                 newset = LHCbCompressedFileSet(files)
-                self.files.append(newset)
+                self.addSet(newset)
             #Is it a list of DiracFiles?
             if isType(files[0], DiracFile):
                 lfns = []
                 for _df in files:
                     lfns.append(_df.lfn)
                 newset = LHCbCompressedFileSet(lfns)
-                self.files.append(newset)
+                self.addSset.append(newset)
             #Is it a list of file sets?
             if isType(files[0], LHCbCompressedFileSet):
-                    self.files.extend(files)
+                    self.addSet.extend(files)
 
-        self.files._setParent(self)
+        #self.files._setParent(self)
         self.persistency = persistency
         self.current = 0
         logger.debug("Dataset Created")
@@ -149,26 +149,35 @@ class LHCbCompressedDataset(GangaDataset):
         '''Figure out where a file of index i is. Returns the subset no and the location within that subset'''
         setNo = 0
         fileTotal = 0
-        while fileTotal < i+1 and setNo < len(self.files):
-            fileTotal += len(self.files[setNo])
+        while fileTotal < i+1 and setNo < len(self._getFileSets()):
+            fileTotal += len(self._getFileSets()[setNo])
             setNo += 1
         if fileTotal < i:
             return -1, -1
         setNo = setNo - 1
-        fileTotal = fileTotal - len(self.files[setNo])
+        fileTotal = fileTotal - len(self._getFileSets()[setNo])
         setLocation = i - fileTotal
         return setNo, setLocation
 
     def _totalNFiles(self):
         '''Return the total no. of files in the dataset'''
         total = 0
-        for _set in self.files:
+        for _set in self._getFileSets():
             total += len(_set)
         return total
 
     def __len__(self):
         '''Redefine the __len__ function'''
         return self._totalNFiles()
+
+    def __getattribute__(self, name):
+        if name == 'files':
+            outList = GangaList()
+            for _set in self._getFileSets():
+                outList.extend(_set.getLFNs())
+            return outList
+        else:
+            return super(LHCbCompressedDataset, self).__getattribute__(name)
 
     def __getitem__(self, i):
         '''Proivdes scripting (e.g. ds[2] returns the 3rd file) '''
@@ -183,14 +192,14 @@ class LHCbCompressedDataset(GangaDataset):
             #If we are going backwards start at the end
             if i.step and i.step < 0:
                 step = -1
-                setNo = len(self.files)-1
+                setNo = len(self._getFileSets())-1
             currentPrefix = None
             #Iterate over the LFNs and find out where it came from
             ds = LHCbCompressedDataset()
             tempList = []
             j = 0
             while j < len(newLFNs):
-                if newLFNs[j] in self.files[setNo].getLFNs():
+                if newLFNs[j] in self._getFileSets()[setNo].getLFNs():
                     tempList.append(newLFNs[j])
                     j += 1
                 else:
@@ -205,7 +214,7 @@ class LHCbCompressedDataset(GangaDataset):
             if setNo < 0 or i >= self._totalNFiles():
                 logger.error("Unable to retrieve file %s. It is larger than the dataset size" % i)
                 return None
-            ds = DiracFile(lfn = self.files[setNo].getLFN(setLocation), credential_requirements = self.credential_requirements)
+            ds = DiracFile(lfn = self._getFileSets()[setNo].getLFN(setLocation), credential_requirements = self.credential_requirements)
         return ds
 
     def __iter__(self):
@@ -221,9 +230,16 @@ class LHCbCompressedDataset(GangaDataset):
             self.current += 1
             return self[self.current-1]
 
+    def _getFileSets(self):
+        '''Internal method to get the list of file sets'''
+        return super(LHCbCompressedDataset, self).__getattribute__('files')
+
     def addSet(self, newSet):
         '''Add a new FileSet to the dataset'''
-        self.files.append(newSet)
+        if isType(newSet, [list, GangaList]):
+            self._getFileSets().extend(newSet)
+        else:
+            self._getFileSets().append(newSet)
 
     def getFileNames(self):
         'Returns a list of the names of all files stored in the dataset'
@@ -252,14 +268,14 @@ class LHCbCompressedDataset(GangaDataset):
         LHCbDataset, DiracFile or a list of string of LFNs'''
 
         if isType(other, LHCbCompressedDataset):
-            self.files.extend(other.files)
+            self._getFileSets().extend(other.files)
         elif isType(other, GangaLHCb.Lib.LHCbDataset.LHCbDataset):
             lfns = other.getLFNs()
-            self.files.append(LHCbCompressedFileSet(lfns))
+            self._getFileSets().append(LHCbCompressedFileSet(lfns))
         elif isType(other, DiracFile):
-            self.files.append(LHCbCompressedFileSet(other.lfn))
+            self._getFileSets().append(LHCbCompressedFileSet(other.lfn))
         elif isType(other, [list, tuple, GangaList]):
-            self.files.append(LHCbCompressedFileSet(other))
+            self._getFilesSets().append(LHCbCompressedFileSet(other))
         else:
             logger.error("Cannot add object of type %s to an LHCbCompressedDataset" % type(other))
 
@@ -268,7 +284,7 @@ class LHCbCompressedDataset(GangaDataset):
         lfns = []
         if not self:
             return lfns
-        for fileset in self.files:
+        for fileset in self._getFileSets():
             lfns.extend(fileset.getLFNs())
         logger.debug("Returning #%s LFNS" % str(len(lfns)))
         return lfns

--- a/ganga/GangaLHCb/Lib/LHCbDataset/LHCbCompressedDataset.py
+++ b/ganga/GangaLHCb/Lib/LHCbDataset/LHCbCompressedDataset.py
@@ -173,8 +173,9 @@ class LHCbCompressedDataset(GangaDataset):
     def __getattribute__(self, name):
         if name == 'files':
             outList = GangaList()
+            outList.setPrintSummary()
             for _set in self._getFileSets():
-                outList.extend(_set.getLFNs())
+                outList.extend([DiracFile(lfn = _lfn) for _lfn in _set.getLFNs()])
             return outList
         else:
             return super(LHCbCompressedDataset, self).__getattribute__(name)

--- a/ganga/GangaLHCb/test/GPI/TestDatasets.py
+++ b/ganga/GangaLHCb/test/GPI/TestDatasets.py
@@ -91,7 +91,7 @@ class TestDatasets(GangaUnitTest):
         assert ds1[2].lfn == '/second/path/set/c'
         assert isinstance(ds1[0:2], LHCbCompressedDataset)
         assert len(ds1[0:2]) == 2
-        assert len(ds1[0:2].files) == 1
+        assert len(ds1[0:2].files) == 2
         assert len(ds1[::2]) == 2
 
         #Check the getLFNs


### PR DESCRIPTION
Fixes #1741 

The LHCbCompresedFileSet is now hidden. `ds.files` returns a list of DiracFiles as per the regular LHCbDataset. In general this now appears to behave much like the `LHCbDataset`.

There is a little hack to `GangaList` so it prints a summary instead of the whole file list. This is needed as the thing returned by the `__getattribute__` doesn't have a parent object.

~~The tests need rewriting.~~ The tests have been amended