### PR TITLE
Shut down monitoring thread explicitly

### DIFF
--- a/ganga/GangaCore/Core/MonitoringComponent/MonitoringService.py
+++ b/ganga/GangaCore/Core/MonitoringComponent/MonitoringService.py
@@ -173,3 +173,4 @@ class AsyncMonitoringService(GangaThread):
         self.thread_executor.shutdown()
         self._cleanup_scheduled_tasks()
         self.loop.stop()
+        exit(0)


### PR DESCRIPTION
This PR adds an explicit `exit(0)` to the monitoring thread's `stop` method so that it doesn't hang when requested to close and lead to runtime errors.