### PR TITLE
Allow for multi-core make-ing of the input sandbox

### DIFF
--- a/ganga/GangaLHCb/Lib/Applications/GaudiExec.py
+++ b/ganga/GangaLHCb/Lib/Applications/GaudiExec.py
@@ -105,6 +105,8 @@ class GaudiExec(IPrepareApp):
 
     prepare_cmake_app(myApp, myVer, myPath, myGetpack)
 
+    The argument 'nMakeCores' allows to set the number of cores allowed for make-ing the ganga-input-sandbox (default = 1). 
+
     =============
     How it works:
     =============
@@ -168,7 +170,8 @@ class GaudiExec(IPrepareApp):
         'extraArgs':    SimpleItem(defvalue=[], typelist=[str], sequence=1, doc='Extra runtime arguments which are passed to the code running on the WN'),
         'run_args' :    SimpleItem(defvalue = [], typelist=[list], doc='A list of arguments to pass to the lb-run script at run time. i.e. --quiet'),
         'getMetadata':  SimpleItem(defvalue=False, doc='Do you want to get the metadata from your jobs'),
-
+        'nMakeCores':   SimpleItem(defvalue=1, doc='Number of cores to be provided via the "-j" option to the "make" command when building the ganga-input-sandbox'),
+        
         # Prepared job object
         'is_prepared':  SimpleItem(defvalue=None, strict_sequence=0, visitable=1, copyable=1, hidden=0, typelist=[None, ShareDir], protected=0, comparable=1,
             doc='Location of shared resources. Presence of this attribute implies the application has been prepared.'),
@@ -532,7 +535,7 @@ class GaudiExec(IPrepareApp):
         """
         logger.info("Make-ing target '%s'     (This may take a few minutes depending on the size of your project)" % GaudiExec.build_target)
         # Up to the user to run something like make clean... (Although that would avoid some potential CMake problems)
-        self.execCmd('make %s' % GaudiExec.build_target)
+        self.execCmd('make {0} -j{1}'.format(GaudiExec.build_target, self.nMakeCores))
 
         targetPath = path.join(self.directory, 'build.%s' % self.platform, 'ganga')
         if not path.isdir(targetPath):


### PR DESCRIPTION
This introduces a new argument 'nMakeCores' (default=1) which is provided to the `make` command.