### PR TITLE
Add resplit for subjob

### DIFF
--- a/doc/UserGuide/Splitters.rst
+++ b/doc/UserGuide/Splitters.rst
@@ -105,3 +105,34 @@ The ``GangaDatasetSplitter`` is provided as an easy way of splitting over a numb
 
 
 If you check the output you will see the list of files that each subjob was given using ``j.subjobs()`` as above.
+
+Resplitting a job
+-----------------
+Sometimes a job that has been split will have some of the subjobs failing. This might for example be due to that they run out of CPU time and are required to be split into smaller units. To support this, it is possible to apply a new splitter to a subjob which is in the ``completed`` or ``failed`` state. In the example below can be seen how the first subjob is subsequently split into a further two subjobs. 
+
+.. code-block:: python
+    j = Job(splitter=ArgSplitter(args=[ [0],[0] ]))
+    j.submit()
+
+    # wait for jobs to complete
+    j.subjobs
+    
+    Registry Slice: jobs(8).subjobs (2 objects)
+    --------------
+        fqid |    status       |                       comment |
+    -------------------------------------------------------
+         8.0 | completed       |                               |
+         8.1 | completed       |                               |
+    
+    j.subjobs(0).resplit(ArgSplitter(args=[ [1], [1] ]))
+
+    # wait for jobs to complete
+    j.subjobs
+    
+    --------------
+        fqid |    status       |                       comment |
+    -------------------------------------------------------
+         8.0 |completed_failed |            - has been resplit |
+         8.1 | completed       |                               |
+         8.2 | completed       |              - resplit of 8.0 |
+         8.3 | completed       |              - resplit of 8.0 |

--- a/ganga/GangaCore/GPIDev/Adapters/IBackend.py
+++ b/ganga/GangaCore/GPIDev/Adapters/IBackend.py
@@ -127,8 +127,8 @@ class IBackend(GangaObject):
         """
         from GangaCore.Utility.logging import log_user_exception
 
-        logger.info("SubJobConfigs: %s" % len(subjobconfigs))
-        logger.info("rjobs: %s" % len(rjobs))
+        logger.debug("SubJobConfigs: %s" % len(subjobconfigs))
+        logger.debug("rjobs: %s" % len(rjobs))
         assert(implies(rjobs, len(subjobconfigs) == len(rjobs)))
 
         incomplete = 0

--- a/ganga/GangaCore/GPIDev/Adapters/IBackend.py
+++ b/ganga/GangaCore/GPIDev/Adapters/IBackend.py
@@ -127,8 +127,8 @@ class IBackend(GangaObject):
         """
         from GangaCore.Utility.logging import log_user_exception
 
-        logger.debug("SubJobConfigs: %s" % len(subjobconfigs))
-        logger.debug("rjobs: %s" % len(rjobs))
+        logger.info("SubJobConfigs: %s" % len(subjobconfigs))
+        logger.info("rjobs: %s" % len(rjobs))
         assert(implies(rjobs, len(subjobconfigs) == len(rjobs)))
 
         incomplete = 0

--- a/ganga/GangaCore/GPIDev/Adapters/IBackend.py
+++ b/ganga/GangaCore/GPIDev/Adapters/IBackend.py
@@ -239,15 +239,17 @@ class IBackend(GangaObject):
         """
         from GangaCore.GPIDev.Lib.File.OutputFileManager import getInputFilesPatterns
         from GangaCore.GPIDev.Lib.File.File import File, ShareDir
-
+        print('master prepare')
         job = self.getJobObject()
-
         create_sandbox = job.createInputSandbox
         if self._packed_input_sandbox:
+            print('createPackedInputSandbox')
             create_sandbox = job.createPackedInputSandbox
-
+        print('created')
         if masterjobconfig:
+            print('is masterjobconfig')
             if hasattr(job.application, 'is_prepared') and isType(job.application.is_prepared, ShareDir):
+                print('hasattr is prpared')
                 sharedir_pred = lambda f: f.name.find(job.application.is_prepared.name) > -1
                 sharedir_files = filter(sharedir_pred, masterjobconfig.getSandboxFiles())
                 nonsharedir_files = itertools.filterfalse(sharedir_pred, masterjobconfig.getSandboxFiles())

--- a/ganga/GangaCore/GPIDev/Adapters/IBackend.py
+++ b/ganga/GangaCore/GPIDev/Adapters/IBackend.py
@@ -239,17 +239,12 @@ class IBackend(GangaObject):
         """
         from GangaCore.GPIDev.Lib.File.OutputFileManager import getInputFilesPatterns
         from GangaCore.GPIDev.Lib.File.File import File, ShareDir
-        print('master prepare')
         job = self.getJobObject()
         create_sandbox = job.createInputSandbox
         if self._packed_input_sandbox:
-            print('createPackedInputSandbox')
             create_sandbox = job.createPackedInputSandbox
-        print('created')
         if masterjobconfig:
-            print('is masterjobconfig')
             if hasattr(job.application, 'is_prepared') and isType(job.application.is_prepared, ShareDir):
-                print('hasattr is prpared')
                 sharedir_pred = lambda f: f.name.find(job.application.is_prepared.name) > -1
                 sharedir_files = filter(sharedir_pred, masterjobconfig.getSandboxFiles())
                 nonsharedir_files = itertools.filterfalse(sharedir_pred, masterjobconfig.getSandboxFiles())

--- a/ganga/GangaCore/GPIDev/Lib/Job/Job.py
+++ b/ganga/GangaCore/GPIDev/Lib/Job/Job.py
@@ -1566,12 +1566,12 @@ class Job(GangaObject):
             # submit the job
             # master_submit has been written as the interface which ganga
             # should call, not submit directly
-
-            r = self.backend.master_submit( rjobs, jobsubconfig, jobmasterconfig)
-
+            print('about to master submit')
+            r = mJob.backend.master_submit( rjobs, jobsubconfig, jobmasterconfig)
+            print('returned: ', r)
             if not r:
                 for sj in rjobs:
-                    mJobs.subjobs.remove(sj)
+                    mJob.subjobs.remove(sj)
                 raise JobManagerError('error during submit')
 
             mJob.updateStatus('submitted')

--- a/ganga/GangaCore/GPIDev/Lib/Job/Job.py
+++ b/ganga/GangaCore/GPIDev/Lib/Job/Job.py
@@ -1486,6 +1486,8 @@ class Job(GangaObject):
             raise JobError("resplit not provided with a splitter!")
         if not self.master:
             raise JobError("You can only resplit subjobs!")
+        if not self.status in ['completed', 'failed']:
+            raise JobError("You can only resplit subjobs in the failed or completed status!")
 
         mJob = self.master
         rjobs = None

--- a/ganga/GangaCore/GPIDev/Lib/Job/Job.py
+++ b/ganga/GangaCore/GPIDev/Lib/Job/Job.py
@@ -16,6 +16,7 @@ from GangaCore.Core.GangaRepository import getRegistry
 from GangaCore.GPIDev.Adapters.ApplicationRuntimeHandlers import allHandlers
 from GangaCore.GPIDev.Adapters.IApplication import PostprocessStatusUpdate
 from GangaCore.GPIDev.Adapters.IPostProcessor import MultiPostProcessor
+from GangaCore.GPIDev.Adapters.ISplitter import ISplitter
 from GangaCore.GPIDev.Base import GangaObject
 from GangaCore.GPIDev.Base.Objects import Node, synchronised
 from GangaCore.GPIDev.Base.Proxy import addProxy, getName, getRuntimeGPIObject, isType, runtimeEvalString, stripProxy
@@ -235,7 +236,7 @@ class Job(GangaObject):
     _category = 'jobs'
     _name = 'Job'
     _exportmethods = ['prepare', 'unprepare', 'submit', 'remove', 'kill', 'freeze', 'unfreeze',
-                      'resubmit', 'peek', 'force_status', 'runPostProcessors', 'returnSubjobStatuses']
+                      'resubmit', 'peek', 'force_status', 'runPostProcessors', 'returnSubjobStatuses', 'resplit']
 
     default_registry = 'jobs'
 
@@ -1235,12 +1236,19 @@ class Job(GangaObject):
                 appsubconfig = [j.application.configure(appmasterconfig)[1] for j in subjobs]
 
         else:
-            #   I am a sub-job, lets just generate our own config
-            appsubconfig = self._storedAppSubConfig
-            if appsubconfig is None or len(appsubconfig) == 0:
-                appmasterconfig = self._getMasterAppConfig()
-                logger.debug("Job %s Calling application.configure 1 times" % self.getFQID('.'))
-                appsubconfig = [self.application.configure(appmasterconfig)[1]]
+            if len(subjobs)>1:
+                appsubconfig = self._storedAppSubConfig
+                if appsubconfig is None or len(appsubconfig) == 0:
+                    appmasterconfig = self._getMasterAppConfig()
+                    logger.debug("Job %s Calling application.configure %s times" % (self.getFQID('.'), len(self.subjobs)))
+                    appsubconfig = [j.application.configure(appmasterconfig)[1] for j in subjobs]
+            else:
+                #   I am a sub-job, lets just generate our own config
+                appsubconfig = self._storedAppSubConfig
+                if appsubconfig is None or len(appsubconfig) == 0:
+                    appmasterconfig = self._getMasterAppConfig()
+                    logger.debug("Job %s Calling application.configure 1 times" % self.getFQID('.'))
+                    appsubconfig = [self.application.configure(appmasterconfig)[1]]
 
         self._storedAppSubConfig = appsubconfig
 
@@ -1313,12 +1321,24 @@ class Job(GangaObject):
 
         else:
             #   I am a sub-job, lets calculate my config
-            rtHandler = self._getRuntimeHandler()
-            appmasterconfig = self._getMasterAppConfig()
-            jobmasterconfig = self._getJobMasterConfig()
-            appsubconfig = self._getAppSubConfig(self)
-            logger.debug("Job %s Calling rtHandler.prepare once for self" % self.getFQID('.'))
-            jobsubconfig = [rtHandler.prepare(self.application, appsubconfig[0], appmasterconfig, jobmasterconfig)]
+            if len(subjobs) > 1:
+                rtHandler = self._getRuntimeHandler()
+                appmasterconfig = self._getMasterAppConfig()
+                jobmasterconfig = self._getJobMasterConfig()
+                appsubconfig = self._getAppSubConfig(subjobs)
+                logger.debug("Job %s Calling rtHandler.prepare %s times" % (self.getFQID('.'), len(self.subjobs)))
+                logger.info("Preparing subjobs")
+                #Make an empty list
+                jobsubconfig = [None]*len(subjobs)
+                jobsubconfig = [rtHandler.prepare(sub_job.application, sub_conf, appmasterconfig, jobmasterconfig) for (sub_job, sub_conf) in zip(subjobs, appsubconfig)]
+               
+            else:
+                rtHandler = self._getRuntimeHandler()
+                appmasterconfig = self._getMasterAppConfig()
+                jobmasterconfig = self._getJobMasterConfig()
+                appsubconfig = self._getAppSubConfig(self)
+                logger.debug("Job %s Calling rtHandler.prepare once for self" % self.getFQID('.'))
+                jobsubconfig = [rtHandler.prepare(self.application, appsubconfig[0], appmasterconfig, jobmasterconfig)]
 
         self._storedJobSubConfig = jobsubconfig
 
@@ -1456,6 +1476,111 @@ class Job(GangaObject):
             rjobs = [self]
 
         return rjobs
+
+    def resplit(self, new_splitter):
+        """
+        Resplit a subjob into new subjobs and submit them. Will put this subjob into a frozen state and add a note
+        to the comment. Will return an error if attempted on a master job.
+        """
+        if not isinstance(new_splitter, ISplitter):
+            raise JobError("resplit not provided with a splitter!")
+        if not self.master:
+            raise JobError("You can only resplit subjobs!")
+
+        mJob = self.master
+        rjobs = None
+        fqid = self.getFQID('.')
+
+        # App Configuration
+        logger.debug("App Configuration, Job %s:" % fqid)
+
+        # The App is configured first as information in the App may be
+        # needed by the Job Splitter
+        appmasterconfig = self._getMasterAppConfig()
+
+        logger.info("Re-splitting Job: %s" % fqid)
+
+        self.splitter = new_splitter
+
+        rjobs = self.splitter.validatedSplit(self)
+        if not rjobs:
+            raise SplitterError("Splitter '%s' failed to produce any subjobs from re-splitting. Aborting submit" % (getName(self.splitter),))
+
+        index = len(mJob.subjobs)
+
+        logger.debug('First index of new jobs: %s' % index)
+        if rjobs:
+            if not isType(mJob.subjobs, (list, GangaList)):
+                    mJob.subjobs = GangaList()
+            i = index
+            for sj in rjobs:
+                sj.info.uuid = str(uuid.uuid4())
+                sj.status = 'new'
+                sj.time.timenow('new')
+                sj.id = i
+                i += 1
+                mJob.subjobs.append(sj)
+
+            cfg = GangaCore.Utility.Config.getConfig('Configuration')
+            for j in rjobs:
+                if cfg['autoGenerateJobWorkspace']:
+                    j._init_workspace()
+
+            logger.info('submitting %s subjobs', len(rjobs))
+        
+            # Output Files
+            # validate the output files
+            for this_job in rjobs:
+                (validOutputFiles, errorMsg) = this_job.validateOutputfilesOnSubmit()
+                if not validOutputFiles:
+                    raise JobError(errorMsg)
+
+            # configure the application of each subjob
+            appsubconfig = self._getAppSubConfig(rjobs)
+            if appsubconfig is not None:
+                logger.debug("# appsubconfig: %s" % len(appsubconfig))
+
+            # Job Configuration
+            logger.debug("Job Configuration, Job %s:" % self.getFQID('.'))
+
+            # prepare the master job with the correct runtime handler
+            # Calls rtHandler.master_prepare if it hasn't already been called by the master job or by self
+            # Only stored as transient if the master_prepare successfully
+            # completes
+            jobmasterconfig = self._getJobMasterConfig()
+
+            # prepare the subjobs with the runtime handler
+            # Calls the rtHandler.prepare if it hasn't already been called by the master job or by self
+            # Only stored as a transient if the prepare successfully completes
+            jobsubconfig = self._getJobSubConfig(rjobs)
+            logger.debug("# jobsubconfig: %s" % len(jobsubconfig))
+
+            # Submission
+            logger.debug("Submitting to a backend, Job %s:" % self.getFQID('.'))
+
+            # notify monitoring-services
+            self.monitorPrepare_hook(jobsubconfig)
+
+            # submit the job
+            # master_submit has been written as the interface which ganga
+            # should call, not submit directly
+
+            r = self.backend.master_submit( rjobs, jobsubconfig, jobmasterconfig)
+
+            if not r:
+                raise JobManagerError('error during submit')
+
+            mJob.updateStatus('submitted')
+            # make sure that the status change goes to the repository, NOTE:
+            # this commit is redundant if updateStatus() is used on the line
+            # above
+
+            self.freeze()
+            self.comment = self.comment + ' - has been resplit'
+            for _r in rjobs:
+                _r.comment = _r.comment + ' - resplit of %s' % self.getFQID('.')
+            self._getRegistry()._flush([mJob])
+            return 1
 
     def submit(self, keep_going=None, keep_on_fail=None, prepare=False):
         """Submits a job. Return true on success.
@@ -2122,7 +2247,10 @@ class Job(GangaObject):
                 subjob_slice = stripProxy(self._stored_subjobs_proxy)
                 #First clear the dictionary
                 if subjob_slice.objects:
-                    del subjob_slice.objects[:]
+                    if isinstance(subjob_slice.objects, dict):
+                        subjob_slice.objects.clear()
+                    else:
+                        del subjob_slice.objects[:]
                 #Not put the objects back in
                 for sj in self.subjobs:
                     subjob_slice.objects[sj.id] = sj

--- a/ganga/GangaCore/GPIDev/Lib/Job/Job.py
+++ b/ganga/GangaCore/GPIDev/Lib/Job/Job.py
@@ -1568,6 +1568,8 @@ class Job(GangaObject):
             r = self.backend.master_submit( rjobs, jobsubconfig, jobmasterconfig)
 
             if not r:
+                for sj in rjobs:
+                    mJobs.subjobs.remove(sj)
                 raise JobManagerError('error during submit')
 
             mJob.updateStatus('submitted')

--- a/ganga/GangaCore/GPIDev/Lib/Job/Job.py
+++ b/ganga/GangaCore/GPIDev/Lib/Job/Job.py
@@ -1322,12 +1322,10 @@ class Job(GangaObject):
         else:
             #   I am a sub-job, lets calculate my config
             if len(subjobs) > 1:
-                print('where I should be')
                 rtHandler = self._getRuntimeHandler()
                 appmasterconfig = self.master._getMasterAppConfig()
                 jobmasterconfig = self.master._getJobMasterConfig()
                 appsubconfig = self._getAppSubConfig(subjobs)
-                print('length appsubconfig: ', len(appsubconfig))
                 logger.debug("Job %s Calling rtHandler.prepare %s times" % (self.getFQID('.'), len(self.subjobs)))
                 logger.info("Preparing subjobs")
                 #Make an empty list
@@ -1345,7 +1343,6 @@ class Job(GangaObject):
         self._storedJobSubConfig = jobsubconfig
 
         logger.debug("jobsubconfig: %s" % jobsubconfig)
-        print('length of jbsubconfig: ', len(jobsubconfig))
         return jobsubconfig
 
     def _getRuntimeHandler(self):

--- a/ganga/GangaCore/GPIDev/Lib/Job/Job.py
+++ b/ganga/GangaCore/GPIDev/Lib/Job/Job.py
@@ -1236,7 +1236,7 @@ class Job(GangaObject):
                 appsubconfig = [j.application.configure(appmasterconfig)[1] for j in subjobs]
 
         else:
-            if len(subjobs)>1:
+            if isinstance(subjobs, GangaList) and len(subjobs)>1:
                 appsubconfig = self._storedAppSubConfig
                 if appsubconfig is None or len(appsubconfig) == 0:
                     appmasterconfig = self._getMasterAppConfig()

--- a/ganga/GangaDirac/Lib/Backends/DiracBase.py
+++ b/ganga/GangaDirac/Lib/Backends/DiracBase.py
@@ -227,8 +227,9 @@ class DiracBase(IBackend):
         dirac_cmd = """execfile(\'%s\')""" % myscript
         submitFailures = {}
         try:
+            print('trying: ', myscript)
             result = execute(dirac_cmd, cred_req=self.credential_requirements, return_raw_dict = True, new_subprocess = True)
-
+            print('result: ', result)
         except GangaDiracError as err:
             err_msg = 'Error submitting job to Dirac: %s' % str(err)
             logger.error(err_msg)
@@ -244,6 +245,7 @@ class DiracBase(IBackend):
         #Now put the list of Dirac IDs into the subjobs and get them monitored:
         if len(j.subjobs)>0:
             for jobNo in result.keys():
+                print('setting info: ', jobNo)
                 sjNo = jobNo.split('.')[1]
                 #If we get an int we have a DIRAC ID so job submitted
                 if isinstance(result[jobNo], int):
@@ -260,26 +262,31 @@ class DiracBase(IBackend):
                     j.subjobs[int(sjNo)].updateStatus('failed')
                     submitFailures.update({jobNo : 'DIRAC error!'})
         else:
+            print('else')
             result_id = list(result.keys())[0]
+            print('result_id: ', result_id)
             if isinstance(result[result_id], int):
+                print('setting backend id')
                 j.backend.id = result[result_id]
                 j.updateStatus('submitted')
                 j.time.timenow('submitted')
+                print('about to increment info')
                 stripProxy(j.info).increment()
+                print('strip proxy')
             elif isinstance(result[result_id], str):
                 j.updateStatus('failed')
                 submitFailures.update({result_id: result[result_id]})
             else:
                 j.updateStatus('failed')
                 submitFailures.update({result_id: 'DIRAC error!'})
-
+        print('check failures')
         #Check that every subjob got submitted ok
         if len(submitFailures) > 0:
             for sjNo in submitFailures.keys():
                 logger.error('Job submission failed for job %s : %s' % (sjNo, submitFailures[sjNo]))
             raise GangaDiracError("Some subjobs failed to submit! Check their status!")
             return 0
-
+        print('about to return')
         return 1 
 
     def master_submit(self, rjobs, subjobconfigs, masterjobconfig, keep_going=False, parallel_submit=False):
@@ -292,8 +299,8 @@ class DiracBase(IBackend):
             return IBackend.master_submit(self, rjobs, subjobconfigs, masterjobconfig, keep_going, parallel_submit)
 
         #Otherwise use the block submit. Much of this is copied from IBackend
-        logger.debug("SubJobConfigs: %s" % len(subjobconfigs))
-        logger.debug("rjobs: %s" % len(rjobs))
+        logger.info("SubJobConfigs: %s" % len(subjobconfigs))
+        logger.info("rjobs: %s" % len(rjobs))
 
         if rjobs and len(subjobconfigs) != len(rjobs):
             raise BackendError("The number of subjob configurations does not match the number of subjobs!")
@@ -349,12 +356,13 @@ class DiracBase(IBackend):
                 logger.info("Submitting job")
             else:
                 logger.info("Submitting subjobs %s to %s" % (i*nPerProcess, upperlimit-1))
-
+                print('hello')
             try:
                 #Either do the submission in parallel with threads or sequentially
                 if parallel_submit:
                     getQueues()._monitoring_threadpool.add_function(self._block_submit, (dirac_script_filename, nSubjobs, keep_going))
                 else:
+                    print('about t block submit')
                     self._block_submit(dirac_script_filename, nSubjobs, keep_going)
 
                 while not self._subjob_status_check(rjobs, nPerProcess, i):

--- a/ganga/GangaLHCb/Lib/RTHandlers/GaudiExecRTHandlers.py
+++ b/ganga/GangaLHCb/Lib/RTHandlers/GaudiExecRTHandlers.py
@@ -165,13 +165,7 @@ def prepareCommand(app):
             raise ApplicationConfigurationError("The filetype: %s is not yet supported for use as an opts file.\nPlease contact the Ganga devs is you wish this implemented." %
                                                 getName(opts_file))
 
-    #Check if this was checked out with LbEnv or not
-    isLbEnv = True
-#    with open(app.directory+'/Makefile', "r") as makefile:
-#        if 'LbEnv' in makefile.read():
-#            isLbEnv = True
-
-    sourceEnv = app.getWNEnvScript(isLbEnv)
+    sourceEnv = app.getWNEnvScript(True)
 
     #Get the options for the run script
     run_args = ''

--- a/ganga/GangaLHCb/Lib/RTHandlers/GaudiExecRTHandlers.py
+++ b/ganga/GangaLHCb/Lib/RTHandlers/GaudiExecRTHandlers.py
@@ -166,10 +166,10 @@ def prepareCommand(app):
                                                 getName(opts_file))
 
     #Check if this was checked out with LbEnv or not
-    isLbEnv = False
-    with open(app.directory+'/Makefile', "r") as makefile:
-        if 'LbEnv' in makefile.read():
-            isLbEnv = True
+    isLbEnv = True
+#    with open(app.directory+'/Makefile', "r") as makefile:
+#        if 'LbEnv' in makefile.read():
+#            isLbEnv = True
 
     sourceEnv = app.getWNEnvScript(isLbEnv)
 


### PR DESCRIPTION
Fixes #1669 , inspired by #1883 .

Looks like:
```python
[14:17:25]                                                                                                                                                                         
Ganga In [7]: newsplitter = ArgSplitter(args = newargs)                                                                                                                            

[14:17:33]                                                                                                                                                                         
Ganga In [8]: jobs(14).subjobs(0).resplit(newsplitter)                                                                                                                             
INFO     removing: /tmp/masmith/tmpejoldzk2
INFO     removing: /tmp/masmith/tmp02bfpat6
INFO     job 14 status changed to "running"
INFO     Job 14 Running PostProcessor hook
INFO     job 14 status changed to "completed"
INFO     removing: /tmp/masmith/tmpfqb7xcix
INFO     Re-splitting Job: 14.0
INFO     submitting 2 subjobs
INFO     Preparing subjobs
INFO     SubJobConfigs: 2
INFO     rjobs: 2
INFO     submitting job 14.3 to Local backend
INFO     job 14 status changed to "submitting"
INFO     job 14 status changed to "submitted"
INFO     submitting job 14.4 to Local backend
INFO     job 14 status changed to "submitting"
INFO     job 14 status changed to "submitted"
Ganga Out [8]: 1

[14:17:48]                                                                                                                                                                         
Ganga In [9]: jobs(14).subjobs                                                                                                                                                     
Ganga Out [9]: 
Registry Slice: jobs(14).subjobs (5 objects)
--------------
    fqid |    status |      name | subjobs |    application |        backend |                             backend.actualCE |                       comment |  subjob status 
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
    14.0 |completed_ |           |         |     Executable |      Localhost |                           lxplus7103.cern.ch |            - has been resplit |            --- 
    14.1 | completed |           |         |     Executable |      Localhost |                           lxplus7103.cern.ch |                               |            --- 
    14.2 | completed |           |         |     Executable |      Localhost |                           lxplus7103.cern.ch |                               |            --- 
    14.3 | completed |           |         |     Executable |      Localhost |                           lxplus7103.cern.ch |             - resplit of 14.0 |            --- 
    14.4 | completed |           |         |     Executable |      Localhost |                           lxplus7103.cern.ch |             - resplit of 14.0 |            --- 
```