### PR TITLE
Fixed erroneous virtualization commands in Virtualization.rst (#2300)

### DIFF
--- a/doc/UserGuide/Virtualization.rst
+++ b/doc/UserGuide/Virtualization.rst
@@ -39,7 +39,7 @@ The container can also be provided as a Docker image from a repository. The defa
 .. code-block:: python
 
     j.virtualization = Singularity("docker://gitlab-registry.cern.ch/lhcb-core/lbdocker/centos7-build:v3")
-    j.virtualization = Docker("docker://fedora:latest")   
+    j.virtualization = Docker(image="fedora:latest")
 
 Another option is to provide a ``GangaFile`` Object which points to a singularity file. In that case the singularity image file will be copied to the worker node. The first example is with an image located on some shared disk. This will be effective for running on a local backend or a batch system with a shared disk system.
 
@@ -78,7 +78,7 @@ the image from the docker hub.
 .. code-block:: python
 
     j=Job()
-    j.virtualization = Docker("image:tag")
+    j.virtualization = Docker(image="image:tag")
 
 Ganga will try to run the container using Docker if Docker is availabe in the worker node and if the user has the 
 permission to run docker containers. If not ganga will download `UDocker <https://github.com/indigo-dc/udocker>`_ which provides the ability to run docker containers in userspace. The runmode in Udocker can be changed as seen in the documentation. Using Singualarity as the run mode is not recommended; use the ``Singularity`` class above instead.


### PR DESCRIPTION
Command that works is of the pattern:
`j.virtualization = Docker(image="image:tag")`