### PR TITLE
Fix tests for async monitoring

### DIFF
--- a/.github/workflows/ci_push_testing.yml
+++ b/.github/workflows/ci_push_testing.yml
@@ -195,7 +195,8 @@ jobs:
       - name: Set up Python 3
         run: |
           yum install -y centos-release-scl-rh
-          yum install -y rh-python38-python rh-python38-python-pip
+          yum install -y rh-python38-python rh-python38-python-pip rh-python38-python-devel
+          yum install -y gcc
       - name: Install dependencies
         run: |
           /opt/rh/rh-python38/root/usr/bin/python -m pip install --upgrade pip setuptools wheel
@@ -245,7 +246,8 @@ jobs:
       - name: Set up Python 3
         run: |
           yum install -y centos-release-scl-rh
-          yum install -y rh-python38-python rh-python38-python-pip
+          yum install -y rh-python38-python rh-python38-python-pip rh-python38-python-devel
+          yum install -y gcc
       - name: Install dependencies
         run: |
           /opt/rh/rh-python38/root/usr/bin/python -m pip install --upgrade pip setuptools wheel
@@ -364,6 +366,8 @@ jobs:
         run: |
           /cvmfs/sft.cern.ch/lcg/releases/LCG_100/Python/3.8.6/x86_64-centos7-gcc9-opt/bin/python3 -m venv ~/venv
           . ~/venv/bin/activate
+          yum install -y glibc-devel
+          export CC=/cvmfs/sft.cern.ch/lcg/releases/gcc/7.3.0/x86_64-centos7/bin/gcc
           python3 -m pip install --upgrade pip setuptools wheel
           python3 -m pip install -e .[dev,LHCb,Dirac]
       - name: Install gangarc file

--- a/.github/workflows/ci_push_testing.yml
+++ b/.github/workflows/ci_push_testing.yml
@@ -320,6 +320,8 @@ jobs:
         run: |
           /cvmfs/sft.cern.ch/lcg/releases/LCG_100/Python/3.8.6/x86_64-centos7-gcc9-opt/bin/python3 -m venv ~/venv
           . ~/venv/bin/activate
+          yum install -y glibc-devel
+          export CC=/cvmfs/sft.cern.ch/lcg/releases/gcc/7.3.0/x86_64-centos7/bin/gcc
           python3 -m pip install --upgrade pip setuptools wheel
           python3 -m pip install -e .[dev,LHCb,Dirac]
       - name: Test with pytest

--- a/.github/workflows/ci_push_testing.yml
+++ b/.github/workflows/ci_push_testing.yml
@@ -199,7 +199,7 @@ jobs:
       - name: Install dependencies
         run: |
           /opt/rh/rh-python38/root/usr/bin/python -m pip install --upgrade pip setuptools wheel
-          /opt/rh/rh-python38/root/usr/bin/python -m pip install -e .[dev]
+          /opt/rh/rh-python38/root/usr/bin/python -m pip install -e .[dev,Dirac]
       - name: Install Robot certificate
         env: # Or as an environment variable
           ROBOT_CERT: ${{ secrets.GangaRobot_UserCert }}
@@ -249,7 +249,7 @@ jobs:
       - name: Install dependencies
         run: |
           /opt/rh/rh-python38/root/usr/bin/python -m pip install --upgrade pip setuptools wheel
-          /opt/rh/rh-python38/root/usr/bin/python -m pip install -e .[dev]
+          /opt/rh/rh-python38/root/usr/bin/python -m pip install -e .[dev,Dirac]
       - name: Install Robot certificate
         env: # Or as an environment variable
           ROBOT_CERT: ${{ secrets.GangaRobot_UserCert }}
@@ -319,7 +319,7 @@ jobs:
           /cvmfs/sft.cern.ch/lcg/releases/LCG_100/Python/3.8.6/x86_64-centos7-gcc9-opt/bin/python3 -m venv ~/venv
           . ~/venv/bin/activate
           python3 -m pip install --upgrade pip setuptools wheel
-          python3 -m pip install -e .[dev,LHCb]
+          python3 -m pip install -e .[dev,LHCb,Dirac]
       - name: Test with pytest
         run: |
           . ~/venv/bin/activate
@@ -365,7 +365,7 @@ jobs:
           /cvmfs/sft.cern.ch/lcg/releases/LCG_100/Python/3.8.6/x86_64-centos7-gcc9-opt/bin/python3 -m venv ~/venv
           . ~/venv/bin/activate
           python3 -m pip install --upgrade pip setuptools wheel
-          python3 -m pip install -e .[dev,LHCb]
+          python3 -m pip install -e .[dev,LHCb,Dirac]
       - name: Install gangarc file
         run: |
           echo -e "[Configuration]\nRUNTIME_PATH=GangaDirac:GangaGaudi:GangaLHCb" > ~/.gangarc

--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,8 @@ setup(
             'pytest-pylint',
             'pytest-mock'],
         'profiler': ['memory_profiler'],
-        'LHCb': ['LbDevTools']},
+        'LHCb': ['LbDevTools'],
+        'Dirac': ['UltraDict']},
     classifiers=[
         'License :: OSI Approved :: GNU General Public License v2 (GPLv2)',
         'Programming Language :: Python :: 3.8',


### PR DESCRIPTION
I think we need to merge this first to get the Dirac and LHCb tests to run on the new monitoring branch - they need `UltraDict`