### PR TITLE
Fix whitespace in docs

### DIFF
--- a/doc/UserGuide/GoogleOauth.rst
+++ b/doc/UserGuide/GoogleOauth.rst
@@ -21,6 +21,7 @@ Click on the "+ CREATE CREDENTIALS" button at the top of the screen, then select
 Choose an application type of "Desktop app" if you using a Google account or "Other" if you using a GSuite account and click "Create". (the default name is fine)
 
 It will show you a client ID and client secret. These values, you should store in your `~/.gangarc` file
+
 .. code-block:: python
 
     [Google]

--- a/doc/UserGuide/InputAndOutputData.rst
+++ b/doc/UserGuide/InputAndOutputData.rst
@@ -135,6 +135,7 @@ Ganga won't retrieve the output to the submission node so if you need it locally
 Often it might be better to simply stream the data from its remote destination. You can get th ``URL`` for this as
 
 .. code-block:: python
+
     j.outputfiles[0].accessURL()
 
     
@@ -180,6 +181,7 @@ Only files created by Ganga can be deleted (or restored after deletion).
 To download files previously uploaded by ganga, use the `get` method:
 
 .. code-block:: python
+
     # consider "mydata.txt" file was previously uploaded by ganga
     j = GangaFile("mydata.txt")
     j.localDir = "~/temp" # folder where the file should be downloaded

--- a/doc/UserGuide/Splitters.rst
+++ b/doc/UserGuide/Splitters.rst
@@ -7,6 +7,7 @@ job but keeps track of all their status, etc. individually. There are two main s
 Core which are detailed below. You can see which splitter are available with
 
 .. code-block:: python
+
     Ganga In [1]: plugins('splitters')
     Ganga Out [1]: 
     ['ArgSplitter',
@@ -39,6 +40,7 @@ ArgSplitter
 For a job that is using an `Executable` application, it is very common that you want to run it multiple times with a different set of arguments (like a random number seed). The `ArgSplitter` can do exactly that. For each of the subjobs created, it will replace the arguments fot he job with one from the array of array of arguments provided to the splitter. So
 
 .. code-block:: python
+
     j = Job()
     j.splitter=ArgSplitter(args=[['Hello 1'], ['Hello 2']])
 
@@ -134,7 +136,7 @@ Sometimes a job that has been split will have some of the subjobs failing. This 
     --------------
         fqid |    status       |                       comment |
     -------------------------------------------------------
-         8.0 |completed_failed |            - has been resplit |
+         8.0 |completed_frozen |            - has been resplit |
          8.1 | completed       |                               |
          8.2 | completed       |              - resplit of 8.0 |
          8.3 | completed       |              - resplit of 8.0 |

--- a/doc/UserGuide/Splitters.rst
+++ b/doc/UserGuide/Splitters.rst
@@ -138,4 +138,4 @@ Sometimes a job that has been split will have some of the subjobs failing. This 
          8.3 | completed       |              - resplit of 8.0 |
 
 
-Any splitter can be used forthe resplitting. The subjob that was the origin of the replit is clearly marked as seen above.
+Any splitter can be used for the resplitting. The subjob that was the origin of the replit is clearly marked as seen above.

--- a/doc/UserGuide/Splitters.rst
+++ b/doc/UserGuide/Splitters.rst
@@ -142,4 +142,4 @@ Sometimes a job that has been split will have some of the subjobs failing. This 
          8.3 | completed       |              - resplit of 8.0 |
 
 
-Any splitter can be used for the resplitting. The subjob that was the origin of the replit is clearly marked as seen above.
+Any splitter can be used for the resplitting. The subjob that was the origin of the resplit is clearly marked as seen above.

--- a/doc/UserGuide/Splitters.rst
+++ b/doc/UserGuide/Splitters.rst
@@ -32,8 +32,8 @@ After the job and been submitted and finished, the output of each of the subjobs
 
 See the section :doc:`PostProcessors` for how we can merge the output into a single file.
 
-ArgSplitter:
-------------
+ArgSplitter
+-----------
 
 For a job that is using an `Executable` application, it is very common that you want to run it multiple times with a different set of arguments (like a random number seed). The `ArgSplitter` can do exactly that. For each of the subjobs created, it will replace the arguments fot he job with one from the array of array of arguments provided to the splitter. So
 
@@ -136,3 +136,6 @@ Sometimes a job that has been split will have some of the subjobs failing. This 
          8.1 | completed       |                               |
          8.2 | completed       |              - resplit of 8.0 |
          8.3 | completed       |              - resplit of 8.0 |
+
+
+Any splitter can be used forthe resplitting. The subjob that was the origin of the replit is clearly marked as seen above.

--- a/doc/UserGuide/Splitters.rst
+++ b/doc/UserGuide/Splitters.rst
@@ -28,6 +28,7 @@ Using the prime factorisation example from the Tutorial plugin (:doc:`TutorialPl
 After the job and been submitted and finished, the output of each of the subjobs will be available. Remember that ganga is just a standard Python prompt, so we can use standard Python syntax
 
 .. code-block:: python
+
     for js in j.subjobs: js.peek('stdout','cat')
 
 See the section :doc:`PostProcessors` for how we can merge the output into a single file.
@@ -111,6 +112,7 @@ Resplitting a job
 Sometimes a job that has been split will have some of the subjobs failing. This might for example be due to that they run out of CPU time and are required to be split into smaller units. To support this, it is possible to apply a new splitter to a subjob which is in the ``completed`` or ``failed`` state. In the example below can be seen how the first subjob is subsequently split into a further two subjobs. 
 
 .. code-block:: python
+
     j = Job(splitter=ArgSplitter(args=[ [0],[0] ]))
     j.submit()
 

--- a/doc/UserGuide/Virtualization.rst
+++ b/doc/UserGuide/Virtualization.rst
@@ -27,6 +27,7 @@ The Singularity class can be used for either Singularity or Docker images. It re
 For Singularity images you provide the image name and tag from Singularity hub like
 
 .. code-block:: python
+
     j=Job()
     j.application=Executable(exe=File('my/full/path/to/executable'))
     j.virtualization = Singularity("shub://image:tag")
@@ -36,30 +37,35 @@ Notice how the executable is given as a ``File`` object. This ensures that it is
 The container can also be provided as a Docker image from a repository. The default repository is Docker hub. 
 
 .. code-block:: python
+
     j.virtualization = Singularity("docker://gitlab-registry.cern.ch/lhcb-core/lbdocker/centos7-build:v3")
     j.virtualization = Docker("docker://fedora:latest")   
 
 Another option is to provide a ``GangaFile`` Object which points to a singularity file. In that case the singularity image file will be copied to the worker node. The first example is with an image located on some shared disk. This will be effective for running on a local backend or a batch system with a shared disk system.
 
 .. code-block:: python
+
     imagefile = SharedFile('myimage.sif', locations=['/my/full/path/myimage.sif'])
     j.virtualization = Singularity(image= imagefile)
 
 while a second example is with an image located in the Dirac Storage Element. This will be effective when using the Dirac backend.
 
 .. code-block:: python
+
     imagefile = DiracFile('myimage.sif', lfn=['/some/lfn/path'])
     j.virtualization = Singularity(image= imagefile)
   
 If the image is a private image, the username and password of the deploy token can be given like the example below. Look inside Gitlab setting for how to set this up. The token will only need access to the images and nothing else.
 
 .. code-block:: python
+
     j.virtualization.tokenuser = 'gitlab+deploy-token-123'
     j.virtualization.tokenpassword = 'gftrh84dgel-245^ghHH'
 
 Directories can be mounted from the host to the container using key-value pairs to the mounts option. If the directory is not vailable on the host, a warning will be written to stderr of the job and no mount will be attempted.
 
 .. code-block:: python
+
     j.virtualization.mounts = {'/cvmfs':'/cvmfs'}
 
 By default the container is started in singularity with the ``--nohome`` option. Extra options can be provided through the ``options`` attribute. See the Singularity documentation for what is possible.
@@ -70,6 +76,7 @@ You can define a docker container by providing an image name and tag. Using that
 the image from the docker hub. 
 
 .. code-block:: python
+
     j=Job()
     j.virtualization = Docker("image:tag")
 


### PR DESCRIPTION
It turns out that an empty line is required after 

```
.. code-block:: python
```
for the subsequent code to render in the documentation. Fixed in several places.