### PR TITLE
#2299: Fixed a syntax error that occurs while running a ganga job using Docker

### DIFF
--- a/ganga/GangaCore/Lib/Virtualization/Docker.py
+++ b/ganga/GangaCore/Lib/Virtualization/Docker.py
@@ -78,7 +78,7 @@ if (checkDocker()):
         else:
             print('Requested directory %s is not available and no bind will be made to container' % k)
     options = options + virtualization_options
-    execmd = ['docker', 'run', '--rm', '-v', workdir+":"+"/work_dir"] +
+    execmd = ['docker', 'run', '--rm', '-v', workdir+":"+"/work_dir"] + \
              options + [virtualization_image] + execmd
 else:
     print("Docker not available or no permission to run docker deamon, will attempt UDocker.")
@@ -101,7 +101,7 @@ else:
         else:
             print('Requested directory %s is not available and no bind will be made to container' % k)
     options = options + virtualization_options
-    execmd = [binary, '--quiet', 'run', '--rm', '--volume', workdir+":"+"/work_dir"] +
+    execmd = [binary, '--quiet', 'run', '--rm', '--volume', workdir+":"+"/work_dir"] + \
              options + [virtualization_image] + execmd
 
 """


### PR DESCRIPTION
Adding an escape character to each of the `execmd` lines (81 and 104) in [Docker.py](https://github.com/ganga-devs/ganga/blob/develop/ganga/GangaCore/Lib/Virtualization/Docker.py) seems to solve the issue.

Visible changes on `line 230` in the resulting input file (`/home/[your_linux_username]/gangadir/workspace/[your_linux_username]/LocalXML/[job_number]/input/__jobscript__`) after the job is submitted:

**Before the fix**
```
execmd = ['docker', 'run', '--rm', '-v', workdir+":"+"/work_dir"] +
             options + [virtualization_image] + execmd
```
**After the fix**
`execmd = ['docker', 'run', '--rm', '-v', workdir+":"+"/work_dir"] +              options + [virtualization_image] + execmd`

Similar change in `line 253`.

Passed all unit tests.