### PR TITLE
Make sure Popen used in MassStorageFile wrapper script returns stdout and stderr as string

### DIFF
--- a/ganga/GangaCore/GPIDev/Lib/File/scripts/MassStorageFileWNScript.py.template
+++ b/ganga/GangaCore/GPIDev/Lib/File/scripts/MassStorageFileWNScript.py.template
@@ -10,7 +10,7 @@ def execSyscmdSubprocessAndReturnOutputMAS(cmd):
     mystderr = ''
 
     try:
-        child = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        child = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
         (mystdout, mystderr) = child.communicate()
         exitcode = child.returncode
     finally:


### PR DESCRIPTION
When using the `SGE()` backend with `MassStorageFile`, my Gaudi job runs successfully but fails inside the jobScript once the process is finished:
![image](https://user-images.githubusercontent.com/56410978/108138074-1ba32400-70b5-11eb-9512-875e41274b45.png)

Setting `universal_newlines=True` in the `Popen` call makes sure that the stdout and stderr returned by Popen are returned as the expected `str` type.

In Python 3.7 onwards, `text=True` also achieves the desired result, however for backwards compatibility I've used `universal_newlines` instead which does the same thing in `>=3.7` and earlier versions.