### PR TITLE
First steps towards supporting Python 3 LHCbDIRAC installations

### DIFF
--- a/ganga/GangaDirac/Lib/Backends/DiracBase.py
+++ b/ganga/GangaDirac/Lib/Backends/DiracBase.py
@@ -183,7 +183,7 @@ class DiracBase(IBackend):
         self.extraInfo = None
         self.statusInfo = ''
         j.been_queued = False
-        dirac_cmd = """execfile(\'%s\')""" % dirac_script
+        dirac_cmd = """exec(open(\'%s\').read())""" % dirac_script
 
         try:
             result = execute(dirac_cmd, cred_req=self.credential_requirements)
@@ -224,7 +224,7 @@ class DiracBase(IBackend):
         self.extraInfo = None
         self.statusInfo = ''
         j.been_queued = False
-        dirac_cmd = """execfile(\'%s\')""" % myscript
+        dirac_cmd = """exec(open(\'%s\').read())""" % myscript
         submitFailures = {}
         try:
             result = execute(dirac_cmd, cred_req=self.credential_requirements, return_raw_dict = True, new_subprocess = True)

--- a/ganga/GangaDirac/Lib/Server/DiracCommands.py
+++ b/ganga/GangaDirac/Lib/Server/DiracCommands.py
@@ -261,8 +261,8 @@ def finished_job(id, outputDir=os.getcwd(), unpack=True, oversized=True, noJobDi
 def finaliseJobs(inputDict, statusmapping, downloadSandbox=True, oversized=True, noJobDir=True):
     ''' A function to get the necessaries to finalise a whole bunch of jobs. Returns a dict of job information and a dict of stati.'''
     returnDict = {}
-    statusList = dirac.getJobStatus(inputDict.keys())
-    for diracID in inputDict.keys():
+    statusList = dirac.getJobStatus(list(inputDict))
+    for diracID in inputDict:
         returnDict[diracID] = {}
         returnDict[diracID]['cpuTime'] = normCPUTime(diracID, pipe_out=False)
         if downloadSandbox:
@@ -367,7 +367,7 @@ def monitorJobs(job_ids, status_mapping, pipe_out=True):
                 state_job_status[update_status] = []
             state_job_status[update_status].append(job_id)
     state_info = {}
-    for this_status, these_jobs in state_job_status.iteritems():
+    for this_status, these_jobs in state_job_status.items():
         state_info[this_status] = getBulkStateTime(these_jobs, this_status, pipe_out=False)
 
     return (status_info, state_info)
@@ -479,7 +479,7 @@ def listFiles(baseDir, minAge = None):
     emptyDirs = []
 
     while len(activeDirs) > 0:
-        currentDir = activeDirs.pop()	
+        currentDir = activeDirs.pop()
         res = fc.listDirectory(currentDir, withMetaData, timeout = 360)
         if not res['OK']:
             return "Error retrieving directory contents", "%s %s" % ( currentDir, res['Message'] )
@@ -499,7 +499,7 @@ def listFiles(baseDir, minAge = None):
                     fileOK = False
                     if (not withMetaData) or files[filename]['MetaData']['CreationDate'] < cutoffTime:
                         fileOK = True
-		    if not fileOK:
+                    if not fileOK:
                         files.pop(filename)
                 allFiles += sorted(files)
 

--- a/ganga/GangaDirac/Lib/Server/DiracProcess.py
+++ b/ganga/GangaDirac/Lib/Server/DiracProcess.py
@@ -4,9 +4,10 @@ import os
 import errno
 import socket
 import traceback
+import six
 HOST = 'localhost'  # Standard loopback interface address (localhost)
 PORT = int(sys.argv[1])        # Port to listen on
-rand_hash = raw_input() 
+rand_hash = six.moves.input()
 import time
 #We have to define an output function as a placeholder here.
 def output(data):
@@ -28,7 +29,7 @@ class socketWrapper(object):
     def read(self):
         cmd = ''
         while end_trans not in cmd:
-            data = self._socket.recv(1024)
+            data = self._socket.recv(1024).decode()
             if not data:
                 cmd = '###BROKEN###'
                 break
@@ -54,7 +55,7 @@ while True:
         cmd = sock.read()
         #Here we define the output method to just send the output of the diracCommand wrapper.
         def output(data):
-            conn.sendall(repr(data))
+            conn.sendall(repr(data).encode())
 
         if cmd=='close-connection':
             conn.shutdown(socket.SHUT_RDWR)
@@ -65,6 +66,7 @@ while True:
             conn.shutdown(socket.SHUT_RDWR)
             conn.close()
             break
+
         try:
             print(eval(cmd))
         except:
@@ -74,7 +76,7 @@ while True:
                 print("Exception raised executing command (cmd) '%s'\n" % cmd)
                 print(traceback.format_exc())
 
-        conn.sendall('###END-TRANS###')
+        conn.sendall(b'###END-TRANS###')
     #Catch the timeout and exit
     except socket.timeout:
         break

--- a/ganga/GangaLHCb/Lib/Server/DiracLHCbCommands.py
+++ b/ganga/GangaLHCb/Lib/Server/DiracLHCbCommands.py
@@ -104,11 +104,11 @@ def getDBtagsFromLFN( lfn ):
     conddb = ''
     if res['OK']: # there should probably also be an 'else' for cases where no information could be retrieved 
         val = res['Value']
-	steps = val['Steps']
-	last_step = steps[-1] # the tags are taken from the last step of production
-	dddb = last_step[4]
-	conddb = last_step[5]
-	return dddb, conddb
+        steps = val['Steps']
+        last_step = steps[-1] # the tags are taken from the last step of production
+        dddb = last_step[4]
+        conddb = last_step[5]
+        return dddb, conddb
     else:
         res = {'OK': False, 'Message': 'Error getting DB tags!'}
 

--- a/ganga/GangaLHCb/Utility/LHCbDIRACenv.py
+++ b/ganga/GangaLHCb/Utility/LHCbDIRACenv.py
@@ -36,7 +36,7 @@ def store_dirac_environment():
     lbVersion = LooseVersion(requestedVersion).version
     try:
         # we check if a real version (e.g. v9r2, or v9r3p13 or v10r12-pre9) is requested
-        if isinstance(lbVersion[1], int) and isinstance(lbVersion[3], int):
+        if "prod" in requestedVersion or isinstance(lbVersion[1], int) and isinstance(lbVersion[3], int):
             logger.warn("Specific version is requested (%s), please consider removing it!", requestedVersion)
             diracversion = requestedVersion
         else:


### PR DESCRIPTION
This is the first few things I've noticed when trying to use ganga with a Python 3 based installation of LHCbDIRAC. I'm probably not going to find time to fully check and finish this PR but hopefully this is useful nevertheless.

To test with Python 3 yourself you currently need to change to `/cvmfs/lhcb.cern.ch/lib/LbEnv-unstable` in `LHCbDIRACenv.py` and change `LHCbDiracVersion = v10.2.0a8` in your `~/gangarc`.

There is at lease one bug on the LHCbDIRAC side which makes bookkeeping queries fail and will be fixed by: https://gitlab.cern.ch/lhcb-dirac/LHCbDIRAC/-/merge_requests/1005