### PR TITLE
Fix typo in number of tasks in Splitters.rst

### DIFF
--- a/doc/UserGuide/Splitters.rst
+++ b/doc/UserGuide/Splitters.rst
@@ -18,7 +18,7 @@ Core which are detailed below. You can see which splitter are available with
 
 Try it out:
 -----------
-Using the prime factorisation example from the Tutorial plugin (:doc:`TutorialPlugin`). We can split up the factorisation of a very large number up into 5 different tasks.
+Using the prime factorisation example from the Tutorial plugin (:doc:`TutorialPlugin`). We can split up the factorisation of a very large number up into 10 different tasks.
 
 .. code-block:: python
 


### PR DESCRIPTION
In the documentation page for [Splitters](https://github.com/ganga-devs/ganga/blob/develop/doc/UserGuide/Splitters.rst), it is mentioned that the prime factorisation job for a very large number is being split into 5 different tasks whereas the code for job declation actually splits it up into 10 subjobs:

We can split up the factorisation of a very large number up into **_5 different tasks_**.
`splitter = PrimeFactorizerSplitter(numsubjobs=10))`

This PR fixes the typo to resolve the discrepancy in the documentation.