### PR TITLE
Generic substitution of illegal substrings in job names for Batch backends

### DIFF
--- a/ganga/GangaCore/Lib/Batch/Batch.py
+++ b/ganga/GangaCore/Lib/Batch/Batch.py
@@ -169,13 +169,18 @@ class Batch(IBackend):
             queue_option = queue_option + " " + self.extraopts
 
         if jobnameopt and job.name != '':
-            # PBS doesn't like names with spaces
             tmp_name = job.name
-            if isType(self, PBS):
-                tmp_name = tmp_name.replace(" ", "_")
-            # SGE doesn't like names with colons
-            if isType(self, SGE):
-                tmp_name = tmp_name.replace(":", "-")
+
+            # if jobnamesubstitution is set and not empty, then transform the job
+            # name to conform to requirements
+            if 'jobnamesubstitution' in self.config:
+                job_name_sub_cfg = self.config['jobnamesubstitution']
+                if len(job_name_sub_cfg) == 2:
+                    tmp_name = re.sub(*job_name_sub_cfg, tmp_name)
+                elif not len(job_name_sub_cfg) == 0:
+                    # list is not empty, and not of length 2
+                    logger.warning("jobnamesubstitution should be a list of length 2. Skipping job name substitution.")
+
             queue_option = queue_option + " " + \
                 jobnameopt + " " + "'%s'" % (tmp_name)
 

--- a/ganga/GangaCore/Lib/Batch/Batch.py
+++ b/ganga/GangaCore/Lib/Batch/Batch.py
@@ -173,6 +173,9 @@ class Batch(IBackend):
             tmp_name = job.name
             if isType(self, PBS):
                 tmp_name = tmp_name.replace(" ", "_")
+            # SGE doesn't like names with colons
+            if isType(self, SGE):
+                tmp_name = tmp_name.replace(":", "-")
             queue_option = queue_option + " " + \
                 jobnameopt + " " + "'%s'" % (tmp_name)
 

--- a/ganga/GangaCore/Lib/Batch/Batch.py
+++ b/ganga/GangaCore/Lib/Batch/Batch.py
@@ -119,6 +119,19 @@ class Batch(IBackend):
 
     command = classmethod(command)
 
+    def _getLegalJobName(self, job):
+        tmp_name = job.name
+        # if jobnamesubstitution is set and not empty, then transform the job
+        # name to conform to requirements
+        if 'jobnamesubstitution' in self.config:
+            job_name_sub_cfg = self.config['jobnamesubstitution']
+            if len(job_name_sub_cfg) == 2:
+                tmp_name = re.sub(*job_name_sub_cfg, tmp_name)
+            elif not len(job_name_sub_cfg) == 0:
+                # list is not empty, and not of length 2
+                logger.warning("jobnamesubstitution should be a list of length 2. Skipping job name substitution.")
+        return tmp_name
+
     def submit(self, jobconfig, master_input_sandbox):
         global re
         job = self.getJobObject()
@@ -169,18 +182,7 @@ class Batch(IBackend):
             queue_option = queue_option + " " + self.extraopts
 
         if jobnameopt and job.name != '':
-            tmp_name = job.name
-
-            # if jobnamesubstitution is set and not empty, then transform the job
-            # name to conform to requirements
-            if 'jobnamesubstitution' in self.config:
-                job_name_sub_cfg = self.config['jobnamesubstitution']
-                if len(job_name_sub_cfg) == 2:
-                    tmp_name = re.sub(*job_name_sub_cfg, tmp_name)
-                elif not len(job_name_sub_cfg) == 0:
-                    # list is not empty, and not of length 2
-                    logger.warning("jobnamesubstitution should be a list of length 2. Skipping job name substitution.")
-
+            tmp_name = self._getLegalJobName()
             queue_option = queue_option + " " + \
                 jobnameopt + " " + "'%s'" % (tmp_name)
 
@@ -276,12 +278,7 @@ class Batch(IBackend):
 
         if jobnameopt and job.name != '':
             # PBS doesn't like names with spaces
-            tmp_name = job.name
-            if isType(self, PBS):
-                tmp_name = tmp_name.replace(" ", "_")
-            # SGE doesn't like names with colons
-            if isType(self, SGE):
-                tmp_name = tmp_name.replace(":", "-")
+            tmp_name = self._getLegalJobName(job)
             queue_option = queue_option + " " + \
                 jobnameopt + " " + "'%s'" % (tmp_name)
 

--- a/ganga/GangaCore/Lib/Batch/Batch.py
+++ b/ganga/GangaCore/Lib/Batch/Batch.py
@@ -271,6 +271,9 @@ class Batch(IBackend):
             tmp_name = job.name
             if isType(self, PBS):
                 tmp_name = tmp_name.replace(" ", "_")
+            # SGE doesn't like names with colons
+            if isType(self, SGE):
+                tmp_name = tmp_name.replace(":", "-")
             queue_option = queue_option + " " + \
                 jobnameopt + " " + "'%s'" % (tmp_name)
 

--- a/ganga/GangaCore/__init__.py
+++ b/ganga/GangaCore/__init__.py
@@ -465,6 +465,10 @@ lsf_config.addOption('postexecute', tempstr, "String contains commands executing
 lsf_config.addOption('jobnameopt', 'J', "String contains option name for name of job in batch system")
 lsf_config.addOption('timeout', 600, 'Timeout in seconds after which a job is declared killed if it has not touched its heartbeat file. Heartbeat is touched every 30s so do not set this below 120 or so.')
 
+# illegal substring substition in job names
+lsf_config.addOption('jobnamesubstitution', [], "A list containing (1) a regular expression used to substitute illegal substrings in a job name, and (2) the substring to replace such occurences with.")
+
+
 # ------------------------------------------------
 # PBS
 pbs_config = makeConfig('PBS', 'internal PBS command line interface')
@@ -508,6 +512,10 @@ pbs_config.addOption('jobnameopt', 'N', "String contains option name for name of
 pbs_config.addOption('timeout', 600,
                  'Timeout in seconds after which a job is declared killed if it has not touched its heartbeat file. Heartbeat is touched every 30s so do not set this below 120 or so.')
 
+# illegal substring substition in job names
+pbs_config.addOption('jobnamesubstitution', ['[\s]', '_'], "A list containing (1) a regular expression used to substitute illegal substrings in a job name, and (2) the substring to replace such occurences with.")
+
+
 # ------------------------------------------------
 # SGE
 sge_config = makeConfig('SGE', 'internal SGE command line interface')
@@ -549,6 +557,9 @@ sge_config.addOption('preexecute', 'os.chdir(os.environ["TMPDIR"])\nos.environ["
 sge_config.addOption('postexecute', '', "String contains commands executing before submiting job to queue")
 sge_config.addOption('jobnameopt', 'N', "String contains option name for name of job in batch system")
 sge_config.addOption('timeout', 600, 'Timeout in seconds after which a job is declared killed if it has not touched its heartbeat file. Heartbeat is touched every 30s so do not set this below 120 or so.')
+
+# illegal substring substition in job names
+sge_config.addOption('jobnamesubstitution', ['[\s:]', '_'], "A list containing (1) a regular expression used to substitute illegal substrings in a job name, and (2) the substring to replace such occurences with.")
 
 # ------------------------------------------------
 # Slurm
@@ -619,6 +630,10 @@ slurm_config.addOption('postexecute', tempstr,
 slurm_config.addOption('jobnameopt', 'J', "String contains option name for name of job in batch system")
 slurm_config.addOption('timeout', 600,
                        'Timeout in seconds after which a job is declared killed if it has not touched its heartbeat file. Heartbeat is touched every 30s so do not set this below 120 or so.')
+
+# illegal substring substition in job names
+slurm_config.addOption('jobnamesubstitution', [], "A list containing (1) a regular expression used to substitute illegal substrings in a job name, and (2) the substring to replace such occurences with.")
+
 
 # ------------------------------------------------
 # Mergers


### PR DESCRIPTION
Fixes #1838

It seems that a similar fix was implemented for `PBS()`, so this seemed like a good solution