### PR TITLE
Asyncio compatible tests

### DIFF
--- a/ganga/GangaCore/Core/InternalServices/Coordinator.py
+++ b/ganga/GangaCore/Core/InternalServices/Coordinator.py
@@ -92,15 +92,9 @@ def _diskSpaceChecker():
 
 
 def disableMonitoringService():
-
-    # disable the mon loop
-    log.debug("Shutting down the main monitoring loop")
-    from GangaCore.Core.MonitoringComponent.Local_GangaMC_Service import _purge_actions_queue, stop_and_free_thread_pool
-    _purge_actions_queue()
-    stop_and_free_thread_pool()
     log.debug("Disabling the central Monitoring")
     from GangaCore.Core import monitoring_component
-    monitoring_component.disableMonitoring()
+    monitoring_component.disable()
 
 
 def disableInternalServices():
@@ -155,11 +149,7 @@ def disableInternalServices():
 
 def enableMonitoringService():
     from GangaCore.Core import monitoring_component
-    monitoring_component.alive = True
-    monitoring_component.enableMonitoring()
-    from GangaCore.Core.MonitoringComponent.Local_GangaMC_Service import _makeThreadPool, ThreadPool
-    if not ThreadPool or len(ThreadPool) == 0:
-        _makeThreadPool()
+    monitoring_component.enable()
     global servicesEnabled
     servicesEnabled = True
 

--- a/ganga/GangaCore/Core/MonitoringComponent/MonitoringService.py
+++ b/ganga/GangaCore/Core/MonitoringComponent/MonitoringService.py
@@ -75,6 +75,22 @@ class AsyncMonitoringService(GangaThread):
         for task in scheduled_tasks:
             task.cancel()
 
+    def disable(self):
+        if not self.alive:
+            log.error("Cannot disable monitoring loop. It has already been stopped")
+            return False
+        self._cleanup_scheduled_tasks()
+        self.enabled = False
+        return True
+
+    def enable(self):
+        if not self.alive:
+            log.error("Cannot start monitoring loop. It has already been stopped")
+            return False
+        self.enabled = True
+        self.loop.call_soon_threadsafe(self._check_active_backends)
+        return True
+
     def stop(self):
         self.alive = False
         self.enabled = False

--- a/ganga/GangaCore/Core/MonitoringComponent/MonitoringService.py
+++ b/ganga/GangaCore/Core/MonitoringComponent/MonitoringService.py
@@ -70,6 +70,10 @@ class AsyncMonitoringService(GangaThread):
             stripProxy(backend_obj).master_updateMonitoringInformation(these_jobs)
         self.loop.call_later(POLL_RATE, self._check_active_backends)
 
+    def run_monitoring_task(self, coro, executor=None):
+        if not executor:
+            self.loop.create_task(coro)
+
     def _cleanup_scheduled_tasks(self):
         scheduled_tasks = [task for task in asyncio.all_tasks(self.loop) if task is not asyncio.current_task(self.loop)]
         for task in scheduled_tasks:

--- a/ganga/GangaCore/Core/__init__.py
+++ b/ganga/GangaCore/Core/__init__.py
@@ -36,8 +36,6 @@ def bootstrap(reg_slice, interactive_session, my_interface=None):
     from GangaCore.Utility.logging import getLogger
     global monitoring_component
 
-    # The asyncio monitoring loop implementation to use
-    aioloop = asyncio.new_event_loop()
     # start the monitoring loop
     monitoring_component = AsyncMonitoringService(registry_slice=reg_slice)
     # monitoring_component = JobRegistry_Monitor(registry_slice=reg_slice)

--- a/ganga/GangaCore/Core/__init__.py
+++ b/ganga/GangaCore/Core/__init__.py
@@ -36,6 +36,8 @@ def bootstrap(reg_slice, interactive_session, my_interface=None):
     from GangaCore.Utility.logging import getLogger
     global monitoring_component
 
+    # The asyncio monitoring loop implementation to use
+    aioloop = asyncio.new_event_loop()
     # start the monitoring loop
     monitoring_component = AsyncMonitoringService(registry_slice=reg_slice)
     # monitoring_component = JobRegistry_Monitor(registry_slice=reg_slice)

--- a/ganga/GangaCore/GPIDev/Adapters/IBackend.py
+++ b/ganga/GangaCore/GPIDev/Adapters/IBackend.py
@@ -451,7 +451,6 @@ class IBackend(GangaObject):
             logger.debug("Problem with PollThread Config, defaulting to block size of 5 in master_updateMon...")
             logger.debug("Error: %s" % err)
             blocks_of_size = 5
-
         # Separate different backends implicitly
         simple_jobs = {}
         for j in jobs:

--- a/ganga/GangaCore/GPIDev/Adapters/IBackend.py
+++ b/ganga/GangaCore/GPIDev/Adapters/IBackend.py
@@ -485,8 +485,8 @@ class IBackend(GangaObject):
                         for sj_id in this_block:
                             subjobs_to_monitor.append(j.subjobs[sj_id])
 
-                        monitoring_component.run_monitoring_task(
-                            j.backend.updateMonitoringInformation(subjobs_to_monitor))
+                        task = j.backend.updateMonitoringInformation
+                        monitoring_component.run_monitoring_task(task, subjobs_to_monitor)
                     except Exception as err:
                         logger.error("Monitoring Error: %s" % err)
 
@@ -500,9 +500,10 @@ class IBackend(GangaObject):
 
         if len(simple_jobs) > 0:
             for this_backend in simple_jobs.keys():
-                logger.debug('Monitoring jobs: %s', repr([jj._repr() for jj in simple_jobs[this_backend]]))
-                monitoring_component.run_monitoring_task(stripProxy(
-                    simple_jobs[this_backend][0].backend).updateMonitoringInformation(simple_jobs[this_backend]))
+                jobs = simple_jobs[this_backend]
+                logger.debug('Monitoring jobs: %s', repr([jj._repr() for jj in jobs]))
+                task = stripProxy(simple_jobs[this_backend][0].backend).updateMonitoringInformation
+                monitoring_component.run_monitoring_task(task, jobs)
 
         logger.debug("Finished Monitoring request")
 

--- a/ganga/GangaCore/GPIDev/Adapters/IBackend.py
+++ b/ganga/GangaCore/GPIDev/Adapters/IBackend.py
@@ -485,7 +485,8 @@ class IBackend(GangaObject):
                         for sj_id in this_block:
                             subjobs_to_monitor.append(j.subjobs[sj_id])
 
-                        asyncio.create_task(j.backend.updateMonitoringInformation(subjobs_to_monitor))
+                        monitoring_component.run_monitoring_task(
+                            j.backend.updateMonitoringInformation(subjobs_to_monitor))
                     except Exception as err:
                         logger.error("Monitoring Error: %s" % err)
 
@@ -500,7 +501,7 @@ class IBackend(GangaObject):
         if len(simple_jobs) > 0:
             for this_backend in simple_jobs.keys():
                 logger.debug('Monitoring jobs: %s', repr([jj._repr() for jj in simple_jobs[this_backend]]))
-                asyncio.create_task(stripProxy(
+                monitoring_component.run_monitoring_task(stripProxy(
                     simple_jobs[this_backend][0].backend).updateMonitoringInformation(simple_jobs[this_backend]))
 
         logger.debug("Finished Monitoring request")

--- a/ganga/GangaCore/test/GPI/TutorialTests.py
+++ b/ganga/GangaCore/test/GPI/TutorialTests.py
@@ -80,9 +80,7 @@ j.submit()
 
     def test_c_JobManipulation(self):
 
-        from GangaCore.GPI import runMonitoring, Job, jobs, export, load
-
-        runMonitoring()
+        from GangaCore.GPI import Job, jobs, export, load
 
         # -- JOBMANIPULATION JOBCOPY START
         j = Job(name='original')

--- a/ganga/GangaTest/Framework/utils.py
+++ b/ganga/GangaTest/Framework/utils.py
@@ -48,14 +48,8 @@ def sleep_until_state(j, timeout=None, state='completed', break_states=None, sle
 
     current_status = None
     while j.status != state and timeout > 0:
-        if not monitoring_component.isEnabled():
-            monitoring_component.runMonitoring(jobs=jobs.select(j.id, j.id))
-        else:
-            monitoring_component.alive = True
-            monitoring_component.enabled = True
-            monitoring_component.steps = -1
-            monitoring_component.__updateTimeStamp = 0
-            monitoring_component.__sleepCounter = -0.5
+        if not monitoring_component.enabled:
+            monitoring_component.enable()
         if verbose and j.status != current_status:
             logger.info("Job %s: status = %s" % (str(j.id), str(j.status)))
         if current_status is None:


### PR DESCRIPTION
The problems that caused the tests to fail with the new monitoring sevice were the following:

1. The test runner used the old service's disable/enable monitoring methods. I recreated this functionality for the new service. However, stopping the event loop would cause the thread to die. So I am using a simple `enabled` flag and stopping the `check_active_backends` method that runs continuously when that flag is `False`.
2. When running in the testing context, the running event loop wasn't automatically detected by other threads. To solve this, I added the `run_monitoring_task` method to the service which the rest of the services can use as a simple interface to send their monitoring tasks with. This can also be used to also choose different executors such as threads and processes.