### PR TITLE
Add DIRAC executor process tear down

### DIFF
--- a/ganga/GangaCore/Core/MonitoringComponent/MonitoringService.py
+++ b/ganga/GangaCore/Core/MonitoringComponent/MonitoringService.py
@@ -79,7 +79,10 @@ class AsyncMonitoringService(GangaThread):
                 self._check_backend(backend_obj)
 
         self._log_backend_summary(found_active_backends)
-        self._cleanup_finished_backends(previously_active_backends, found_active_backends)
+
+        if previously_active_backends:
+            self._cleanup_finished_backends(previously_active_backends, found_active_backends)
+
         self.loop.call_later(POLL_RATE, self._check_active_backends)
 
     def _log_backend_summary(self, active_backends):
@@ -130,6 +133,11 @@ class AsyncMonitoringService(GangaThread):
         # Check for backends which have no more jobs to monitor and trigger their cleanup.
         for backend, jobs in previously_active_backends.items():
             if backend not in found_active_backends:
+                for job in jobs:
+                    if job.status == 'completing':
+                        self.loop.call_later(1, self._cleanup_finished_backends,
+                                             previously_active_backends, found_active_backends)
+                        return
                 log.debug(f'Removing {getName(backend)} from active backends')
                 backend_obj = lazyLoadJobBackend(jobs[0])
                 self._cleanup_backend(backend_obj)

--- a/ganga/GangaCore/Core/__init__.py
+++ b/ganga/GangaCore/Core/__init__.py
@@ -8,9 +8,15 @@ Attributes:
         in the bootstrap function.
 """
 import asyncio
+import signal
+from GangaCore.Core.exceptions import TerminationSignalException
 
 
 monitoring_component = None
+
+
+def handle_sigterm(signum, frame):
+    raise TerminationSignalException
 
 
 def bootstrap(reg_slice, interactive_session, my_interface=None):
@@ -40,6 +46,8 @@ def bootstrap(reg_slice, interactive_session, my_interface=None):
     monitoring_component = AsyncMonitoringService(registry_slice=reg_slice)
     # monitoring_component = JobRegistry_Monitor(registry_slice=reg_slice)
     monitoring_component.start()
+    # Register global SIGTERM handler which raises the appropriate exception
+    signal.signal(signal.SIGTERM, handle_sigterm)
 
     # override the default monitoring autostart value with the setting from interactive session
     config = getConfig("PollThread")

--- a/ganga/GangaCore/Core/exceptions.py
+++ b/ganga/GangaCore/Core/exceptions.py
@@ -194,7 +194,8 @@ class GangaKeyError(GangaException, KeyError):
 
 class GangaTypeError(GangaException, TypeError):
     """
-    Class analogous to GangaKeyError. This class wraps TypeError so that users are prevented from seeing stack traces from known good exceptions thrown in Ganga code.
+    Class analogous to GangaKeyError. This class wraps TypeError so that users are prevented from seeing stack traces
+    from known good exceptions thrown in Ganga code.
     """
 
     def __init__(self, *args, **kwds):

--- a/ganga/GangaCore/Core/exceptions.py
+++ b/ganga/GangaCore/Core/exceptions.py
@@ -149,7 +149,7 @@ class RepositoryError(GangaException):
             logger.error("Shutting Down Repository_runtime")
             from GangaCore.Runtime import Repository_runtime
             Repository_runtime.shutdown()
-        except:
+        except BaseException:
             logger.error("Unable to disable Internal services, they may have already been disabled!")
 
 

--- a/ganga/GangaCore/Core/exceptions.py
+++ b/ganga/GangaCore/Core/exceptions.py
@@ -203,5 +203,5 @@ class GangaTypeError(GangaException, TypeError):
         self.kwds = kwds
 
 
-class TerminationSignalException(GangaException):
+class TerminationSignalException(Exception):
     pass

--- a/ganga/GangaCore/Core/exceptions.py
+++ b/ganga/GangaCore/Core/exceptions.py
@@ -201,3 +201,7 @@ class GangaTypeError(GangaException, TypeError):
         super(GangaException, self).__init__(args)
         TypeError.__init__(self, *args)
         self.kwds = kwds
+
+
+class TerminationSignalException(GangaException):
+    pass

--- a/ganga/GangaDirac/Lib/Backends/DiracBase.py
+++ b/ganga/GangaDirac/Lib/Backends/DiracBase.py
@@ -1298,7 +1298,6 @@ class DiracBase(IBackend):
         theseJobs = []
 
         if not monitoring_component.enabled:
-            print('NOPE')
             return
         for sj in allJobs:
             if stripProxy(sj).status in ['completing', 'failed', 'killed', 'removed']:
@@ -1317,9 +1316,7 @@ class DiracBase(IBackend):
         jobs = [stripProxy(j) for j in theseJobs]
         manager = AsyncDiracManager()
         for job in jobs:
-            print(f'Attempting to add from DIRAC task for {finished_job}')
             if not monitoring_component.enabled:
-                print('NOPERZ')
                 break
             monitoring_component.loop.create_task(manager.execute(
                 finished_job,

--- a/ganga/GangaDirac/Lib/Backends/DiracBase.py
+++ b/ganga/GangaDirac/Lib/Backends/DiracBase.py
@@ -1058,6 +1058,11 @@ class DiracBase(IBackend):
         # malformed job output?
 
     @staticmethod
+    def tear_down_monitoring():
+        dm = AsyncDiracManager()
+        dm.kill_dirac_processes()
+
+    @staticmethod
     @require_disk_space
     async def _internal_job_finalisation(job, updated_dirac_status):
         """
@@ -1293,6 +1298,7 @@ class DiracBase(IBackend):
         theseJobs = []
 
         if not monitoring_component.enabled:
+            print('NOPE')
             return
         for sj in allJobs:
             if stripProxy(sj).status in ['completing', 'failed', 'killed', 'removed']:
@@ -1311,6 +1317,10 @@ class DiracBase(IBackend):
         jobs = [stripProxy(j) for j in theseJobs]
         manager = AsyncDiracManager()
         for job in jobs:
+            print(f'Attempting to add from DIRAC task for {finished_job}')
+            if not monitoring_component.enabled:
+                print('NOPERZ')
+                break
             monitoring_component.loop.create_task(manager.execute(
                 finished_job,
                 args_dict={

--- a/ganga/GangaDirac/Lib/Server/DiracExecutorProcess.py
+++ b/ganga/GangaDirac/Lib/Server/DiracExecutorProcess.py
@@ -2,12 +2,12 @@ import functools
 import os
 from concurrent.futures import ThreadPoolExecutor
 from multiprocessing import Lock, Process
+from GangaCore.Core.exceptions import TerminationSignalException
 
 
 class DiracProcess(Process):
     def __init__(self, task_queue, task_result_dict, env=None):
         super(Process, self).__init__()
-        self.daemon = True
         self.task_queue = task_queue
         self.task_result_dict = task_result_dict
         self.env = env
@@ -15,6 +15,10 @@ class DiracProcess(Process):
     def initialize_dirac_api(self):
         from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script  # type: ignore
         Script.parseCommandLine(ignoreErrors=False)
+
+    def handle_termination(self):
+        self.executor.shutdown()
+        exit(0)
 
     def run(self):
         def send_result(event, id, lock, future):
@@ -27,12 +31,15 @@ class DiracProcess(Process):
                 os.environ[var_name] = value
 
         self.initialize_dirac_api()
-        executor = ThreadPoolExecutor()
+        self.executor = ThreadPoolExecutor()
         lock = Lock()
         while True:
-            is_done, task_id, cmd, args_dict = self.task_queue.get()
-            future = executor.submit(self.run_dirac_command, cmd, args_dict)
-            future.add_done_callback(functools.partial(send_result, is_done, task_id, lock))
+            try:
+                is_done, task_id, cmd, args_dict = self.task_queue.get()
+                future = self.executor.submit(self.run_dirac_command, cmd, args_dict)
+                future.add_done_callback(functools.partial(send_result, is_done, task_id, lock))
+            except TerminationSignalException:
+                self.handle_termination()
 
     def run_dirac_command(self, cmd, args_dict):
         from DIRAC.Interfaces.API.Dirac import Dirac  # type: ignore

--- a/ganga/GangaDirac/Lib/Server/DiracExecutorProcess.py
+++ b/ganga/GangaDirac/Lib/Server/DiracExecutorProcess.py
@@ -9,6 +9,7 @@ from GangaCore.Core.exceptions import TerminationSignalException
 class DiracProcess(Process):
     def __init__(self, task_queue, task_result_dict, env=None):
         super(Process, self).__init__()
+        self.daemon = True
         self.task_queue = task_queue
         self.task_result_dict = task_result_dict
         self.env = env

--- a/ganga/GangaDirac/Lib/Server/DiracProcessManager.py
+++ b/ganga/GangaDirac/Lib/Server/DiracProcessManager.py
@@ -8,7 +8,6 @@ from GangaCore.GPIDev.Credentials import credential_store
 from GangaCore.Utility.logging import getLogger
 
 from .DiracExecutorProcess import DiracProcess
-from GangaCore.Utility.logging import getLogger
 
 
 logger = getLogger()
@@ -61,7 +60,7 @@ class AsyncDiracManager(metaclass=Singleton):
             env=dirac_env)
         dirac_process.start()
 
-        logger.debug(f"DIRAC process started with PID {dirac_process.pid}")
+        print(f"DIRAC process started with PID {dirac_process.pid}")
         self.active_processes[env_hash] = dirac_process
 
     def parse_command_result(self, result, cmd, return_raw_dict=False):
@@ -93,25 +92,26 @@ class AsyncDiracManager(metaclass=Singleton):
         if not self.is_dirac_process_active(env_hash):
             self.start_dirac_process(dirac_env)
 
-        try:
-            task_id = uuid.uuid4()
-            task_done = self.manager.AioEvent()
-            await self.task_queues[env_hash].coro_put((task_done, task_id, cmd, args_dict))
+        # try:
+        task_id = uuid.uuid4()
+        task_done = self.manager.AioEvent()
+        await self.task_queues[env_hash].coro_put((task_done, task_id, cmd, args_dict))
 
-            await task_done.coro_wait()
-            dirac_result = self.task_result_dicts[env_hash].get(task_id)
-            del self.task_result_dicts[env_hash][task_id]
+        await task_done.coro_wait()
+        dirac_result = self.task_result_dicts[env_hash].get(task_id)
+        del self.task_result_dicts[env_hash][task_id]
 
-            returnable = self.parse_command_result(dirac_result, str(cmd), return_raw_dict)
-            logger.debug(f'Executed DIRAC command {cmd} with result {returnable}')
-            return returnable
-        except RuntimeError:
-            logger.error('Attempted to add asyncio task after Ganga shutdown. Returning...')
-            return {'OK': False, 'Message': 'The event loop has shut down'}
-            
+        returnable = self.parse_command_result(dirac_result, str(cmd), return_raw_dict)
+        print(f'Executed DIRAC command {cmd} with result {returnable}')
+        return returnable
+        # except RuntimeError:
+        #     print('Attempted to add asyncio task after Ganga shutdown. Returning...')
+        #     self.kill_dirac_processes()
+        #     return {'OK': False, 'Message': 'The event loop has shut down'}
+
     def kill_dirac_processes(self):
         for process in self.active_processes.values():
             process.terminate()
             process.join()
-            logger.debug(f"Terminated DIRAC executor process with pid {process.pid}")
+            print(f"Terminated DIRAC executor process with pid {process.pid}")
         self.active_processes = None

--- a/ganga/GangaDirac/Lib/Server/DiracProcessManager.py
+++ b/ganga/GangaDirac/Lib/Server/DiracProcessManager.py
@@ -60,7 +60,7 @@ class AsyncDiracManager(metaclass=Singleton):
             env=dirac_env)
         dirac_process.start()
 
-        print(f"DIRAC process started with PID {dirac_process.pid}")
+        logger.debug(f"DIRAC process started with PID {dirac_process.pid}")
         self.active_processes[env_hash] = dirac_process
 
     def parse_command_result(self, result, cmd, return_raw_dict=False):
@@ -92,26 +92,26 @@ class AsyncDiracManager(metaclass=Singleton):
         if not self.is_dirac_process_active(env_hash):
             self.start_dirac_process(dirac_env)
 
-        # try:
-        task_id = uuid.uuid4()
-        task_done = self.manager.AioEvent()
-        await self.task_queues[env_hash].coro_put((task_done, task_id, cmd, args_dict))
+        try:
+            task_id = uuid.uuid4()
+            task_done = self.manager.AioEvent()
+            await self.task_queues[env_hash].coro_put((task_done, task_id, cmd, args_dict))
 
-        await task_done.coro_wait()
-        dirac_result = self.task_result_dicts[env_hash].get(task_id)
-        del self.task_result_dicts[env_hash][task_id]
+            await task_done.coro_wait()
+            dirac_result = self.task_result_dicts[env_hash].get(task_id)
+            del self.task_result_dicts[env_hash][task_id]
 
-        returnable = self.parse_command_result(dirac_result, str(cmd), return_raw_dict)
-        print(f'Executed DIRAC command {cmd} with result {returnable}')
-        return returnable
-        # except RuntimeError:
-        #     print('Attempted to add asyncio task after Ganga shutdown. Returning...')
-        #     self.kill_dirac_processes()
-        #     return {'OK': False, 'Message': 'The event loop has shut down'}
+            returnable = self.parse_command_result(dirac_result, str(cmd), return_raw_dict)
+            logger.debug(f'Executed DIRAC command {cmd} with result {returnable}')
+            return returnable
+        except RuntimeError:
+            logger.warn('Attempted to add asyncio task after Ganga shutdown. Returning...')
+            self.kill_dirac_processes()
+            return {'OK': False, 'Message': 'The event loop has shut down'}
 
     def kill_dirac_processes(self):
         for process in self.active_processes.values():
             process.terminate()
             process.join()
-            print(f"Terminated DIRAC executor process with pid {process.pid}")
+            logger.debug(f"Terminated DIRAC executor process with pid {process.pid}")
         self.active_processes = None


### PR DESCRIPTION
This PR adds the functionality to terminate a DIRAC process when there are no more jobs to monitor.

*Please note and review the following:*
I added a global signal handler that throws a `TerminationSignalException` whenever a SIGTERM is received. Since this is a change that can be used within the whole core codebase let me know if I should change anything. Specifically I am unsure about where in the code I should instantiate the signal handler (right now I am doing it in the bootstrap method) and whether the `TerminationSignalException` should be registered as a `GangaException` or a regular one.