### PR TITLE
Prevent the flask server from starting during shutdown

### DIFF
--- a/ganga/GangaCore/Core/InternalServices/ShutdownManager.py
+++ b/ganga/GangaCore/Core/InternalServices/ShutdownManager.py
@@ -58,8 +58,9 @@ def _unprotected_ganga_exitfuncs():
     setConfigOption('Configuration', 'DiskIOTimeout', 1)
 
     # Stop APIServerThread - GangaGUI
-    from GangaGUI.start import stop_gui, api_server
-    if api_server is not None:
+    from GangaGUI import guistate
+    if guistate.get_api_server() is not None:
+        from GangaGUI.start import stop_gui
         try:
             stop_gui()
         except Exception as err:

--- a/ganga/GangaGUI/guistate.py
+++ b/ganga/GangaGUI/guistate.py
@@ -1,0 +1,19 @@
+# Global API Server, will run in Ganga thread pool
+api_server = None
+
+# Global GUI Server, will start gunicorn server using subprocess.popen
+gui_server = None
+
+def set_api_server(value):
+    global api_server
+    api_server = value
+
+def get_api_server():
+    return api_server
+
+def set_gui_server(value):
+    global gui_server
+    gui_server = value
+
+def get_gui_server():
+    return gui_server


### PR DESCRIPTION
The flask server was started during the import of a module. So when running ganga without the GUI starting the following happened.

- At startup, the flask server was not started
- At shutdown the GUI module was imported to check if the flask server was running. But this CAUSED the flask server to start.

A new module is now used as a singleton object to keep the state in.