### PR TITLE
Add splitter to download input locally

### DIFF
--- a/ganga/GangaLHCb/Lib/Splitters/SplitByFiles.py
+++ b/ganga/GangaLHCb/Lib/Splitters/SplitByFiles.py
@@ -243,3 +243,19 @@ class SplitByFiles(GaudiInputDataSplitter):
         logger.debug("split_return: %s" % split_return)
         return split_return
 
+
+class SplitByFilesAndDownload(SplitByFiles):
+    '''Split by files and add the DiracFiles in the subjob's inputdata
+    to their inputfiles so they're downloaded to the job's working dir.'''
+
+    _name = 'SplitByFilesAndDownload'
+    _schema = SplitByFiles._schema
+    
+    def _create_subjob(self, job, dataset):
+        '''Create the subjob with the given dataset and add DiracFiles
+        to the subjob's inputfiles.'''
+        sj = super(SplitByFilesAndDownload, self)._create_subjob(job, dataset)
+        for f in sj.inputdata:
+            if hasattr(f, 'lfn'):
+                sj.inputfiles.append(f)
+        return sj

--- a/ganga/GangaLHCb/Lib/Splitters/__init__.py
+++ b/ganga/GangaLHCb/Lib/Splitters/__init__.py
@@ -1,3 +1,3 @@
-from .SplitByFiles import SplitByFiles
+from .SplitByFiles import SplitByFiles, SplitByFilesAndDownload
 from .OptionsFileSplitter import OptionsFileSplitter
 from .GaussSplitter import GaussSplitter


### PR DESCRIPTION
The `SplitByFilesAndDownload` splitter adds `DiracFile` instances to a subjob's `inputfiles` after its creation, so that they're downloaded to the job's working directory. When the LFN->PFN xml catalog is generated on the working node, it finds the local copies and adds them so that they can be accessed by LFN. This is needed for jobs running in containers and using XRootD v3 based stacks (ie, slc5 builds), as they can't access files remotely.

As discussed with @egede, maybe it's better to add this as an option to the existing `SplitByFiles`, rather than adding a new splitter. Currently I get a warning on Ganga startup:
```
WARNING  Possible schema clash in class SplitByFilesAndDownload between SplitByFilesAndDownload and SplitByFiles
```

Note that this PR builds on top of the `container_build` branch that @mesmith75 is working on, as I needed that to be able to submit the containerised slc5 jobs. I can rebase this branch to include just my commits if necessary.