### PR TITLE
Check for duplicate in splitter

### DIFF
--- a/ganga/GangaDirac/Lib/Splitters/OfflineGangaDiracSplitter.py
+++ b/ganga/GangaDirac/Lib/Splitters/OfflineGangaDiracSplitter.py
@@ -316,13 +316,6 @@ def lookUpLFNReplicas(inputs, ignoremissing):
     for _lfn in inputs:
         LFNdict[_lfn.lfn] = _lfn
 
-    lfnset = set(allLFNs)
-    del_list = list(allLFNs)
-    for _l in lfnset:
-        del_list.remove(_l)
-    if len(del_list)>0:
-        raise SplitterError("Duplicate LFNs found, check your inputdata! %s" % del_list)
-
     # Request the replicas for all LFN 'LFN_parallel_limit' at a time to not overload the
     # server and give some feedback as this is going on
     global LFN_parallel_limit
@@ -498,6 +491,15 @@ def OfflineGangaDiracSplitter(_inputs, filesPerJob, maxFiles, ignoremissing, ban
         check_count = check_count + len(i)
 
     if check_count != len(inputs) - len(bad_lfns):
+        #First check if there are duplicates causing this problem
+        allLFNs = [_lfn.lfn for _lfn in inputs]
+        lfnset = set(allLFNs)
+        del_list = list(allLFNs)
+        for _l in lfnset:
+            del_list.remove(_l)
+        if len(del_list)>0:
+            raise SplitterError("Duplicate LFNs found, check your inputdata! %s" % del_list)
+
         logger.error("SERIOUS SPLITTING ERROR!!!!!")
         logger.warning("%s != %s - %s" % (check_count, len(inputs), len(bad_lfns)))
         logger.warning("inputs:\n%s" % str(inputs))

--- a/ganga/GangaDirac/Lib/Splitters/OfflineGangaDiracSplitter.py
+++ b/ganga/GangaDirac/Lib/Splitters/OfflineGangaDiracSplitter.py
@@ -316,6 +316,13 @@ def lookUpLFNReplicas(inputs, ignoremissing):
     for _lfn in inputs:
         LFNdict[_lfn.lfn] = _lfn
 
+    lfnset = set(allLFNs)
+    del_list = list(allLFNs)
+    for _l in lfnset:
+        del_list.remove(_l)
+    if len(del_list)>0:
+        raise SplitterError("Duplicate LFNs found, check your inputdata! %s" % del_list)
+
     # Request the replicas for all LFN 'LFN_parallel_limit' at a time to not overload the
     # server and give some feedback as this is going on
     global LFN_parallel_limit


### PR DESCRIPTION
If the splitter finds a problem check for duplicates to print a more helpful error. This check is only done if we find a problem to save time.

Fixes #2212 