### PR TITLE
Improve job remove files

### DIFF
--- a/ganga/GangaCore/GPIDev/Lib/Job/Job.py
+++ b/ganga/GangaCore/GPIDev/Lib/Job/Job.py
@@ -1681,6 +1681,11 @@ class Job(GangaObject):
 
         if getConfig('Output')['AutoRemoveFilesWithJob']:
             logger.info('Removing all output data of types %s' % getConfig('Output')['AutoRemoveFileTypes'])
+
+            #First use the backend's method if appropriate for maximum speed
+            if hasattr(j.backend, 'removeOutputData'):
+                j.backend.removeOutputData(getConfig('Output')['AutoRemoveFileTypes'])
+
             def removeFiles(this_file):
                 if getName(this_file) in getConfig('Output')['AutoRemoveFileTypes'] and hasattr(this_file, '_auto_remove'):
                     this_file._auto_remove()

--- a/ganga/GangaDirac/Lib/Backends/DiracBase.py
+++ b/ganga/GangaDirac/Lib/Backends/DiracBase.py
@@ -751,12 +751,15 @@ class DiracBase(IBackend):
 
         return True
 
-    def removeOutputData(self):
+    def removeOutputData(self, fileType = 'DiracFile'):
         """
         Remove all the LFNs associated with this job.
         """
         # Note when the API can accept a list for removeFile I will change
         # this.
+        if not fileType=='DiracFile':
+            return False
+
         j = self.getJobObject()
         logger.info("Removing all DiracFile output for job %s" % j.id)
         lfnsToRemove = []

--- a/ganga/GangaDirac/Lib/Backends/DiracUtils.py
+++ b/ganga/GangaDirac/Lib/Backends/DiracUtils.py
@@ -227,3 +227,28 @@ def getReplicas(inSet, credential_requirements=None):
     return reps['Successful']
 
 exportToGPI('getReplicas', getReplicas, 'Functions')
+
+
+def removeLFNs(lfns, credential_requirements=None):
+    """
+    Remove a list o lfns from Dirac storage
+    """
+    #Start off with some checks
+    lfns = []
+    if isinstance(inSet, str):
+        lfns = [inSet]
+    elif isinstance(inSet, list):
+        lfns = inSet
+    elif hasattr(inSet, 'getLFNs'):
+            lfns = inSet.getLFNs()
+    else:
+        raise GangaDiracError('You must supply, an LFN as a string, a list of LFNs or a GangaDataset with getLFNs() implemented')
+
+    res = execute('removeFile(%s)' % str(lfns), cred_req=credential_requirements)
+    if isinstance(lfns, list) and not len(reps['Successful'].keys()) == len(lfns):
+        logger.warning("Not successfully removed all files! The following failed: %s" % reps['Failed'].keys())
+        
+    return reps['Successful']
+
+exportToGPI('removeLFNs', removeLFNs, 'Functions')
+


### PR DESCRIPTION
Adds a `Dirac` `removeLFNs` help function. Also uses the Dirac `removeOutputData` when removing jobs for better speed. The `Dirac` function passes a list of LFNs to the Dirac thread, rather than removing each file one at a time.

There is a function in the Dirac API that takes a list of LFNs but it probably won't be much quicker than this.