### PR TITLE
[Draft] Allow full_print to output in json

### DIFF
--- a/ganga/GangaCore/GPIDev/Base/Objects.py
+++ b/ganga/GangaCore/GPIDev/Base/Objects.py
@@ -29,7 +29,7 @@ from GangaCore.Utility.Profiling import cpu_profiler, mem_profiler, call_counter
 
 
 def _getName(obj):
-    """ Return the name of an object based on what we prioritise 
+    """ Return the name of an object based on what we prioritise
     Name is defined as the first in the list of:
     obj._name, obj.__name__, obj.__class__.__name__ or str(obj)
     Args:
@@ -212,10 +212,20 @@ class Node(object, metaclass=abc.ABCMeta):
         This method will print a full tree which contains a full description of the class which of interest
         Args:
             f (stream): file-like output stream
-            sel (str): Selection to display 
+            sel (str): Selection to display
         """
         from GangaCore.GPIDev.Base.VPrinter import VPrinter
         self.accept(VPrinter(f, sel))
+
+    def printTreeJSON(self, f=None, sel=''):
+        """
+        This method will print a full tree which contains a full description of the class which of interest
+        Args:
+            f (stream): file-like output stream
+            sel (str): Selection to display
+        """
+        from GangaCore.GPIDev.Base.VPrinterJSON import VPrinterJSON
+        self.accept(VPrinterJSON(f, sel))
 
     def printSummaryTree(self, level=0, verbosity_level=0, whitespace_marker='', out=None, selection='', interactive=False):
         """If this method is overridden, the following should be noted:

--- a/ganga/GangaCore/GPIDev/Base/VPrinterJSON.py
+++ b/ganga/GangaCore/GPIDev/Base/VPrinterJSON.py
@@ -60,6 +60,9 @@ def full_print_json(obj, out=None, interactive=False):
 
     _obj = stripProxy(obj)
 
+    # wrap everything in {"output" : ... }
+    print("{\"output\" : ", file=out)
+
     if isType(_obj, GangaList):
         obj_len = len(_obj)
         if obj_len == 0:
@@ -80,15 +83,14 @@ def full_print_json(obj, out=None, interactive=False):
             outString += ", ".join(outStringList)
             outString += "]"
             print(outString, end=" ", file=out)
-        return
-
-    if isProxy(obj) and isinstance(_obj, GangaObject):
+    elif isProxy(obj) and isinstance(_obj, GangaObject):
         sio = StringIO()
         runProxyMethod(obj, "printTreeJSON", sio, interactive)
         print(sio.getvalue(), end=" ", file=out)
     else:
         print(wrapStringInQuotes(str(_obj)), end=" ", file=out)
 
+    print("}", file=out)
 
 class VPrinterJSON(object):
     # Arguments:

--- a/ganga/GangaCore/GPIDev/Base/VPrinterJSON.py
+++ b/ganga/GangaCore/GPIDev/Base/VPrinterJSON.py
@@ -133,7 +133,7 @@ class VPrinterJSON(object):
             print(
                 '{ "type" : ',
                 wrapStringInQuotes(node._schema.name),
-                ',\n"attributes:" : {',
+                ',\n"attributes" : {',
                 file=self.out,
             )
         else:

--- a/ganga/GangaCore/GPIDev/Base/VPrinterJSON.py
+++ b/ganga/GangaCore/GPIDev/Base/VPrinterJSON.py
@@ -1,0 +1,252 @@
+##########################################################################
+# Ganga Project. http://cern.ch/ganga
+#
+# $Id: VPrinterJSON.py,v 1.1 2008-07-17 16:40:52 moscicki Exp $
+##########################################################################
+from GangaCore.GPIDev.Base.Proxy import isProxy, isType, runProxyMethod, stripProxy
+from GangaCore.GPIDev.Base.Objects import GangaObject
+from io import StringIO
+
+from inspect import isclass
+
+from GangaCore.Utility.logging import getLogger
+import json
+
+logger = getLogger()
+
+
+def wrapStringInQuotes(s: str):
+    return '"' + s + '"'
+
+
+def quoteValue(value, interactive=False) -> str:
+    """A quoting function. Used to get consistent formatting"""
+    if isType(value, str):
+        # If it's a string then use `repr` for the quoting
+        if interactive is True:
+            return str(value)
+        else:
+            return json.dumps(repr(value))
+    if hasattr(value, "items"):
+        # If it's a mapping like a dict then quote each key and value
+        quoted_list = [
+            "%s:%s" % (quoteValue(k, interactive), quoteValue(v, interactive))
+            for k, v in value.items()
+        ]
+        string_of_list = "{" + ", ".join(quoted_list) + "}"
+        return string_of_list
+    try:
+        # If it's an iterable like a list or a GangaList then quote each element
+        quoted_list = [quoteValue(val, interactive) for val in value]
+        string_of_list = "[" + ", ".join(quoted_list) + "]"
+        return string_of_list
+    except TypeError:
+        # If it's not a string or iterable then just return it plain
+        return json.dumps(value, default=str)
+
+
+def indent(level):
+    return " " * int((level) * 2)
+
+
+def full_print_json(obj, out=None, interactive=False):
+    """Print the full contents of a GPI object without abbreviation."""
+    import sys
+
+    if out is None:
+        out = sys.stdout
+
+    from GangaCore.GPIDev.Lib.GangaList.GangaList import GangaList
+
+    _obj = stripProxy(obj)
+
+    if isType(_obj, GangaList):
+        obj_len = len(_obj)
+        if obj_len == 0:
+            print("[]", end=" ", file=out)
+        else:
+            outString = "["
+            outStringList = []
+            for x in _obj:
+                if isType(x, GangaObject):
+                    sio = StringIO()
+                    stripProxy(x).printTreeJSON(sio, interactive)
+                    result = sio.getvalue()
+                    # remove trailing whitespace and newlines
+                    outStringList.append(result.rstrip())
+                else:
+                    # remove trailing whitespace and newlines
+                    outStringList.append(str(x).rstrip())
+            outString += ", ".join(outStringList)
+            outString += "]"
+            print(outString, end=" ", file=out)
+        return
+
+    if isProxy(obj) and isinstance(_obj, GangaObject):
+        sio = StringIO()
+        runProxyMethod(obj, "printTreeJSON", sio, interactive)
+        print(sio.getvalue(), end=" ", file=out)
+    else:
+        print(wrapStringInQuotes(str(_obj)), end=" ", file=out)
+
+
+class VPrinterJSON(object):
+    # Arguments:
+    # out: file-like output stream where to print, default sys.stdout
+    # selection: string specifying properties to print (default ''):
+    #            'all'            - print all properties
+    #            'copyable'       - print only copyable properties
+    #            any other string - print unhidden properties
+
+    __slots__ = ("level", "nocomma", "selection", "out", "empty_body", "_interactive")
+
+    def __init__(self, out=None, selection="", interactive=False):
+        self.level = 0
+        self.nocomma = 1
+        self.selection = selection
+        if out:
+            self.out = out
+        else:
+            import sys
+
+            self.out = sys.stdout
+
+        # detect whether the body is empty to handle the comma correctly in
+        # this case too
+        self.empty_body = 0
+        self._interactive = interactive
+
+    def indent(self):
+        return indent(self.level)
+
+    def comma(self, force=0):
+        if not self.nocomma or force:
+            print(",", file=self.out)
+
+        self.nocomma = 0
+
+    def nodeBegin(self, node):
+        if node._schema is not None:
+            # print(self.indent(), node._schema.name, '(', file=self.out)
+            print(
+                '{ "type" : ',
+                wrapStringInQuotes(node._schema.name),
+                ',\n"attributes:" : {',
+                file=self.out,
+            )
+        else:
+            print("{", file=self.out)
+        self.level += 1
+        self.nocomma = 1
+        self.empty_body = 1
+
+    def nodeEnd(self, node):
+        self.level -= 1
+
+        if self.empty_body:
+            print(self.indent(), "}\n}", end="", file=self.out, sep="")
+            self.nocomma = 0
+        else:
+            if self.nocomma:
+                print("}\n}", end="", file=self.out)
+            else:
+                print("\n", self.indent(), "}\n}", end="", file=self.out, sep="")
+
+        if self.level == 0:
+            print("\n", file=self.out)
+
+    def showAttribute(self, node, name):
+        visible = False
+        if self.selection == "all":
+            visible = True
+        elif self.selection == "copyable":
+            if node._schema.getItem(name)["copyable"]:
+                if not node._schema.getItem(name)["hidden"]:
+                    visible = True
+        elif self.selection == "preparable":
+            # the following relies on the assumption that we only ever call printTreeJSON on
+            # a preparable application.
+            if node._schema.getItem(name)["preparable"]:
+                if not node._schema.getItem(name)["hidden"]:
+                    visible = True
+        else:
+            if not node._schema.getItem(name)["hidden"]:
+                visible = True
+        return visible
+
+    def simpleAttribute(self, node, name, value, sequence):
+        if self.showAttribute(node, name):
+            self.empty_body = 0
+            self.comma()
+            # DISABLED
+            # print '*'*20,name
+            # if sequence:
+            #    print 'transformation:',repr(value)
+            #    value = value.toString()
+            #    print 'into',repr(value)
+            # else:
+            #    print 'no transformation'
+            if isclass(value):
+                if self._interactive is True:
+                    print(
+                        self.indent(),
+                        wrapStringInQuotes(name),
+                        ":",
+                        str(value),
+                        end="",
+                        file=self.out,
+                    )
+                else:
+                    print(
+                        self.indent(),
+                        wrapStringInQuotes(name),
+                        ":",
+                        repr(value),
+                        end="",
+                        file=self.out,
+                    )
+            else:
+                print(
+                    self.indent(),
+                    wrapStringInQuotes(name),
+                    ":",
+                    self.quote(value),
+                    end="",
+                    file=self.out,
+                )
+
+    def sharedAttribute(self, node, name, value, sequence):
+        self.simpleAttribute(node, name, value, sequence)
+
+    def acceptOptional(self, s):
+        if s is None:
+            print("null", end="", file=self.out)
+        else:
+            if isType(stripProxy(s), list):
+                print(s, end="", file=self.out)
+            elif hasattr(s, "accept"):
+                stripProxy(s).accept(self)
+            else:
+                self.quote(s)
+
+    def componentAttribute(self, node, name, subnode, sequence):
+        if self.showAttribute(node, name):
+            self.empty_body = 0
+            self.comma()
+            print(self.indent(), wrapStringInQuotes(name), ":", end="", file=self.out)
+            # self.level+=1
+            if sequence:
+                print("[", end="", file=self.out)
+                self.level += 1
+                for s in subnode:
+                    print(self.indent(), file=self.out)
+                    self.acceptOptional(s)
+                    print(",", end="", file=self.out)
+                self.level -= 1
+                print("]", end="", file=self.out)
+            else:
+                self.acceptOptional(subnode)
+            # self.level-=1
+
+    def quote(self, x):
+        return quoteValue(x, self._interactive)

--- a/ganga/GangaCore/Runtime/bootstrap.py
+++ b/ganga/GangaCore/Runtime/bootstrap.py
@@ -184,6 +184,10 @@ def manualExportToGPI(my_interface=None):
     from GangaCore.GPIDev.Base.VPrinter import full_print
     exportToInterface(my_interface, 'full_print', full_print, 'Functions')
 
+    # export full_print_json
+    from GangaCore.GPIDev.Base.VPrinterJSON import full_print_json
+    exportToInterface(my_interface, 'full_print_json', full_print_json, 'Functions')
+
     import GangaCore.GPIDev.Lib.Config
     exportToInterface(my_interface, 'config', GangaCore.GPIDev.Lib.Config.config,
                       'Objects', 'access to Ganga configuration')


### PR DESCRIPTION
### Proposal for a new function
#### What is `full_print_json`?
Instead of just outputting a description of the object like `full_print` or individual properties in a human-readable way, we output a JSON so that it can read by external tools.

#### Motivation
Since in future we will be enabling Ganga to be used in conjunction with other workflow management tools, we might need to share job info to and from Ganga. Instead of writing wrapper scripts that parse the output of Ganga, we can allow Ganga to export information in JSON which can then be consumed by any tool.

#### Advantages
- Straightforward to implement and does not touch core Ganga classes. So maintenance should be a non-issue.
- There will be no need to import Ganga classes in a script to run Ganga programmatically so that we can interact with the job, i.e. by `python script.py`. All of the details of the job is JSON exportable.
- There will be no need to write wrapper functions to parse the output of Ganga repl (since that is the only way/API to interact with jobs)

#### Disadvantages
- *Ganga already has internal APIs that we can use. So this function will make no sense once those are exposed.*
- Current implementation outputs every attribute for now. So it will be slow to evaluate for complex objects.
- Potentially useless function since the usefulness is only limited to interfacing with Ganga by other tools which for now is rarely used.
- Interactive mode is still present.
- Since this could become the standard for other tools to interface with Ganga, we might need to develop a JSON Schema so that random scripts do not break on new releases.

#### Current Approach to implement `full_print_json`(WIP)
Modify existing `full_print` command to output JSON. For this to be more machine-friendly instead of humans, we might export more information and we might drop indentation altogether. That way it can be fast to process and more useful for external tools.

#### Current usage
In my evaluation task, instead of getting the output in an ad-hoc manner, I am using `full_print_json` to get the information (JobID, JobStatus, OutputDirectory, etc) by calling `ganga script.py` where `script.py` is
```python
j = Job()
j.submit()
full_print_json(j)
```

I am currently trying out newer ways to interact with Ganga. This is one of the approaches that seems to be have some potential, so I am creating a draft pull request.