### PR TITLE
Fix CI Linting step: Include checkout fetch depth

### DIFF
--- a/.github/workflows/ci_push_testing.yml
+++ b/.github/workflows/ci_push_testing.yml
@@ -14,6 +14,7 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: 3.8
+          fetch-depth: 0
 
       - name: Get changed files
         id: changed-files


### PR DESCRIPTION
The linting step fails on the [getting changed files step](https://github.com/ganga-devs/ganga/blob/3ec76823744452a91edd82c72552f1ca2204be14/.github/workflows/ci_push_testing.yml#L18) when running on newly pushed commits. ([Example failed Action](https://github.com/ganga-devs/ganga/runs/7749133291?check_suite_focus=true))

This PR includes the fetch-depth option which fixes this issue.

