### PR TITLE
Ensure DiracCommands.getOutputDataInfo doesn't return dict_keys

### DIFF
--- a/ganga/GangaDirac/Lib/Server/DiracCommands.py
+++ b/ganga/GangaDirac/Lib/Server/DiracCommands.py
@@ -190,7 +190,7 @@ def getOutputDataInfo(id, pipe_out=True):
                 continue
             rp = dirac.getReplicas(lfn)
             if rp.get('OK', False) and lfn in rp.get('Value', {'Successful': {}})['Successful']:
-                ret[file_name]['LOCATIONS'] = rp['Value']['Successful'][lfn].keys()
+                ret[file_name]['LOCATIONS'] = list(rp['Value']['Successful'][lfn])
     return ret
 
 


### PR DESCRIPTION
I suspect this fixes the issue reported in https://mattermost.web.cern.ch/lhcb/pl/a81pi1dqdjyf8jfyzp15ynapjc