### PR TITLE
Ignore W503 in linting test

### DIFF
--- a/.github/workflows/ci_push_testing.yml
+++ b/.github/workflows/ci_push_testing.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
             if [[ $file == *.py ]]; then
-              flake8 --ignore=W503 $file
+              flake8 $file
             fi
           done
 

--- a/.github/workflows/ci_push_testing.yml
+++ b/.github/workflows/ci_push_testing.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
             if [[ $file == *.py ]]; then
-              flake8 $file
+              flake8 --ignore=W503 $file
             fi
           done
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ python_files=*.py
 addopts = --doctest-modules -v
 
 [flake8]
-ignore = E402
+ignore = E402,W503
 exclude =
     .git,
     Dockerfile,


### PR DESCRIPTION
I propose we explicitly ignore W503 as it is apparently outdated. We cannot have both W504 and W503 - they seem mutually exclusive but we are picking up both.