### PR TITLE
Adjust DiracFile put filename length warning

### DIFF
--- a/ganga/GangaDirac/Lib/Files/DiracFile.py
+++ b/ganga/GangaDirac/Lib/Files/DiracFile.py
@@ -773,8 +773,8 @@ class DiracFile(IGangaFile):
 
             if lfn=='':
                 lfn = os.path.join(lfn_base, os.path.basename(this_file))
-            if len(os.path.basename(lfn)) > 60:
-                logger.warning('Filename is longer than 60 characters. This may cause problems with Dirac storage.')
+            if len(os.path.basename(lfn)) > 99:
+                logger.warning('Filename is longer than 99 characters. This may cause problems with Dirac storage.')
 
             d = DiracFile()
             d.namePattern = os.path.basename(name)


### PR DESCRIPTION
60 was a bit short - the GaudiExec sandboxes are often already longer than that.