### PR TITLE
Handle monitoring service autostart

### DIFF
--- a/ganga/GangaCore/Core/MonitoringComponent/MonitoringService.py
+++ b/ganga/GangaCore/Core/MonitoringComponent/MonitoringService.py
@@ -37,9 +37,7 @@ class AsyncMonitoringService(GangaThread):
 
     def run(self):
         asyncio.set_event_loop(self.loop)
-        self.enabled = True
         self.thread_executor = ThreadPoolExecutor(max_workers=THREAD_POOL_SIZE)
-        self._check_active_backends()
         self.loop.run_forever()
 
     def _check_active_backends(self, job_slice=None):

--- a/ganga/GangaCore/Core/__init__.py
+++ b/ganga/GangaCore/Core/__init__.py
@@ -46,15 +46,15 @@ def bootstrap(reg_slice, interactive_session, my_interface=None):
     config.overrideDefaultValue('autostart', interactive_session)
 
     # has the user changed monitoring autostart from the default? if so, warn them
-    # if config['autostart'] != interactive_session:
-    #     if config['autostart']:
-    #         getLogger().warning('Monitoring loop enabled (the default setting for a batch session is disabled)')
-    #     else:
-    #         getLogger().warning('Monitoring loop disabled (the default setting for an interactive session is enabled)')
+    if config['autostart'] != interactive_session:
+        if config['autostart']:
+            getLogger().warning('Monitoring loop enabled (the default setting for a batch session is disabled)')
+        else:
+            getLogger().warning('Monitoring loop disabled (the default setting for an interactive session is enabled)')
 
     # Enable job monitoring if requested
-    # if config['autostart']:
-    #     monitoring_component.enableMonitoring()
+    if config['autostart']:
+        monitoring_component.enable()
 
     # export the runMonitoring function to the public interface
     if not my_interface:


### PR DESCRIPTION
This PR enables the previous service's autostart functionality. Meaning that the thread starts running but not enabled, and the `enable`method is automatically called only when running in script mode or when `autostart` is enabled in the config.