### PR TITLE
Make sys.path behave as iPython

### DIFF
--- a/ganga/GangaCore/Runtime/GPIFunctions.py
+++ b/ganga/GangaCore/Runtime/GPIFunctions.py
@@ -1,3 +1,5 @@
+import sys
+import os.path
 import runpy
 from GangaCore.GPI import *
 
@@ -112,4 +114,7 @@ def runfile(path_to_file):
     """
     if not isinstance(path_to_file, str):
         raise ValueError("path_to_file must be a string containing the path to the file to be executed. ")
+    scriptdir = os.path.abspath(os.path.dirname(path_to_file))
+    sys.path.insert(0,scriptdir)
     runpy.run_path(path_to_file, init_globals=globals())
+    sys.path.remove(scriptdir)

--- a/ganga/GangaCore/Runtime/bootstrap.py
+++ b/ganga/GangaCore/Runtime/bootstrap.py
@@ -1009,6 +1009,8 @@ under certain conditions; type license() for details.
         logger = getLogger("run")
         logger.debug("Entering run")
 
+        sys.path.insert(0,'')
+
         if self.options.webgui == True:
             from GangaGUI.start import start_gui
             start_gui()

--- a/ganga/GangaCore/Runtime/bootstrap.py
+++ b/ganga/GangaCore/Runtime/bootstrap.py
@@ -1092,7 +1092,10 @@ under certain conditions; type license() for details.
                     setConfigOption('PollThread','forced_shutdown_policy', 'timeout')
                 from GangaCore.Core.GangaThread import GangaThreadPool
                 GangaThreadPool.shutdown_policy = 'batch'
+                scriptdir = os.path.abspath(os.path.dirname(script))
+                sys.path.insert(0,scriptdir)
                 exec(compile(open(script).read(), script, 'exec'), local_ns)
+                sys.path.remove(scriptdir)
             else:
                 logger.error("'%s' not found" % self.args[0])
                 logger.info("Searched in path %s" % path)


### PR DESCRIPTION
For scripts, sys.path will behave in exactly the same way as ipython does now.

- `ganga /for/bar.py` will have `/foo` in `sys.path` when script executes.
- `runfile('/for/bar.py') from Ganga prompt will add `/foo` to `sys.path` for executing scirpt.
- simply starting Ganga does not add PWD to to `sys.path`
