### PR TITLE
Allow for some more time to get initial response from Mongo DB

### DIFF
--- a/ganga/GangaCore/Core/GangaRepository/container_controllers.py
+++ b/ganga/GangaCore/Core/GangaRepository/container_controllers.py
@@ -173,7 +173,7 @@ def mongod_exists(controller, cname=None):
                 return proc
     return None
 
-@repeat_while_none(max=10, message='Waiting for mongod database to start')
+@repeat_while_none(max=10, message='Waiting for Mongo DB to start')
 def mongod_exists_wait(controller, cname=None):
     return mongod_exists(controller, cname)
 


### PR DESCRIPTION
Seems to work. On a fresh lxplus node, I see

```
INFO     reading config file /afs/cern.ch/user/u/uegede/.gangarc
INFO     Waiting for Mongo DB to start
INFO     Waiting for Mongo DB to start
INFO     Waiting for Mongo DB to start
INFO     Waiting for Mongo DB to start
INFO     Singularity gangaDB started on port: 37529
INFO     Waiting for Mongo DB to reply
```
The first INFO lines are related to that it takes a long time for the Singularity container to start (most like related to simply reading the `mongo.sif` file on the `/afs` file system. 

The last INFO line is related to that we get an initial timeout in talking to the database. Again most like related to that it on `/afs` takes time to read the journal file for the DB.

With this last change it seems like the singularity implementation works at CERN (as long as singularity works at all on the lxplus node).