### PR TITLE
WIP: Move credential decorators for splitters

### DIFF
--- a/ganga/GangaDirac/Lib/Splitters/GangaSplitterUtils.py
+++ b/ganga/GangaDirac/Lib/Splitters/GangaSplitterUtils.py
@@ -3,6 +3,7 @@ from GangaDirac.Lib.Utilities.DiracUtilities import execute
 from GangaDirac.Lib.Backends.DiracUtils import result_ok
 from GangaCore.Utility.Config import getConfig
 from GangaCore.Utility.logging import getLogger
+from GangaCore.GPIDev.Credentials import require_credential
 logger = getLogger()
 
 
@@ -16,7 +17,7 @@ def igroup(iterable, num, leftovers=False):
             return
         yield iterable[i: i + num]
 
-
+@require_credential
 def GangaDiracSplitter(inputs, filesPerJob, maxFiles, ignoremissing):
     """
     Generator that yields a datasets for dirac split jobs

--- a/ganga/GangaDirac/Lib/Splitters/OfflineGangaDiracSplitter.py
+++ b/ganga/GangaDirac/Lib/Splitters/OfflineGangaDiracSplitter.py
@@ -5,6 +5,7 @@ from GangaCore.Utility.logging import getLogger
 from GangaDirac.Lib.Utilities.DiracUtilities import execute, GangaDiracError
 from GangaCore.Core.GangaThread.WorkerThreads import getQueues
 from GangaDirac.Lib.Files.DiracFile import DiracFile
+from GangaCore.GPIDev.Credentials import require_credential
 from copy import deepcopy
 import random
 import time
@@ -399,7 +400,7 @@ def updateLFNData(bad_lfns, allLFNs, LFNdict, ignoremissing, allLFNData):
 
 
 # Actually Do the work of the splitting
-
+@require_credential
 def OfflineGangaDiracSplitter(_inputs, filesPerJob, maxFiles, ignoremissing, bannedSites=[]):
     """
     Generator that yields a datasets for dirac split jobs

--- a/ganga/GangaDirac/Lib/Splitters/SplitterUtils.py
+++ b/ganga/GangaDirac/Lib/Splitters/SplitterUtils.py
@@ -5,6 +5,7 @@ from GangaDirac.Lib.Backends.DiracUtils import result_ok
 from GangaCore.Utility.Config import getConfig
 from GangaDirac.Lib.Files.DiracFile import DiracFile
 from GangaCore.Utility.logging import getLogger
+from GangaCore.GPIDev.Credentials import require_credential
 logger = getLogger()
 
 
@@ -18,7 +19,7 @@ def igroup(iterable, num, leftovers=False):
             return
         yield iterable[i: i + num]
 
-
+@require_credential
 def DiracSplitter(inputs, filesPerJob, maxFiles, ignoremissing):
     """
     Generator that yields a datasets for dirac split jobs

--- a/ganga/GangaLHCb/Lib/Splitters/LHCbSplitterUtils.py
+++ b/ganga/GangaLHCb/Lib/Splitters/LHCbSplitterUtils.py
@@ -4,6 +4,7 @@ from GangaDirac.Lib.Utilities.DiracUtilities import execute
 from GangaDirac.Lib.Backends.DiracUtils import result_ok
 from GangaCore.Utility.Config import getConfig
 from GangaCore.Utility.logging import getLogger
+from GangaCore.GPIDev.Credentials import require_credential
 logger = getLogger()
 
 
@@ -17,7 +18,7 @@ def igroup(iterable, num, leftovers=False):
             return
         yield iterable[i: i + num]
 
-
+@require_credential
 def DiracSizeSplitter(inputs, filesPerJob, maxSize, ignoremissing):
     """
     Generator that yields a datasets for LHCbdirac split jobs by size

--- a/ganga/GangaLHCb/Lib/Splitters/SplitByFiles.py
+++ b/ganga/GangaLHCb/Lib/Splitters/SplitByFiles.py
@@ -126,7 +126,6 @@ class SplitByFiles(GaudiInputDataSplitter):
         logger.debug("Returning new subjob")
         return j
 
-    @require_credential
     def _splitter(self, job, inputdata):
         """
         This is the main method used in splitting by inputdata for Dirac backends


### PR DESCRIPTION
Fixes #1848 

Moves the `requrie_credential` decorators to the creation of the splitter generators. Thus if `SplitByFiles` is not doing anything with Dirac it won't ask for a credential.