### PR TITLE
Don't raise an error if there is no sandbox for jobs killed by Dirac

### DIFF
--- a/ganga/GangaDirac/Lib/Backends/DiracBase.py
+++ b/ganga/GangaDirac/Lib/Backends/DiracBase.py
@@ -1047,12 +1047,12 @@ class DiracBase(IBackend):
 
             output_path = job.getOutputWorkspace().getPath()
 
-            logger.info('Contacting DIRAC for job: %s' % job.fqid)
+            logger.debug('Contacting DIRAC for job: %s' % job.fqid)
             # Contact dirac which knows about the job
             job.backend.normCPUTime, getSandboxResult, file_info_dict, completeTimeResult = execute("finished_job(%d, '%s', %s, downloadSandbox=%s)" % (job.backend.id, output_path, job.backend.unpackOutputSandbox, job.backend.downloadSandbox), cred_req=job.backend.credential_requirements)
 
             now = time.time()
-            logger.info('%0.2fs taken to download output from DIRAC for Job %s' % ((now - start), job.fqid))
+            logger.debug('%0.2fs taken to download output from DIRAC for Job %s' % ((now - start), job.fqid))
 
             #logger.info('Job ' + job.fqid + ' OutputDataInfo: ' + str(file_info_dict))
             #logger.info('Job ' + job.fqid + ' OutputSandbox: ' + str(getSandboxResult))

--- a/ganga/GangaDirac/Lib/Server/DiracCommands.py
+++ b/ganga/GangaDirac/Lib/Server/DiracCommands.py
@@ -258,7 +258,7 @@ def finished_job(id, outputDir=os.getcwd(), unpack=True, oversized=True, noJobDi
 
 
 @diracCommand
-def finaliseJobs(inputDict, statusmapping, downloadSandbox=True, oversized=True, noJobDir=True):
+def finaliseJobs(inputDict, downloadSandbox=True, oversized=True, noJobDir=True):
     ''' A function to get the necessaries to finalise a whole bunch of jobs. Returns a dict of job information and a dict of stati.'''
     returnDict = {}
     statusList = dirac.getJobStatus(list(inputDict))

--- a/ganga/GangaDirac/Lib/Server/DiracCommands.py
+++ b/ganga/GangaDirac/Lib/Server/DiracCommands.py
@@ -265,7 +265,7 @@ def finaliseJobs(inputDict, downloadSandbox=True, oversized=True, noJobDir=True)
     for diracID in inputDict:
         returnDict[diracID] = {}
         returnDict[diracID]['cpuTime'] = normCPUTime(diracID, pipe_out=False)
-        if downloadSandbox:
+        if downloadSandbox and not statusList['Value'][diracID]['Status'] == 'Killed':
             returnDict[diracID]['outSandbox'] = getOutputSandbox(diracID, inputDict[diracID], oversized, noJobDir, pipe_out=False)
         else:
             returnDict[diracID]['outSandbox'] = None


### PR DESCRIPTION
Fixes #2015 

This intercepts the exception from the failed sandbox download if the backend status is `Killed`. I am checking with the Dirac developers if in fact one should *never* expect a sandbox from Dirac if the job is killed. If that is the case then I'll alter it to not even try downloading.