### PR TITLE
Fix SplitByFiles credential requirements

### DIFF
--- a/ganga/GangaLHCb/Lib/Splitters/SplitByFiles.py
+++ b/ganga/GangaLHCb/Lib/Splitters/SplitByFiles.py
@@ -160,9 +160,6 @@ class SplitByFiles(GaudiInputDataSplitter):
 
         isDirac = False
         if stripProxy(job.backend).__module__.find('Dirac') > 0 or all(isinstance(this_file, DiracFile) for this_file in indata):
-            isDirac = True
-
-        if isDirac:
             return self._dirac_splitter(job, indata)
 
         else:


### PR DESCRIPTION
Split the `_splitter` method into a Dirac bit and non Dirac bit so non-Dirac splitting doesn't ask for a credential.

Fixes #1848 