### PR TITLE
Update release_workflow.yml

### DIFF
--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Commit release notes
       run: |
         ! read -rd"\n" REL_ID BODY < <(curl --request GET --url ${GITHUB_API_URL}/repos/${{ github.repository }}/releases/tags/${VERSION} | jq -r '.id, .body')
-        echo "::set-env name=REL_ID::${REL_ID}"
+        echo "REL_ID=${REL_ID}" >> $GITHUB_ENV
         echo "${BODY}" > ganga/GangaRelease/ReleaseNotes-${VERSION}
         git add ganga/GangaRelease/ReleaseNotes-${VERSION}
         git commit -m "Creating release notes for version ${VERSION}"
@@ -68,7 +68,7 @@ jobs:
       - name: Checkout re-tagged version
         run: |
           VERSION=$(basename ${GITHUB_REF})
-          echo "::set-env name=VERSION::${VERSION}"
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
           git checkout ${VERSION}
       - name: Create Deployment
         run: |
@@ -78,7 +78,7 @@ jobs:
                            --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
                            --header 'content-type: application/json' \
                            --data "$DATA" | jq -r '.statuses_url'`
-          echo "::set-env name=STATUS_URL::${STATUS_URL}"
+          echo "STATUS_URL=${STATUS_URL}" >> $GITHUB_ENV
       - name: Deploy to PyPI
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -22,11 +22,11 @@ jobs:
       run: |
         sed --in-place "s/^_development = .*/_development = False/g" ganga/GangaCore/__init__.py
         git add ganga/GangaCore/__init__.py
-        git commit -m "Setting developmet flag"
+        git commit -m "Setting development flag"
     - name: Hardcode version number
       run: |
         VERSION=$(basename ${GITHUB_REF})
-        echo "::set-env name=VERSION::${VERSION}"
+        echo "VERSION=${VERSION}" >> $GITHUB_ENV
         sed --in-place "s/^_gangaVersion = .*/_gangaVersion = '${VERSION}'/g" ./setup.py
         sed --in-place "s/^_gangaVersion = .*/_gangaVersion = '${VERSION}'/g" ganga/GangaCore/__init__.py
         sed --in-place "s/^ARG ganga_version=.*/ARG ganga_version='${VERSION}'/g" ganga/GangaCore/Dockerfile


### PR DESCRIPTION
Use environment file. See https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/ and https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files 