### PR TITLE
Refactor out dependency on execute utility

### DIFF
--- a/ganga/GangaCore/Core/GangaThread/WorkerThreads/ThreadPoolQueueMonitor.py
+++ b/ganga/GangaCore/Core/GangaThread/WorkerThreads/ThreadPoolQueueMonitor.py
@@ -1,4 +1,3 @@
-
 import collections
 from GangaCore.Core.GangaThread.WorkerThreads.WorkerThreadPool import WorkerThreadPool
 from GangaCore.Utility.Config import getConfig
@@ -59,7 +58,7 @@ class ThreadPoolQueueMonitor(object):
     def _display_element(self, item):
         if hasattr(item, 'name') and item.name is not None:
             return item.name
-        elif type(item.command_input[0]) != str:
+        elif not isinstance(item.command_input[0], str):
             return getName(item.command_input[0])
         else:
             return item.command_input[0]
@@ -122,7 +121,7 @@ class ThreadPoolQueueMonitor(object):
         _user_queue = [i for i in self._user_threadpool.get_queue()]
         queue_size = len(_user_queue)
         _actually_purge = False
-        if force == True:
+        if force:
             _actually_purge = True
         if queue_size > 0 and not force:
             keyin = None
@@ -154,7 +153,7 @@ class ThreadPoolQueueMonitor(object):
 
         queue_size = len(_monitor_queue)
         _actually_purge = False
-        if force == True:
+        if force:
             _actually_purge = True
         if queue_size > 0 and not force:
             keyin = None
@@ -299,7 +298,7 @@ class ThreadPoolQueueMonitor(object):
                    fallback_kwargs = kwargs for the fallback_func are given here
                                      as a dict.
         """
-        if type(command) != type(''):
+        if not isinstance(command, type('')):
             logger.error("Input command must be of type 'string'")
             return
 

--- a/ganga/GangaCore/Core/GangaThread/WorkerThreads/ThreadPoolQueueMonitor.py
+++ b/ganga/GangaCore/Core/GangaThread/WorkerThreads/ThreadPoolQueueMonitor.py
@@ -190,13 +190,13 @@ class ThreadPoolQueueMonitor(object):
         Note:
         ----
 
-        Unlike with the queues.addProcess (where the overhead in starting up the processes 
+        Unlike with the queues.addProcess (where the overhead in starting up the processes
         take a few seconds) code executes immediately when reported using monitoring
         command queues
 
         args:
         ----
-                   worker_code = Any python callable object to run on thread 
+                   worker_code = Any python callable object to run on thread
                    args        = Any args for the callable object given here
                                  as a tuple
                    kwargs      = Any kwargs for the callable object given here
@@ -240,7 +240,6 @@ class ThreadPoolQueueMonitor(object):
                    env=None,
                    cwd=None,
                    shell=False,
-                   eval_includes=None,
                    update_env=False,
                    priority=5,
                    callback_func=None,
@@ -266,16 +265,12 @@ class ThreadPoolQueueMonitor(object):
 
         args:
         ----
-                   command         = The command to run as a string 
+                   command         = The command to run as a string
                    timeout         = timeout for the command as int or None
                    env             = environment to run command in as dict or None
                    cwd             = working dir to run command in as string
                    shell           = True/False whether to interpret the
                                      command as a python or shell command
-                   eval_includes   = This is a string that will be exec'ed before
-                                     trying to eval the stdout. This allows for the
-                                     the user to import certain libs before attempting
-                                     to parse the output.
                    update_env      = Boolean value determining if the value of env should
                                      be updated with the environment after running the
                                      command.
@@ -283,15 +278,15 @@ class ThreadPoolQueueMonitor(object):
                                      queue with lower number = higher priority.
                                      This then should be an int normally 0-9
                    callback_func   = Any python callable object. This is called
-                                     once the command has finished running (or 
+                                     once the command has finished running (or
                                      timed out) and must take at least one arg.
-                                     This first arg will be the stdout of the 
+                                     This first arg will be the stdout of the
                                      executed command. This arg will be the
-                                     result of unpickling stdout, falling back to 
+                                     result of unpickling stdout, falling back to
                                      eval(stdout) such that '{}' will
                                      become a dict. Fall back to str representation
                                      if the eval fails.
-                   callback_args   = Any additional args to the callback_func 
+                   callback_args   = Any additional args to the callback_func
                                      are specified here as a tuple
                    callback_kwargs = kwargs for the callback_func are given here
                                      as a dict.
@@ -299,7 +294,7 @@ class ThreadPoolQueueMonitor(object):
                                      if the command execution throws an exception.
                                      The function must take at least one arg that
                                      will be the exception that was thrown.
-                   fallback_args   = Any additional args to the fallback_func 
+                   fallback_args   = Any additional args to the fallback_func
                                      are specified here as a tuple
                    fallback_kwargs = kwargs for the fallback_func are given here
                                      as a dict.
@@ -318,7 +313,6 @@ class ThreadPoolQueueMonitor(object):
                                           env=env,
                                           cwd=cwd,
                                           shell=shell,
-                                          eval_includes=eval_includes,
                                           update_env=update_env,
                                           priority=priority,
                                           callback_func=callback_func,

--- a/ganga/GangaCore/Core/GangaThread/WorkerThreads/WorkerThreadPool.py
+++ b/ganga/GangaCore/Core/GangaThread/WorkerThreads/WorkerThreadPool.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 import queue
+import subprocess
 import traceback
 import threading
 import collections
 from GangaCore.Core.exceptions import GangaException, GangaTypeError
 from GangaCore.Core.GangaThread import GangaThread
-from GangaCore.Utility.execute import execute
 from GangaCore.Utility.logging import getLogger
 from GangaCore.Utility.Config import getConfig
 from GangaCore.GPIDev.Base.Proxy import getName
@@ -126,7 +126,7 @@ class WorkerThreadPool(object):
                         these_args = (these_args, )
                     result = item.command_input.function(*these_args, **item.command_input.kwargs)
                 else:
-                    result = execute(*item.command_input)
+                    result = subprocess.check_output([*item.command_input], shell=True, text=True)
             except Exception as e:
                 if issubclass(type(e), GangaException):
                     logger.error("%s" % e)

--- a/ganga/GangaCore/Core/GangaThread/WorkerThreads/WorkerThreadPool.py
+++ b/ganga/GangaCore/Core/GangaThread/WorkerThreads/WorkerThreadPool.py
@@ -14,12 +14,12 @@ from GangaCore.GPIDev.Base.Proxy import getName
 from collections import namedtuple
 
 timeout = getConfig('Queues')['ShutDownTimeout']
-timeout = 0.1 if timeout == None else timeout
+timeout = 0.1 if timeout is None else timeout
 
 logger = getLogger()
 QueueElement = namedtuple('QueueElement', ['priority', 'command_input', 'callback_func', 'fallback_func', 'name'])
 CommandInput = namedtuple('CommandInput', ['command', 'timeout', 'env', 'cwd',
-                          'shell', 'python_setup', 'update_env'])
+                                           'shell', 'python_setup', 'update_env'])
 
 
 class FunctionInput(namedtuple('FunctionInput', ['function', 'args', 'kwargs'])):
@@ -243,7 +243,8 @@ class WorkerThreadPool(object):
 
     def worker_status(self):
         """
-        Returns a informatative tuple containing the threads name, current command it's working on and the timeout for that command.
+        Returns a informatative tuple containing the threads name,
+        current command it's working on and the timeout for that command.
         """
         return [(w.gangaName, w._command, w._timeout) for w in self.__worker_threads]
 
@@ -271,7 +272,7 @@ class WorkerThreadPool(object):
             w.join()
             # FIXME NEED TO CALL AN OPTIONAL CLEANUP FUCNTION HERE IF THREAD IS STOPPED
             # w.unregister()
-            #del w
+            # del w
         self.__worker_threads = []
         return
 

--- a/ganga/GangaCore/Utility/execute.py
+++ b/ganga/GangaCore/Utility/execute.py
@@ -192,18 +192,16 @@ def execute(command,
 
     # Execute the main command of interest
     logger.debug("Executing Command:\n'%s'" % str(command))
-    stdout, stderr = p.communicate(command)
+
+    try:
+        stdout, stderr = p.communicate(command, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        p.terminate()
+        return 'Command timed out!'
 
     # Close the timeout watching thread
     logger.debug("stdout: %s" % stdout)
     logger.debug("stderr: %s" % stderr)
-
-    try:
-        # if this returns, the process completed
-        p.wait(timeout=timeout)
-    except subprocess.TimeoutExpired:
-        p.terminate()
-        return 'Command timed out!'
 
 
     # Finish up and decide what to return

--- a/ganga/GangaCore/Utility/execute.py
+++ b/ganga/GangaCore/Utility/execute.py
@@ -3,7 +3,6 @@ import base64
 import subprocess
 import threading
 import pickle as pickle
-import signal
 from copy import deepcopy
 from GangaCore.Core.exceptions import GangaException
 from GangaCore.Utility.logging import getLogger
@@ -57,7 +56,8 @@ def python_wrapper(command, python_setup='', update_env=False, indent=''):
         python_setup (str): This is some python code to be executed before the python code in question (aka a script header.
         update_env (bool): Contol whether we want to capture the env after running
         indent (str): This allows for an indent to be applied to the script so it can be placed inside other python scripts
-    This returns the file handler objects for the env_update_script, the python wrapper itself and the script which has been generated to be run
+    This returns the file handler objects for the env_update_script, the python wrapper itself
+    and the script which has been generated to be run
     """
     fdread, fdwrite = os.pipe()
     os.set_inheritable(fdwrite, True)
@@ -105,15 +105,14 @@ def __reader(pipes, output_ns, output_var, require_output):
     os.close(pipes[1])
     with os.fdopen(pipes[0], 'rb') as read_file:
         try:
-            # rcurrie this deepcopy hides a strange bug that the wrong dict is sometimes returned from here. Remove at your own risk
+            # rcurrie this deepcopy hides a strange bug that the wrong dict is
+            # sometimes returned from here. Remove at your own risk
             output_ns[output_var] = deepcopy(pickle.load(read_file))
         except UnicodeDecodeError:
             output_ns[output_var] = deepcopy(bytes2string(pickle.load(read_file, encoding="bytes")))
         except Exception as err:
             if require_output:
                 logger.error('Error getting output stream from command: %s', err)
-
-
 
 
 def update_thread(pipes, thread_output, output_key, require_output):
@@ -145,7 +144,8 @@ def execute(command,
     This will execute an external python command when shell=False or an external bash command when shell=True
     Args:
         command (str): This is the command that we want to execute in string format
-        timeout (int): This is the timeout which we want to assign to a function and it will be killed if it runs for longer than n seconds
+        timeout (int): This is the timeout which we want to assign to a function \
+        and it will be killed if it runs for longer than n seconds
         env (dict): This is the environment to use for launching the new command
         cwd (str): This is the cwd the command is to be executed within.
         shell (bool): True for a bash command to be executed, False for a command to be executed within Python
@@ -203,13 +203,11 @@ def execute(command,
     logger.debug("stdout: %s" % stdout)
     logger.debug("stderr: %s" % stderr)
 
-
     # Finish up and decide what to return
     if stderr != '':
         # this is still debug as using the environment from dirac default_env maked a stderr message dump out
         # even though it works
         logger.debug(stderr)
-
 
     # Decode any pickled objects from disk
     if update_env:

--- a/ganga/GangaCore/test/Unit/Utility/TestUtilitiesExecutePrint.py
+++ b/ganga/GangaCore/test/Unit/Utility/TestUtilitiesExecutePrint.py
@@ -62,9 +62,9 @@ def test_execute_output():
 
     # Test printout works with the right includes
     d1 = execute('print(datetime.datetime(2013,12,12))', python_setup='import datetime',
-                 eval_includes='import datetime', shell=False)
+                 shell=False)
     d2 = execute('print(repr(datetime.datetime(2013,12,12)))',
-                 python_setup='import datetime', eval_includes='import datetime', shell=False)
+                 python_setup='import datetime', shell=False)
     assert not hasattr(d1, 'month')
     assert isinstance(d1, str)
     assert hasattr(d2, 'month')

--- a/ganga/GangaCore/test/Unit/Utility/TestUtilitiesExecutePrint.py
+++ b/ganga/GangaCore/test/Unit/Utility/TestUtilitiesExecutePrint.py
@@ -54,18 +54,11 @@ def test_execute_output():
     # Test straight printout doesn't work without includes, stdout as str
     # returned by default
     d1 = execute('import datetime\nprint(datetime.datetime(2013,12,12))', shell=False)
-    d2 = execute('import datetime\nrepr(datetime.datetime(2013,12,12))', shell=False)
     assert not hasattr(d1, 'month')
     assert isinstance(d1, str)
-    assert not hasattr(d2, 'month')
-    assert isinstance(d2, str)
 
     # Test printout works with the right includes
     d1 = execute('print(datetime.datetime(2013,12,12))', python_setup='import datetime',
                  shell=False)
-    d2 = execute('print(repr(datetime.datetime(2013,12,12)))',
-                 python_setup='import datetime', shell=False)
     assert not hasattr(d1, 'month')
     assert isinstance(d1, str)
-    assert hasattr(d2, 'month')
-    assert d2.month == 12

--- a/ganga/GangaDirac/Lib/Backends/DiracUtils.py
+++ b/ganga/GangaDirac/Lib/Backends/DiracUtils.py
@@ -1,13 +1,11 @@
 import time
 import re
 import itertools
-from GangaCore.Core.exceptions import GangaException, BackendError
-#from GangaDirac.BOOT       import dirac_ganga_server
+from GangaCore.Core.exceptions import BackendError
 from GangaDirac.Lib.Utilities.DiracUtilities import execute, GangaDiracError
 from GangaCore.Utility.logging import getLogger
-from GangaCore.GPIDev.Base.Proxy import stripProxy
 logger = getLogger()
-#\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\#
+# \/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\ #
 
 
 def result_ok(result):
@@ -16,7 +14,7 @@ def result_ok(result):
     '''
     if result is None:
         return False
-    elif type(result) is not dict:
+    elif not isinstance(result, dict):
         return False
     else:
         output = result.get('OK', False)
@@ -30,7 +28,8 @@ def get_result(command, exception_message=None, retry_limit=5, credential_requir
         command (str): This is the command we want to get the output from
         exception_message (str): This is the message we want to display if the command fails
         retry_limit (int): This is the number of times to retry the command if it initially fails
-        credential_requirements (ICredentialRequirement): This is the optional credential which is to be used for this DIRAC session
+        credential_requirements (ICredentialRequirement): This is the optional credential \
+        which is to be used for this DIRAC session
     '''
 
     retries = 0
@@ -69,7 +68,7 @@ def get_parametric_datasets(dirac_script_lines):
         # return API_line.find('.setParametricInputData(') >= 0
 
     parametric_line = list(filter(parametric_input_filter, dirac_script_lines))
-    if len(parametric_line) is 0:
+    if len(parametric_line) == 0:
         raise BackendError(
             'Dirac', 'No "setParametricInputData()" lines in dirac API')
     if len(parametric_line) > 1:
@@ -110,7 +109,7 @@ def outputfiles_foreach(job, file_type, func, fargs=(), fkwargs=None,
         output.append(func(f, *fargs, **fkwargs))
     return output
 
-#\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\#
+# \/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\ #
 
 
 def ifilter_chain(selection_pred, *iterables):
@@ -140,7 +139,7 @@ def listFiles(baseDir, minAge=None, credential_requirements=None):
     '''
 
     if minAge:
-        r = re.compile('\d:\d:\d')
+        r = re.compile(r'\d:\d:\d')
         if not r.match(minAge):
             logger.error("Provided min age is not in the right format '%w:%d:H'")
             return

--- a/ganga/GangaDirac/Lib/Backends/DiracUtils.py
+++ b/ganga/GangaDirac/Lib/Backends/DiracUtils.py
@@ -23,13 +23,12 @@ def result_ok(result):
         return output
 
 
-def get_result(command, exception_message=None, eval_includes=None, retry_limit=5, credential_requirements=None):
+def get_result(command, exception_message=None, retry_limit=5, credential_requirements=None):
     '''
     This method returns the object from the result of running the given command against DIRAC.
     Args:
         command (str): This is the command we want to get the output from
         exception_message (str): This is the message we want to display if the command fails
-        eval_includes (str): This is optional extra objects to include when evaluating the output from the command
         retry_limit (int): This is the number of times to retry the command if it initially fails
         credential_requirements (ICredentialRequirement): This is the optional credential which is to be used for this DIRAC session
     '''
@@ -38,7 +37,7 @@ def get_result(command, exception_message=None, eval_includes=None, retry_limit=
     while retries < retry_limit:
 
         try:
-            return execute(command, eval_includes=eval_includes, cred_req=credential_requirements)
+            return execute(command, cred_req=credential_requirements)
         except GangaDiracError as err:
             logger.error(exception_message)
             logger.debug("Sleeping for 5 additional seconds to reduce possible overloading")
@@ -137,7 +136,7 @@ def listFiles(baseDir, minAge=None, credential_requirements=None):
     param baseDir: Top directory to begin search
     type baseDir: string
     param minAge: minimum age of files to be returned
-    type minAge: string, "%w:%d:%H" 
+    type minAge: string, "%w:%d:%H"
     '''
 
     if minAge:
@@ -213,7 +212,7 @@ exportToGPI('getAccessURLs', getAccessURLs, 'Functions')
 def getReplicas(inSet, credential_requirements=None):
     """
     Return a dict of files and their replicas.
-    lfns can be a string, a list or something with 
+    lfns can be a string, a list or something with
     """
     # Start off with some checks
     lfns = []

--- a/ganga/GangaDirac/Lib/Utilities/DiracUtilities.py
+++ b/ganga/GangaDirac/Lib/Utilities/DiracUtilities.py
@@ -200,8 +200,6 @@ def execute(command,
             env=None,
             cwd=None,
             shell=False,
-            python_setup='',
-            eval_includes=None,
             update_env=False,
             return_raw_dict=False,
             cred_req=None,
@@ -218,8 +216,6 @@ def execute(command,
         env (dict): an optional environment to execute the DIRAC code in
         cwd (str): an optional string to a valid path where this code should be executed
         shell (bool): Should this code be executed in a new shell environment
-        python_setup (str): Optional extra code to pass to python when executing
-        eval_includes (???): TODO document me
         update_env (bool): Should this modify the given env object with the env after the command has executed
         return_raw_dict(bool): Should we return the raw dict from the DIRAC interface or parse it here
         cred_req (ICredentialRequirement): What credentials does this call need
@@ -279,8 +275,7 @@ def execute(command,
                 env = getDiracEnv()
             else:
                 env = getDiracEnv(cred_req.dirac_env)
-        if python_setup == '':
-            python_setup = getDiracCommandIncludes()
+        python_setup = getDiracCommandIncludes()
 
         if cred_req is not None:
             env['X509_USER_PROXY'] = credential_store[cred_req].location
@@ -293,7 +288,6 @@ def execute(command,
                                       cwd=cwd_,
                                       shell=shell,
                                       python_setup=python_setup,
-                                      eval_includes=eval_includes,
                                       update_env=update_env)
 
         # If the time

--- a/ganga/GangaGaudi/Lib/Applications/CMTUtils.py
+++ b/ganga/GangaGaudi/Lib/Applications/CMTUtils.py
@@ -133,10 +133,10 @@ def make(self, argument=''):
     config = getConfig('GAUDI')
 
     subprocess.run(f'cmt broadcast {config["make_cmd"]} {argument}',
-                shell=True,
-                check=False,
-                env=self.getenv(False),
-                cwd=self.user_release_area)
+                   shell=True,
+                   check=False,
+                   env=self.getenv(False),
+                   cwd=self.user_release_area)
 
 
 def cmt(self, command):
@@ -145,8 +145,7 @@ def cmt(self, command):
        proper configuration. Do not include the word "cmt" yourself."""
 
     subprocess.run(f'cmt {command}',
-                shell=True,
-                check=False,
-                env=self.getenv(False),
-                cwd=self.user_release_area)
-
+                   shell=True,
+                   check=False,
+                   env=self.getenv(False),
+                   cwd=self.user_release_area)

--- a/ganga/GangaGaudi/Lib/Applications/CMTUtils.py
+++ b/ganga/GangaGaudi/Lib/Applications/CMTUtils.py
@@ -1,4 +1,4 @@
-from GangaCore.Utility.execute import execute
+import subprocess
 import GangaCore.Utility.logging
 import os
 
@@ -132,11 +132,11 @@ def make(self, argument=''):
     from GangaCore.Utility.Config import getConfig
     config = getConfig('GAUDI')
 
-    execute('cmt broadcast %s %s' % (config['make_cmd'], argument),
-            shell=True,
-            timeout=None,
-            env=self.getenv(False),
-            cwd=self.user_release_area)
+    subprocess.run(f'cmt broadcast {config["make_cmd"]} {argument}',
+                shell=True,
+                check=False,
+                env=self.getenv(False),
+                cwd=self.user_release_area)
 
 
 def cmt(self, command):
@@ -144,9 +144,9 @@ def cmt(self, command):
        application. Will execute the command "cmt <command>" after the
        proper configuration. Do not include the word "cmt" yourself."""
 
-    execute('cmt %s' % command,
-            shell=True,
-            timeout=None,
-            env=self.getenv(False),
-            cwd=self.user_release_area)
+    subprocess.run(f'cmt {command}',
+                shell=True,
+                check=False,
+                env=self.getenv(False),
+                cwd=self.user_release_area)
 

--- a/ganga/GangaGaudi/Lib/Applications/GaudiBase.py
+++ b/ganga/GangaGaudi/Lib/Applications/GaudiBase.py
@@ -1,16 +1,14 @@
-#\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\#
+# \/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\ #
 '''Parent for all Gaudi and GaudiPython applications in LHCb.'''
 
 import os
-import tempfile
 import gzip
-import shutil
 import subprocess
 from GangaCore.GPIDev.Base.Proxy import stripProxy
 from GangaCore.GPIDev.Schema import SimpleItem, Schema, Version
 from GangaCore.GPIDev.Adapters.IPrepareApp import IPrepareApp
 import GangaCore.Utility.logging
-from GangaCore.Utility.files import expandfilename, fullpath
+from GangaCore.Utility.files import expandfilename
 from .GaudiUtils import get_user_platform, fillPackedSandbox, get_user_dlls
 from GangaCore.GPIDev.Lib.File import File
 from GangaCore.Core.exceptions import ApplicationConfigurationError
@@ -69,8 +67,7 @@ class GaudiBase(IPrepareApp):
     _schema = Schema(Version(0, 1), schema)
     _hidden = 1
 
-
-    #def __init__(self):
+    # def __init__(self):
     #    super(GaudiBase, self).__init__(None)
 
     def _get_default_version(self, gaudi_app):
@@ -79,7 +76,7 @@ class GaudiBase(IPrepareApp):
     def _get_default_platform(self):
         return get_user_platform(self)
 
-    #def _init(self, set_ura):
+    # def _init(self, set_ura):
     def _init(self):
         if self.appname is None:
             raise ApplicationConfigurationError("appname is None")
@@ -87,7 +84,7 @@ class GaudiBase(IPrepareApp):
             self.version = self._get_default_version(self.appname)
         if (not self.platform):
             self.platform = self._get_default_platform()
-        #if not set_ura:
+        # if not set_ura:
         #    return
         if not self.user_release_area:
             expanded = os.path.expandvars("$User_release_area")
@@ -156,10 +153,10 @@ class GaudiBase(IPrepareApp):
                     return
 
         subprocess.run(f'getpack {options}',
-                shell=True,
-                check=False,
-                env=self.getenv(False),
-                cwd=self.user_release_area)
+                       shell=True,
+                       check=False,
+                       env=self.getenv(False),
+                       cwd=self.user_release_area)
 
     def make(self, argument=''):
         """Build the code in the release area the application object points to."""
@@ -170,10 +167,10 @@ class GaudiBase(IPrepareApp):
         """Eecute a given command at the top level of a requested project."""
 
         subprocess.run(f'{command}',
-                shell=True,
-                check=False,
-                env=self.getenv(False),
-                cwd=self.user_release_area)
+                       shell=True,
+                       check=False,
+                       env=self.getenv(False),
+                       cwd=self.user_release_area)
 
     def cmt(self, command):
         """Execute a cmt command in the cmt user area pointed to by the
@@ -185,10 +182,10 @@ class GaudiBase(IPrepareApp):
             return
 
         subprocess.run(f'cmt {command}',
-                shell=True,
-                check=False,
-                env=self.getenv(False),
-                cwd=self.user_release_area)
+                       shell=True,
+                       check=False,
+                       env=self.getenv(False),
+                       cwd=self.user_release_area)
 
     def unprepare(self, force=False):
         self._unregister()
@@ -258,16 +255,24 @@ class GaudiBase(IPrepareApp):
         # commented out here as inherrited from this class with extended
         # perpare
 
-        fillPackedSandbox(InstallArea, os.path.join(share_dir, 'inputsandbox', '_input_sandbox_%s.tar' % self.is_prepared.name))
+        fillPackedSandbox(
+            InstallArea,
+            os.path.join(
+                share_dir,
+                'inputsandbox',
+                '_input_sandbox_%s.tar' %
+                self.is_prepared.name))
 
     def _register(self, force):
         if (self.is_prepared is not None) and (force is not True):
-            raise Exception('%s application has already been prepared. Use prepare(force=True) to prepare again.' % (getName(self)))
+            raise Exception(
+                '%s application has already been prepared. Use prepare(force=True) to prepare again.' %
+                (getName(self)))
 
         try:
             logger.info('Job %s: Preparing %s application.' % (stripProxy(self).getJobObject().getFQID('.'), getName(self)))
         except AssertionError as err:
-            ## No Job associated with Object!!
+            # No Job associated with Object!!
             logger.info("Preparing %s application." % getName(self))
         self.is_prepared = ShareDir()
 
@@ -277,5 +282,3 @@ class GaudiBase(IPrepareApp):
 
     def configure(self, appmasterconfig):
         raise NotImplementedError
-
-

--- a/ganga/GangaGaudi/Lib/Applications/GaudiBase.py
+++ b/ganga/GangaGaudi/Lib/Applications/GaudiBase.py
@@ -5,6 +5,7 @@ import os
 import tempfile
 import gzip
 import shutil
+import subprocess
 from GangaCore.GPIDev.Base.Proxy import stripProxy
 from GangaCore.GPIDev.Schema import SimpleItem, Schema, Version
 from GangaCore.GPIDev.Adapters.IPrepareApp import IPrepareApp
@@ -14,7 +15,6 @@ from .GaudiUtils import get_user_platform, fillPackedSandbox, get_user_dlls
 from GangaCore.GPIDev.Lib.File import File
 from GangaCore.Core.exceptions import ApplicationConfigurationError
 import GangaCore.Utility.Config
-from GangaCore.Utility.execute import execute
 from GangaCore.GPIDev.Lib.File import ShareDir
 from GangaCore.Utility.Config import getConfig
 from GangaCore.GPIDev.Base.Proxy import getName
@@ -69,7 +69,7 @@ class GaudiBase(IPrepareApp):
     _schema = Schema(Version(0, 1), schema)
     _hidden = 1
 
-    
+
     #def __init__(self):
     #    super(GaudiBase, self).__init__(None)
 
@@ -155,9 +155,9 @@ class GaudiBase(IPrepareApp):
                     logger.debug("%s" % str(err))
                     return
 
-        execute('getpack %s' % options,
+        subprocess.run(f'getpack {options}',
                 shell=True,
-                timeout=None,
+                check=False,
                 env=self.getenv(False),
                 cwd=self.user_release_area)
 
@@ -169,9 +169,9 @@ class GaudiBase(IPrepareApp):
     def projectCMD(self, command):
         """Eecute a given command at the top level of a requested project."""
 
-        execute('%s' % command,
+        subprocess.run(f'{command}',
                 shell=True,
-                timeout=None,
+                check=False,
                 env=self.getenv(False),
                 cwd=self.user_release_area)
 
@@ -184,9 +184,9 @@ class GaudiBase(IPrepareApp):
             logger.warning("Cannot Use this in combination with cmake!")
             return
 
-        execute('cmt %s' % command,
+        subprocess.run(f'cmt {command}',
                 shell=True,
-                timeout=None,
+                check=False,
                 env=self.getenv(False),
                 cwd=self.user_release_area)
 

--- a/ganga/GangaLHCb/Lib/Applications/AppsBase.py
+++ b/ganga/GangaLHCb/Lib/Applications/AppsBase.py
@@ -2,8 +2,6 @@
 # in all cases with the relavent app name (DaVinci, Gauss etc...)
 import os
 import tempfile
-import pprint
-import sys
 from GangaGaudi.Lib.Applications.Gaudi import Gaudi
 from GangaGaudi.Lib.Applications.GaudiUtils import fillPackedSandbox, gzipFile
 from GangaLHCb.Lib.Applications.AppsBaseUtils import available_apps, guess_version, available_packs
@@ -18,7 +16,6 @@ from GangaCore.Utility.files import expandfilename
 from GangaCore.GPIDev.Lib.File.FileBuffer import FileBuffer
 from GangaCore.Core.exceptions import ApplicationConfigurationError
 import GangaCore.Utility.logging
-import subprocess
 import pickle
 logger = GangaCore.Utility.logging.getLogger()
 
@@ -131,7 +128,7 @@ class AppName(Gaudi):
             os.close(temp_fd)
             return temp_filename
 
-        if type(optsfiles) != type([]):
+        if not isinstance(optsfiles, type([])):
             optsfiles = [optsfiles]
 
         # use a dummy file to keep the parser happy
@@ -190,11 +187,11 @@ class AppName(Gaudi):
     def _get_parser(self):
         optsfiles = []
         for fileitem in self.optsfile:
-            if type(fileitem) is str:
+            if isinstance(fileitem, str):
                 optsfiles.append(fileitem)
             else:
                 optsfiles.append(fileitem.name)
-        #optsfiles = [fileitem.name for fileitem in self.optsfile]
+        # optsfiles = [fileitem.name for fileitem in self.optsfile]
         # add on XML summary
 
         extraopts = ''

--- a/ganga/GangaLHCb/Lib/Applications/AppsBase.py
+++ b/ganga/GangaLHCb/Lib/Applications/AppsBase.py
@@ -11,12 +11,10 @@ from GangaLHCb.Lib.Applications.AppsBaseUtils import backend_handlers, activeSum
 from GangaCore.GPIDev.Base.Proxy import GPIProxyObjectFactory
 from GangaCore.GPIDev.Schema import SimpleItem
 from GangaLHCb.Lib.LHCbDataset import LHCbDataset
-from GangaCore.Utility.Shell import Shell
 from GangaLHCb.Lib.Applications.PythonOptionsParser import PythonOptionsParser
 from GangaCore.GPIDev.Adapters.StandardJobConfig import StandardJobConfig
 from GangaCore.Utility.Config import getConfig
 from GangaCore.Utility.files import expandfilename
-from GangaCore.Utility.execute import execute
 from GangaCore.GPIDev.Lib.File.FileBuffer import FileBuffer
 from GangaCore.Core.exceptions import ApplicationConfigurationError
 import GangaCore.Utility.logging
@@ -105,12 +103,12 @@ class AppName(Gaudi):
     def readInputData(self, optsfiles, extraopts=False):
         '''Returns a LHCbDataSet object from a list of options files. The
         optional argument extraopts will decide if the extraopts string inside
-        the application is considered or not. 
+        the application is considered or not.
 
         Usage examples:
         # Create an LHCbDataset object with the data found in the optionsfile
         l=DaVinci(version='v22r0p2').readInputData([\"~/cmtuser/\" \
-        \"DaVinci_v22r0p2/Tutorial/Analysis/options/Bs2JpsiPhi2008.py\"]) 
+        \"DaVinci_v22r0p2/Tutorial/Analysis/options/Bs2JpsiPhi2008.py\"])
         # Get the data from an options file and assign it to the jobs inputdata
         field
         j.inputdata = j.application.readInputData([\"~/cmtuser/\" \
@@ -120,10 +118,10 @@ class AppName(Gaudi):
         # In this case your extraopts need to be fully parseable by gaudirun.py
         # So you must make sure that you have the proper import statements.
         # e.g.
-        from Gaudi.Configuration import * 
+        from Gaudi.Configuration import *
         # If you mix optionsfiles and extraopts, as usual extraopts may
         # overwright your options
-        # 
+        #
         # Use this to create a new job with data from extraopts of an old job
         j=Job(inputdata=jobs[-1].application.readInputData([],True))
         '''
@@ -165,7 +163,7 @@ class AppName(Gaudi):
         return FileFunctions.getpack(self, options)
 
     def make(self, argument=None):
-        """Performs a make on the application. The unix exit code is 
+        """Performs a make on the application. The unix exit code is
            returned. Any arguments given are passed onto as in
            dv.make('clean').
         """
@@ -175,7 +173,7 @@ class AppName(Gaudi):
     def cmt(self, command):
         """Execute a cmt command in the cmt user area pointed to by the
         application. Will execute the command "cmt <command>" after the
-        proper configuration. Do not include the word "cmt" yourself. The 
+        proper configuration. Do not include the word "cmt" yourself. The
         unix exit code is returned."""
         if self.newStyleApp is True:
             logger.error("Cannot use this with cmake enabled!")

--- a/ganga/GangaLHCb/Utility/LHCbDIRACenv.py
+++ b/ganga/GangaLHCb/Utility/LHCbDIRACenv.py
@@ -2,10 +2,10 @@ import json
 import os
 from os.path import join, expanduser
 from optparse import OptionValueError
+import subprocess
 
 from GangaDirac.Lib.Utilities.DiracUtilities import write_env_cache
 import GangaCore.Utility.Config
-from GangaCore.Utility.execute import execute
 from GangaCore.Utility.logging import getLogger
 from GangaCore.Core.exceptions import PluginError
 
@@ -40,7 +40,7 @@ def store_dirac_environment():
         '. /cvmfs/lhcb.cern.ch/lib/LbEnv &>/dev/null && '
         f'lb-dirac {requestedVersion} python -c "import json, os; print(json.dumps(dict(os.environ)))"'
     )
-    env = execute(cmd, env={"PATH": '/usr/bin:/bin', "HOME": os.environ.get("HOME")})
+    env = subprocess.check_output(cmd, shell=True, text=True, env={"PATH": '/usr/bin:/bin', "HOME": os.environ.get("HOME")})
 
     if isinstance(env, str):
         try:

--- a/ganga/GangaLHCb/__init__.py
+++ b/ganga/GangaLHCb/__init__.py
@@ -14,7 +14,6 @@ from GangaCore.Utility.Config.Config import _after_bootstrap
 from GangaCore.Utility.logging import getLogger
 
 from GangaCore.Runtime.GPIexport import exportToGPI
-from GangaCore.Utility.execute import execute
 from GangaCore.GPIDev.Credentials.CredentialStore import credential_store
 from GangaDirac.Lib.Credentials.DiracProxy import DiracProxy
 from GangaLHCb.Utility.LHCbDIRACenv import store_dirac_environment
@@ -25,7 +24,7 @@ logger = getLogger()
 def guessPlatform():
     defaultPlatform = 'x86_64-centos7-gcc8-opt'
     cmd = '. /cvmfs/lhcb.cern.ch/lib/LbEnv &> /dev/null && python3 -c "import json, os; print(json.dumps(dict(os.environ.copy())))"'
-    env = execute(cmd)
+    env = subprocess.check_output(cmd, shell=True, text=True)
     if isinstance(env, str):
         try:
             env = json.loads(env)


### PR DESCRIPTION
Fixes #2105 

Right now, it just removes the use of execute utility except for these cases:
1. `DiracUtilities.execute` uses the `python_setup` feature
2. `DiracUtilities.get_env` uses the `update_env` feature

It also removes the old timer code with a modern equivalent and the `eval_includes` functionality.
