### PR TITLE
Update socket.io to latest version

### DIFF
--- a/ganga/GangaGUI/gui/static/js/slidecli.js
+++ b/ganga/GangaGUI/gui/static/js/slidecli.js
@@ -11,6 +11,6 @@ document.addEventListener('DOMContentLoaded', () => {
 // Show/Hide CLI
 let cliOpen = false;
 function toggleCli() {
-    document.querySelector('#cli-container').style['display'] = cliOpen ? 'none' : 'initial';
+    document.querySelector('#cli-container').style['visibility'] = cliOpen ? 'hidden' : 'initial';
     cliOpen = !cliOpen;
 }

--- a/ganga/GangaGUI/gui/templates/base.html
+++ b/ganga/GangaGUI/gui/templates/base.html
@@ -107,7 +107,7 @@
 
         {# Web CLI Container #}
         <div id="cli-container"
-             style="display: none; position: fixed; bottom: 0; left: 0; height: 50vh; width: 100%; z-index: 50; box-shadow: 0 -2px 6px rgba(0,0,0,0.30);"
+             style="position: fixed; bottom: 0; left: 0; height: 50vh; width: 100%; z-index: 50; box-shadow: 0 -2px 6px rgba(0,0,0,0.30);"
              class="rounded-top overflow-hidden">
             <div class="d-flex justify-content-end align-items-center mt-2 px-2" style="position: absolute; top: 0; right:0;">
                 <a href="{{ url_for('serve_cli') if session['WEB_CLI'] == True }}" target="_blank"
@@ -128,7 +128,7 @@
 <script defer src="{{ url_for('static', filename='js/main.js') }}"></script>
 
 {# JS file specific to web cli mode#}
-<script defer src="{{ url_for('static', filename='js/slidecli.js') if session['WEB_CLI'] == True else '#' }}"></script>
+<script src="{{ url_for('static', filename='js/slidecli.js') if session['WEB_CLI'] == True else '#' }}"></script>
 
 {% block footer %}{% endblock footer %}
 

--- a/ganga/GangaGUI/gui/templates/base.html
+++ b/ganga/GangaGUI/gui/templates/base.html
@@ -107,7 +107,7 @@
 
         {# Web CLI Container #}
         <div id="cli-container"
-             style="position: fixed; bottom: 0; left: 0; height: 50vh; width: 100%; z-index: 50; box-shadow: 0 -2px 6px rgba(0,0,0,0.30);"
+             style="visibility: hidden; position: fixed; bottom: 0; left: 0; height: 50vh; width: 100%; z-index: 50; box-shadow: 0 -2px 6px rgba(0,0,0,0.30);"
              class="rounded-top overflow-hidden">
             <div class="d-flex justify-content-end align-items-center mt-2 px-2" style="position: absolute; top: 0; right:0;">
                 <a href="{{ url_for('serve_cli') if session['WEB_CLI'] == True }}" target="_blank"
@@ -128,7 +128,7 @@
 <script defer src="{{ url_for('static', filename='js/main.js') }}"></script>
 
 {# JS file specific to web cli mode#}
-<script src="{{ url_for('static', filename='js/slidecli.js') if session['WEB_CLI'] == True else '#' }}"></script>
+<script defer src="{{ url_for('static', filename='js/slidecli.js') if session['WEB_CLI'] == True else '#' }}"></script>
 
 {% block footer %}{% endblock footer %}
 

--- a/ganga/GangaGUI/gui/templates/cli.html
+++ b/ganga/GangaGUI/gui/templates/cli.html
@@ -75,7 +75,7 @@
 <script src="https://unpkg.com/xterm@3.6.0/dist/addons/webLinks/webLinks.js"></script>
 <script src="https://unpkg.com/xterm@3.6.0/dist/addons/fullscreen/fullscreen.js"></script>
 <script src="https://unpkg.com/xterm@3.6.0/dist/addons/search/search.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.1.1/socket.io.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.0.0/socket.io.js"></script>
 <script defer src="{{ url_for('static', filename='js/cli.js') }}"></script>
 
 </body>


### PR DESCRIPTION
CLI seems to be stuck.  
Giving error:  ```The client is using an unsupported version of the Socket.IO or Engine.IO protocols.....```
Note: updating this ensures CLI works on safari. For other browsers, the web app still crashes.