### PR TITLE
Stop Dirac process after creating credential

### DIFF
--- a/ganga/GangaDirac/Lib/Credentials/DiracProxy.py
+++ b/ganga/GangaDirac/Lib/Credentials/DiracProxy.py
@@ -74,7 +74,6 @@ class DiracProxyInfo(VomsProxyInfo):
         # Now stop any running Dirac server processes
         stopDiracProcess()
 
-
     @property
     def shell(self):
         """

--- a/ganga/GangaDirac/Lib/Credentials/DiracProxy.py
+++ b/ganga/GangaDirac/Lib/Credentials/DiracProxy.py
@@ -17,6 +17,7 @@ from GangaCore.GPIDev.Credentials.VomsProxy import VomsProxyInfo
 from GangaCore.Utility.Shell import Shell
 
 from GangaDirac.Lib.Utilities.DiracUtilities import getDiracEnv
+from GangaDirac.BOOT import stopDiracProcess
 
 logger = GangaCore.Utility.logging.getLogger()
 
@@ -69,6 +70,10 @@ class DiracProxyInfo(VomsProxyInfo):
         else:
             logger.debug('Grid proxy {path} created. Valid for {time}'.format(
                 path=self.location, time=self.time_left()))
+
+        # Now stop any running Dirac server processes
+        stopDiracProcess()
+
 
     @property
     def shell(self):


### PR DESCRIPTION
We need to stop the currently running Dirac process if we create a new credential. In this way, the next time a Dirac command is run a new process gets started and connects with the new credential.