### PR TITLE
Change to lhcb-proxy-info

### DIFF
--- a/ganga/GangaLHCb/__init__.py
+++ b/ganga/GangaLHCb/__init__.py
@@ -138,7 +138,7 @@ def postBootstrapHook():
     configDirac.setSessionValue('noInputDataBannedSites', [])
     configDirac.setSessionValue('RequireDefaultSE', False)
     configDirac.setSessionValue('proxyInitCmd', 'lhcb-proxy-init')
-    configDirac.setSessionValue('proxyInfoCmd', 'dirac-proxy-info')
+    configDirac.setSessionValue('proxyInfoCmd', 'lhcb-proxy-info')
 
     configOutput.setSessionValue('FailJobIfNoOutputMatched', 'False')
 


### PR DESCRIPTION
Not sure there was a reason to not be using it. It is better as it is part of the standard LHCb environment so you don't need to execute it inside the Dirac one.