### PR TITLE
Add tags for virtualisation with /cvmfs

### DIFF
--- a/ganga/GangaDirac/Lib/RTHandlers/ExeDiracRTHandler.py
+++ b/ganga/GangaDirac/Lib/RTHandlers/ExeDiracRTHandler.py
@@ -99,6 +99,16 @@ class ExeDiracRTHandler(IRuntimeHandler):
 
         dirac_outputfiles = dirac_outputfile_jdl(outputfiles, config['RequireDefaultSE'])
 
+        #If we are doing virtualisation with a CVMFS location, check it is available
+        if job.virtualization and isinstance(job.virtualization.image, str):
+            if 'cvmfs' == job.virtualization.image.split('/')[1]:
+                tag_location = '/'+job.virtualization.image.split('/')[1]+'/'+job.virtualization.image.split('/')[2]+'/'
+                if 'Tag' in job.backend.settings:
+                    job.backend.settings['Tag'].append(tag_location)
+                else:
+                    job.backend.settings['Tag'] = [tag_location]
+
+        
         # NOTE special case for replicas: replicate string must be empty for no
         # replication
         dirac_script = script_generator(diracAPI_script_template(),

--- a/ganga/GangaLHCb/Lib/RTHandlers/ExeDiracRTHandler.py
+++ b/ganga/GangaLHCb/Lib/RTHandlers/ExeDiracRTHandler.py
@@ -105,6 +105,15 @@ class ExeDiracRTHandler(IRuntimeHandler):
                 if not this_file.getReplicas():
                     raise GangaFileError("DiracFile inputfile with LFN %s has no replicas" % this_file.lfn)
 
+        #If we are doing virtualisation with a CVMFS location, check it is available
+        if job.virtualization and isinstance(job.virtualization.image, str):
+            if 'cvmfs' == job.virtualization.image.split('/')[1]:
+                tag_location = '/'+job.virtualization.image.split('/')[1]+'/'+job.virtualization.image.split('/')[2]+'/'
+                if 'Tag' in job.backend.settings:
+                    job.backend.settings['Tag'].append(tag_location)
+                else:
+                    job.backend.settings['Tag'] = [tag_location]
+
         lhcbdirac_outputfiles = lhcbdirac_outputfile_jdl(outputfiles)
         # NOTE special case for replicas: replicate string must be empty for no
         # replication

--- a/ganga/GangaLHCb/Lib/RTHandlers/GaudiExecRTHandlers.py
+++ b/ganga/GangaLHCb/Lib/RTHandlers/GaudiExecRTHandlers.py
@@ -642,6 +642,15 @@ class GaudiExecDiracRTHandler(IRuntimeHandler):
         # This code deals with the outputfiles as outputsandbox and outputdata for us
         lhcbdirac_outputfiles = lhcbdirac_outputfile_jdl(outputfiles)
 
+        #If we are doing virtualisation with a CVMFS location, check it is available
+        if job.virtualization and isinstance(job.virtualization.image, str):
+            if 'cvmfs' == job.virtualization.image.split('/')[1]:
+                tag_location = '/'+job.virtualization.image.split('/')[1]+'/'+job.virtualization.image.split('/')[2]+'/'
+                if 'Tag' in job.backend.settings:
+                    job.backend.settings['Tag'].append(tag_location)
+                else:
+                    job.backend.settings['Tag'] = [tag_location]
+
         # NOTE special case for replicas: replicate string must be empty for no
         # replication
         dirac_script = script_generator(lhcbdiracAPI_script_template(),

--- a/ganga/GangaLHCb/Lib/RTHandlers/LHCbGaudiDiracRunTimeHandler.py
+++ b/ganga/GangaLHCb/Lib/RTHandlers/LHCbGaudiDiracRunTimeHandler.py
@@ -163,6 +163,15 @@ class LHCbGaudiDiracRunTimeHandler(GaudiDiracRunTimeHandler):
 
         lhcb_dirac_outputfiles = lhcbdirac_outputfile_jdl(outputfiles)
 
+        #If we are doing virtualisation with a CVMFS location, check it is available
+        if job.virtualization and isinstance(job.virtualization.image, str):
+            if 'cvmfs' == job.virtualization.image.split('/')[1]:
+                tag_location = '/'+job.virtualization.image.split('/')[1]+'/'+job.virtualization.image.split('/')[2]+'/'
+                if 'Tag' in job.backend.settings:
+                    job.backend.settings['Tag'].append(tag_location)
+                else:
+                    job.backend.settings['Tag'] = [tag_location]
+
         # not necessary to use lhcbdiracAPI_script_template any more as doing our own uploads to Dirac
         # remove after Ganga6 release
         # NOTE special case for replicas: replicate string must be empty for no

--- a/ganga/GangaLHCb/Lib/RTHandlers/LHCbRootDiracRunTimeHandler.py
+++ b/ganga/GangaLHCb/Lib/RTHandlers/LHCbRootDiracRunTimeHandler.py
@@ -50,6 +50,15 @@ class LHCbRootDiracRunTimeHandler(IRuntimeHandler):
 
         lhcb_dirac_outputfiles = lhcbdirac_outputfile_jdl(outputfiles)
 
+        #If we are doing virtualisation with a CVMFS location, check it is available
+        if job.virtualization and isinstance(job.virtualization.image, str):
+            if 'cvmfs' == job.virtualization.image.split('/')[1]:
+                tag_location = '/'+job.virtualization.image.split('/')[1]+'/'+job.virtualization.image.split('/')[2]+'/'
+                if 'Tag' in job.backend.settings:
+                    job.backend.settings['Tag'].append(tag_location)
+                else:
+                    job.backend.settings['Tag'] = [tag_location]
+
         # NOTE special case for replicas: replicate string must be empty for no
         # replication
         params = {'DIRAC_IMPORT': 'from LHCbDIRAC.Interfaces.API.DiracLHCb import DiracLHCb',


### PR DESCRIPTION
Fixes #1840.

Makes the dirac script look like if the virtualisation image is a string starting with `/cvmfs`

```
# <-- user settings
j.setCPUTime(1000000)
j.setTag(['/cvmfs/lhcb.cern.ch', '/cvmfs/unpacked.cern.ch/'])
```