### PR TITLE
Add ganga version to DIRAC JDL for easier debugging

### DIFF
--- a/ganga/GangaDirac/Lib/RTHandlers/DiracRTHScript.py.template
+++ b/ganga/GangaDirac/Lib/RTHandlers/DiracRTHScript.py.template
@@ -26,7 +26,7 @@ j.setParametricInputData(###PARAMETRIC_INPUTDATA###)
 ###DIRAC_OPTS###
 
 # submit the job to dirac
-j.setPlatform( '###PLATFORM###' )
+j.setPlatform('###PLATFORM###')
 
 try:
 	j.setNumberOfProcessors(minNumberOfProcessors=###MIN_PROCESSORS###, maxNumberOfProcessors=###MAX_PROCESSORS###)

--- a/ganga/GangaDirac/Lib/RTHandlers/DiracRTHScript.py.template
+++ b/ganga/GangaDirac/Lib/RTHandlers/DiracRTHScript.py.template
@@ -33,5 +33,7 @@ try:
 except (AttributeError, TypeError):
 	pass
 
+j._addParameter(j.workflow, 'GangaVersion', 'JDL', '###GANGA_VERSION###', 'The version of ganga used to submit this job')
+
 result = dirac.submitJob(j)
 output(result)

--- a/ganga/GangaDirac/Lib/RTHandlers/ExeDiracRTHandler.py
+++ b/ganga/GangaDirac/Lib/RTHandlers/ExeDiracRTHandler.py
@@ -2,6 +2,7 @@
 import os
 import inspect
 import GangaCore.Utility.Virtualization
+from GangaCore import _gangaVersion
 from GangaCore.Core.Sandbox.WNSandbox import PYTHON_DIR
 from GangaDirac.Lib.RTHandlers.DiracRTHUtils import dirac_inputdata, dirac_ouputdata, mangle_job_name, diracAPI_script_template, diracAPI_script_settings, API_nullifier, dirac_outputfile_jdl
 from GangaDirac.Lib.Files.DiracFile import DiracFile
@@ -124,7 +125,8 @@ class ExeDiracRTHandler(IRuntimeHandler):
                                         # leave the sandbox for altering later as needs
                                         # to be done in backend.submit to combine master.
                                         # Note only using 2 #s as auto-remove 3
-                                        INPUT_SANDBOX='##INPUT_SANDBOX##'
+                                        INPUT_SANDBOX='##INPUT_SANDBOX##',
+                                        GANGA_VERSION=_gangaVersion,
                                         )
 
         #logger.info("dirac_script: %s" % dirac_script)

--- a/ganga/GangaGaudi/Lib/RTHandlers/GaudiDiracRunTimeHandler.py
+++ b/ganga/GangaGaudi/Lib/RTHandlers/GaudiDiracRunTimeHandler.py
@@ -1,5 +1,6 @@
 #\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\#
 import os
+from GangaCore import _gangaVersion
 from GangaGaudi.Lib.RTHandlers.RunTimeHandlerUtils import master_sandbox_prepare, sandbox_prepare, script_generator
 from GangaDirac.Lib.RTHandlers.DiracRTHUtils import dirac_inputdata, dirac_ouputdata, mangle_job_name, diracAPI_script_template, diracAPI_script_settings
 from GangaGaudi.Lib.RTHandlers.GaudiRunTimeHandler import GaudiRunTimeHandler
@@ -57,7 +58,8 @@ class GaudiDiracRunTimeHandler(GaudiRunTimeHandler):
                                         # leave the sandbox for altering later as needs
                                         # to be done in backend.submit to combine master.
                                         # Note only using 2 #s as auto-remove 3
-                                        INPUT_SANDBOX='##INPUT_SANDBOX##'
+                                        INPUT_SANDBOX='##INPUT_SANDBOX##',
+                                        GANGA_VERSION=_gangaVersion,
                                         )
 
         return StandardJobConfig(dirac_script,

--- a/ganga/GangaLHCb/Lib/RTHandlers/ExeDiracRTHandler.py
+++ b/ganga/GangaLHCb/Lib/RTHandlers/ExeDiracRTHandler.py
@@ -1,6 +1,7 @@
 #\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\#
 import os
 import inspect
+from GangaCore import _gangaVersion
 import GangaCore.Utility.Virtualization
 from GangaCore.Core.Sandbox.WNSandbox import PYTHON_DIR
 from GangaDirac.Lib.RTHandlers.DiracRTHUtils import dirac_inputdata, dirac_ouputdata, mangle_job_name, diracAPI_script_settings, API_nullifier
@@ -130,7 +131,8 @@ class ExeDiracRTHandler(IRuntimeHandler):
                                         # leave the sandbox for altering later as needs
                                         # to be done in backend.submit to combine master.
                                         # Note only using 2 #s as auto-remove 3
-                                        INPUT_SANDBOX='##INPUT_SANDBOX##'
+                                        INPUT_SANDBOX='##INPUT_SANDBOX##',
+                                        GANGA_VERSION=_gangaVersion,
                                         )
 
         #logger.info("dirac_script: %s" % dirac_script)

--- a/ganga/GangaLHCb/Lib/RTHandlers/GaudiExecRTHandlers.py
+++ b/ganga/GangaLHCb/Lib/RTHandlers/GaudiExecRTHandlers.py
@@ -7,6 +7,7 @@ import random
 import threading
 import uuid
 import shutil
+from GangaCore import _gangaVersion
 from GangaCore.Core.exceptions import ApplicationConfigurationError, ApplicationPrepareError, GangaException, GangaFileError
 from GangaCore.GPIDev.Adapters.ApplicationRuntimeHandlers import allHandlers
 from GangaCore.GPIDev.Adapters.IRuntimeHandler import IRuntimeHandler
@@ -668,6 +669,7 @@ class GaudiExecDiracRTHandler(IRuntimeHandler):
                                         # to be done in backend.submit to combine master.
                                         # Note only using 2 #s as auto-remove 3
                                         INPUT_SANDBOX=repr([f for f in inputsandbox]),
+                                        GANGA_VERSION=_gangaVersion,
                                         )
 
         # NB

--- a/ganga/GangaLHCb/Lib/RTHandlers/LHCbGaudiDiracRunTimeHandler.py
+++ b/ganga/GangaLHCb/Lib/RTHandlers/LHCbGaudiDiracRunTimeHandler.py
@@ -1,6 +1,7 @@
 import copy
 import os
 import pickle
+from GangaCore import _gangaVersion
 from GangaCore.Core.exceptions import BackendError
 from GangaLHCb.Lib.LHCbDataset import LHCbDataset
 from GangaGaudi.Lib.RTHandlers.GaudiDiracRunTimeHandler import GaudiDiracRunTimeHandler
@@ -188,7 +189,8 @@ class LHCbGaudiDiracRunTimeHandler(GaudiDiracRunTimeHandler):
                                         ANCESTOR_DEPTH=ancestor_depth,
                                         ## This is to be modified in the final 'submit' function in the backend
                                         ## The backend also handles the inputfiles DiracFiles ass appropriate
-                                        INPUT_SANDBOX='##INPUT_SANDBOX##'
+                                        INPUT_SANDBOX='##INPUT_SANDBOX##',
+                                        GANGA_VERSION=_gangaVersion,
                                         )
         logger.debug("prepare: LHCbGaudiDiracRunTimeHandler")
 


### PR DESCRIPTION
@VladimirRomanovsky suggested that it would be useful to be able know what Ganga version was used to submit jobs to DIRAC. This implements @fstagni's suggestion for how to include it in the JDL.