### PR TITLE
Pin jedi dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,7 @@ setup(name='ganga',
       packages=pythonPackages,
       install_requires=[
           'ipython>=5.0.0',
+          'jedi==0.17.2',
           'httplib2>=0.8',
           'absl-py>=0.1.2',
           'google-api-python-client',


### PR DESCRIPTION
The most recent version of jedi (0.18.0) doesn't work with IPython - it is a known issue. Therefore pin to the last compatible version for now (0.17.2).