### PR TITLE
Add archive checker to BKQuery

### DIFF
--- a/ganga/GangaDirac/Lib/Server/DiracCommands.py
+++ b/ganga/GangaDirac/Lib/Server/DiracCommands.py
@@ -404,7 +404,11 @@ def getServicePorts():
     ''' Get the service ports from the DiracAdmin based upon the Dirac config'''
     return DiracAdmin().getServicePorts()
 
-
+@diracCommand
+def isSEArchive(se):
+    ''' Ask if the specified SE is for archive '''
+    from DIRAC.DataManagementSystem.Utilities.DMSHelpers import DMSHelpers
+    return DMSHelpers().isSEArchive(se)
 
 @diracCommand
 def getSitesForSE(se):

--- a/ganga/GangaLHCb/Lib/LHCbDataset/BKQuery.py
+++ b/ganga/GangaLHCb/Lib/LHCbDataset/BKQuery.py
@@ -188,7 +188,6 @@ RecoToDST-07/90000000/DST" ,
         isMC = False
         if 'MC' == self.path.split('/')[1]:
             isMC = True
-            print('isMC')
         if isMC and self.check_archived and not self.ignore_archived:
             logger.debug('Detected an MC data set. Checking if it has been archived')
             all_reps = get_result("getReplicas(%s)" % files, 'Get replica error.', credential_requirements=self.credential_requirements)

--- a/ganga/GangaLHCb/Lib/LHCbDataset/BKQuery.py
+++ b/ganga/GangaLHCb/Lib/LHCbDataset/BKQuery.py
@@ -188,7 +188,7 @@ RecoToDST-07/90000000/DST" ,
         isMC = False
         if 'MC' == self.path.split('/')[1]:
             isMC = True
-        if isMC and self.check_archived and not self.ignore_archived:
+        if isMC and self.check_archived:
             logger.debug('Detected an MC data set. Checking if it has been archived')
             all_reps = get_result("getReplicas(%s)" % files, 'Get replica error.', credential_requirements=self.credential_requirements)
             if 'Successful' in all_reps:
@@ -202,8 +202,10 @@ RecoToDST-07/90000000/DST" ,
                 if not is_archived:
                     all_archived = False
                     break
-            if all_archived:
+            if all_archived and not self.ignore_archived:
                 raise GangaDiracError("All the files are only available on archive SEs. It is likely the data set has been archived. Contact data management to request that it be staged")
+            elif all_archived:
+                logger.warning("All the files are only available on archive SEs. It is likely the data set has been archived. Contact data management to request that it be staged")
 
         if compressed:
             ds = LHCbCompressedDataset(files)

--- a/ganga/GangaLHCb/Lib/LHCbDataset/BKQuery.py
+++ b/ganga/GangaLHCb/Lib/LHCbDataset/BKQuery.py
@@ -94,6 +94,8 @@ RecoToDST-07/90000000/DST" ,
     docstr = 'Selection criteria: Runs, ProcessedRuns, NotProcessed (only works for type="RunsByDate")'
     schema['selection'] = SimpleItem(defvalue='', doc=docstr)
     schema['credential_requirements'] = ComponentItem('CredentialRequirement', defvalue='DiracProxy')
+    schema['check_archived'] = SimpleItem(defvalue=True, typelist=['bool'], doc = 'Check if the data set is archived')
+    schema['ignore_archived'] = SimpleItem(defvalue=False, typelist=['bool'], doc = 'Return the data set, even if all the LFNs are archived')
     _schema = Schema(Version(1, 2), schema)
     _category = 'query'
     _name = "BKQuery"
@@ -181,6 +183,28 @@ RecoToDST-07/90000000/DST" ,
             files = tempFiles
 
         logger.debug("Creating dataset")
+
+        #If we think this is an MC request check to see if the data set has been archived.
+        isMC = False
+        if 'MC' == self.path.split('/')[1]:
+            isMC = True
+            print('isMC')
+        if isMC and self.check_archived and not self.ignore_archived:
+            logger.debug('Detected an MC data set. Checking if it has been archived')
+            all_reps = get_result("getReplicas(%s)" % files, 'Get replica error.', credential_requirements=self.credential_requirements)
+            if 'Successful' in all_reps:
+                all_ses = set([])
+                for _lfn, _repz in all_reps['Successful'].items():
+                    all_ses.update(_repz.keys())
+
+            all_archived = True
+            for _se in all_ses:
+                is_archived = get_result("isSEArchive('%s')" % _se, 'Check archive error.', credential_requirements=self.credential_requirements)
+                if not is_archived:
+                    all_archived = False
+                    break
+            if all_archived:
+                raise GangaDiracError("All the files are only available on archive SEs. It is likely the data set has been archived. Contact data management to request that it be staged")
 
         if compressed:
             ds = LHCbCompressedDataset(files)


### PR DESCRIPTION
Fixes #1860 

This operates in the BKQuery rather than the splitter. It gets the list of LFNs and replicas and checks if the SEs are all archives. If they are it raises an error. I added some options to not do the check.

It also makes a guess that the supplied query path is MC. If it is not it won't do the check as we really only worry about the archived MC data sets and it could take a long time for the large sets of collision data. That should catch most instances - people with more complex queries will not be caught but hopefully they are more aware of what they are doing.

The getReplicas should probably be broken up into chunks.