### PR TITLE
Add mapping for DIRAC's "Completing" status

### DIFF
--- a/ganga/GangaDirac/__init__.py
+++ b/ganga/GangaDirac/__init__.py
@@ -68,6 +68,7 @@ if not _after_bootstrap:
 
     configDirac.addOption('statusmapping', {'Checking': 'submitted',
                                             'Completed': 'running',
+                                            'Completing': 'running',
                                             'Deleted': 'failed',
                                             'Done': 'completed',
                                             'Failed': 'failed',


### PR DESCRIPTION
When certifying the next release of LHCbDIRAC (v10r1) I noticed some jobs were being "randomly" marked as failed despite them appearing to be successful from DIRAC's point of view.

This issue turns out to be that DIRAC v7r1 has a new "Completing" status that should be thought of as "running" from ganga's perspective. I'm currently testing this by modifying my local `.gangarc` and it seems to have fixed the problem. I haven't checked if this change is needed elsewhere.