### PR TITLE
allow Batch extraopts to be changed at resubmission

### DIFF
--- a/ganga/GangaCore/Lib/Batch/Batch.py
+++ b/ganga/GangaCore/Lib/Batch/Batch.py
@@ -90,8 +90,8 @@ class Batch(IBackend):
     Kill job if it has exceeded the deadline (i.e. for your presentation)
     backend.extraopts = '-t 07:14:12:59' #Killed if not finished by 14 July before 1 pm
     """
-    _schema = Schema(Version(1, 0), {'queue': SimpleItem(defvalue='', doc='queue name as defomed in your local Batch installation'),
-                                     'extraopts': SimpleItem(defvalue='', doc='extra options for Batch. See help(Batch) for more details'),
+    _schema = Schema(Version(1, 1), {'queue': SimpleItem(defvalue='', doc='queue name as defomed in your local Batch installation'),
+                                     'extraopts': SimpleItem(defvalue='', changable_at_resubmit=1, doc='extra options for Batch. See help(Batch) for more details'),
                                      'id': SimpleItem(defvalue='', protected=1, copyable=0, doc='Batch id of the job'),
                                      'exitcode': SimpleItem(defvalue=None, typelist=[int, None], protected=1, copyable=0, doc='Process exit code'),
                                      'status': SimpleItem(defvalue='', protected=1, hidden=1, copyable=0, doc='Batch status of the job'),

--- a/ganga/GangaCore/Lib/Batch/Batch.py
+++ b/ganga/GangaCore/Lib/Batch/Batch.py
@@ -90,7 +90,7 @@ class Batch(IBackend):
     Kill job if it has exceeded the deadline (i.e. for your presentation)
     backend.extraopts = '-t 07:14:12:59' #Killed if not finished by 14 July before 1 pm
     """
-    _schema = Schema(Version(1, 1), {'queue': SimpleItem(defvalue='', doc='queue name as defomed in your local Batch installation'),
+    _schema = Schema(Version(1, 0), {'queue': SimpleItem(defvalue='', doc='queue name as defomed in your local Batch installation'),
                                      'extraopts': SimpleItem(defvalue='', changable_at_resubmit=1, doc='extra options for Batch. See help(Batch) for more details'),
                                      'id': SimpleItem(defvalue='', protected=1, copyable=0, doc='Batch id of the job'),
                                      'exitcode': SimpleItem(defvalue=None, typelist=[int, None], protected=1, copyable=0, doc='Process exit code'),


### PR DESCRIPTION
Try to allow `extraopts` to be changed at resubmit, which is helpful for resubmitting subjobs, etc to Batch systems with modified runtime or memory resource parameters.

I have marked this as draft as I'm not sure how `Schema` works. Am I right to increment the minor version?