### PR TITLE
Ability to limit simultaneous local jobs

### DIFF
--- a/ganga/GangaCore/GPIDev/Lib/Job/Job.py
+++ b/ganga/GangaCore/GPIDev/Lib/Job/Job.py
@@ -2034,7 +2034,8 @@ class Job(GangaObject):
                         for jobs in self.getJobObject().subjobs:
                             # added this 10/8/2009 - now only kills subjobs
                             # which aren't finished.
-                            if jobs.status not in ['failed', 'killed', 'completed']:
+                            if jobs.status not in ['failed', 'killed', 'completed',
+                                                   'failed_frozen', 'completed_frozen']:
                                 jobs.updateStatus('killed', transition_update=transition_update)
                     self.updateStatus('killed', transition_update=transition_update)
                     #

--- a/ganga/GangaCore/Lib/Localhost/LocalHostExec.py.template
+++ b/ganga/GangaCore/Lib/Localhost/LocalHostExec.py.template
@@ -1,7 +1,5 @@
-#!/usr/bin/env python2
-from __future__ import print_function
+#!/usr/bin/env python3
 import os,os.path,shutil,tempfile
-import sys,time
 import glob
 import sys
 import mimetypes
@@ -100,6 +98,7 @@ try:
 except OSError as x:
     failurereport(statusfile, 'PROBLEM STARTING THE APPLICATION SCRIPT: \'%s\' \'%s\''%(execmd,str(x)))
                 
+print('WRAPPER: %d'% os.getpid(), file=statusfile)
 print('PID: %d'%child.pid, file=statusfile)
 statusfile.flush()
 

--- a/ganga/GangaCore/Lib/Localhost/LocalHostExec_batch.py.template
+++ b/ganga/GangaCore/Lib/Localhost/LocalHostExec_batch.py.template
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+import os
+import sys
+import subprocess
+import time
+import multiprocessing
+from pathlib import Path
+from os.path import dirname, join
+
+def mp_worker(name):
+    if not Path(join(dirname(name), '__syslog__')).is_file():
+        print(f'START: {name} '+ time.strftime('%a %b %d %H:%M:%S %Y',time.gmtime(time.time())))
+        subprocess.run(['python3', name])
+    else:
+        print(f'SKIPPING: {name} '+ time.strftime('%a %b %d %H:%M:%S %Y',time.gmtime(time.time())))
+
+# Make sure that the wrapper (spawned process) is detached from Ganga session
+# the process will not receive Control-C signals
+# using fork  and doing setsid() before  exec would probably  be a bit
+# better (to avoid  slim chance that the signal  is propagated to this
+# process before setsid is reached)
+# this is only enabled if the first argument is 'subprocess' in order to enable
+# running this script by hand from outside ganga (which is sometimes useful)
+if len(sys.argv)>1 and sys.argv[1] == 'subprocess':
+    os.setsid()
+        
+workdir = ###WORKDIR###
+batch_size = ###BATCHSIZE###
+    
+scriptnames_g = Path(workdir).glob('*/*/__jobscript__')
+
+outdir = join(workdir,'output')
+os.mkdir(outdir)
+statusfilename = join(outdir,'__jobstatus__')
+
+try:
+    statusfile=open(statusfilename,'w')
+except IOError as x:
+    print('ERROR: not able to write a status file: ', statusfilename)
+    print('ERROR: ',x)
+    raise
+
+line='START: '+ time.strftime('%a %b %d %H:%M:%S %Y',time.gmtime(time.time())) + os.linesep
+statusfile.writelines(line)
+statusfile.flush()
+
+sys.stdout=open(join(outdir,'__syslog__'),'w')
+sys.stderr=sys.stdout
+
+print(f'Running with a batch size of {batch_size}')
+pool = multiprocessing.Pool(batch_size)
+pool.map(mp_worker, scriptnames_g)
+
+sys.stdout=sys.__stdout__
+sys.stderr=sys.__stderr__
+
+line='STOP: '+time.strftime('%a %b %d %H:%M:%S %Y',time.gmtime(time.time())) + os.linesep
+statusfile.writelines(line)
+statusfile.close()
+sys.exit()

--- a/ganga/GangaCore/test/GPI/TestSubjobs.py
+++ b/ganga/GangaCore/test/GPI/TestSubjobs.py
@@ -40,9 +40,6 @@ class TestSubjobs(GangaUnitTest):
         j.backend = Local()
         j.submit()
 
-        sleep_until_state(j, None, 'running')
-        assert j.status == 'running'
-
         j.subjobs(0).kill()
         assert j.subjobs(0).status == 'killed'
         assert j.subjobs(1).status != 'killed'

--- a/ganga/GangaCore/test/GPI/TestSubjobs.py
+++ b/ganga/GangaCore/test/GPI/TestSubjobs.py
@@ -81,3 +81,18 @@ class TestSubjobs(GangaUnitTest):
             assert sj.application.args == ['400']
             assert stripProxy(sj)._getRoot() is stripProxy(j)
             assert stripProxy(sj.application)._getRoot() is stripProxy(j)
+
+    def testParallelSubJobs(self):
+        from GangaCore.GPI import Job, ArgSplitter, Local, Executable
+        sleeptime = 5
+        nsubjobs = 20
+        batch = 10
+        j = Job(splitter=ArgSplitter(args=[ [sleeptime] for x in range(nsubjobs)]),
+                application=Executable(exe='sleep'),
+                backend=Local(batchsize=batch))
+        j.submit()
+        import datetime
+        from GangaTest.Framework.utils import sleep_until_completed
+        assert sleep_until_completed(j,60)
+        runtime = j.time.timestamps['backend_final']-j.time.timestamps['backend_running']
+        assert  runtime < datetime.timedelta(seconds=int(nsubjobs*sleeptime/batch + 10))


### PR DESCRIPTION
Runs a specific number of jobs at time. The code uses multiprocessing library to create a thread pool, spawning a fixed number of threads as provided by the user to run a specific number of jobs at a time in parallel. I have tested this code on a simple python code to compare the execution time. The link to the test code can be found [here](https://colab.research.google.com/drive/1sc-H7KLmxslz4kBqh_eNl06nN6QXJIkC?usp=sharingl) . I have used the following code to test this in ganga.

```python
j = Job()
j.application.exe='sleep'
j.splitter = GenericSplitter()
j.splitter.attribute = 'application.args'
j.splitter.values=[ [10] for i in range(20) ]
j.backend.batch_submit=3
j.submit()

```