### PR TITLE
fix issues with some malfunctioning docker commands (#2309)

### DIFF
--- a/ganga/GangaCore/Lib/Virtualization/Docker.py
+++ b/ganga/GangaCore/Lib/Virtualization/Docker.py
@@ -36,7 +36,7 @@ class Docker(IVirtualization):
     _schema = IVirtualization._schema.inherit_copy()
     _schema.datadict['mode'] = SimpleItem(defvalue="P1", doc='Mode of container execution')
 
-    def __init__(self, image, mode):
+    def __init__(self, image='', mode='P1'):
         super().__init__(image)
         self.mode = mode
 

--- a/ganga/GangaCore/test/Unit/Virtualization/TestVirtualizationDocker.py
+++ b/ganga/GangaCore/test/Unit/Virtualization/TestVirtualizationDocker.py
@@ -1,0 +1,84 @@
+from GangaCore.testlib.GangaUnitTest import GangaUnitTest
+from GangaCore.Lib.Virtualization import Docker
+from GangaTest.Framework.utils import sleep_until_completed, file_contains
+
+class TestDocker(GangaUnitTest):
+    def test_DockerNoImageArg(self):
+        """
+        The test_DockerNoImageArg function tests that Ganga can 
+        submit a virtualization job using the default Docker image.
+        
+        This test will fail if Ganga cannot find the job in the registry or
+        it cannot intialize the container with the default Docker image.
+        """
+        from GangaCore.GPI import Job
+        j = Job(name="dockertest")
+        self.assertEqual(j.name, 'dockertest', "Something wrong with how\
+Job was imported or initialized.")
+        j.virtualization = Docker()
+        self.assertEqual(j.virtualization.image, '', "Docker image was not\
+passed correctly as an argument.")
+        j.submit()
+        sleep_until_completed(j)
+        j.remove()
+        
+    def test_DockerBareImageArg(self):
+        """
+        The test_DockerBareImageArg function tests that the Docker image
+        is passed correctly as an argument without the 'image=' prefix.
+        
+        This test will fail if Ganga cannot find the job in the registry or
+        it cannot intialize the container with the desired Docker image.
+        """
+        from GangaCore.GPI import Job
+        j = Job(name="dockertest")
+        self.assertEqual(j.name, 'dockertest', "Something wrong with how\
+Job was imported or initialized.")
+        j.virtualization = Docker('fedora:latest')
+        self.assertEqual(j.virtualization.image, 'fedora:latest', "Docker\
+image was not passed correctly as an argument.")
+        j.submit()
+        sleep_until_completed(j)
+        j.remove()
+
+    def test_DockerImageArg(self):
+        """
+        The DockerImageArg function tests that the Docker image
+        is passed correctly as an argument with the 'image=' prefix.
+        
+        This test will fail if Ganga cannot find the job in the registry or
+        it cannot intialize the container with the desired Docker image.
+        """
+        from GangaCore.GPI import Job
+        j = Job(name="dockertest")
+        self.assertEqual(j.name, 'dockertest', "Something wrong with how\
+Job was imported or initialized.")
+        j.virtualization = Docker(image='fedora:latest')
+        self.assertEqual(j.virtualization.image, 'fedora:latest', "Docker\
+image was not passed correctly as an argument.")
+        j.submit()
+        sleep_until_completed(j)
+        j.remove()
+        
+    def test_DockerImageArgWithMode(self):
+        """
+        The DockerImageArgWithMode function tests that the Docker image
+        is passed correctly as an argument with the 'image=' prefix. It
+        also test if mode is explicitly set to 'P1'.
+        
+        This test will fail if Ganga cannot find the job in the registry
+        or it cannot intialize the container with the desired Docker image
+        and mode.
+        """
+        from GangaCore.GPI import Job
+        j = Job(name="dockertest")
+        self.assertEqual(j.name, 'dockertest', "Something wrong with how\
+Job was imported or initialized.")
+        j.virtualization = Docker(image='fedora:latest', mode='P1')
+        self.assertEqual(j.virtualization.image, 'fedora:latest', "Docker\
+image was not passed correctly as an argument.")
+        self.assertEqual(j.virtualization.mode, 'P1', "Mode was not passed\
+correctly as an argument.")
+        j.submit()
+        sleep_until_completed(j)
+        j.remove()

--- a/ganga/GangaCore/test/Unit/Virtualization/TestVirtualizationDocker.py
+++ b/ganga/GangaCore/test/Unit/Virtualization/TestVirtualizationDocker.py
@@ -1,13 +1,14 @@
 from GangaCore.testlib.GangaUnitTest import GangaUnitTest
 from GangaCore.Lib.Virtualization import Docker
-from GangaTest.Framework.utils import sleep_until_completed, file_contains
+from GangaTest.Framework.utils import sleep_until_completed
+
 
 class TestDocker(GangaUnitTest):
     def test_DockerNoImageArg(self):
         """
-        The test_DockerNoImageArg function tests that Ganga can 
+        The test_DockerNoImageArg function tests that Ganga can
         submit a virtualization job using the default Docker image.
-        
+
         This test will fail if Ganga cannot find the job in the registry or
         it cannot intialize the container with the default Docker image.
         """
@@ -21,12 +22,12 @@ passed correctly as an argument.")
         j.submit()
         sleep_until_completed(j)
         j.remove()
-        
+
     def test_DockerBareImageArg(self):
         """
         The test_DockerBareImageArg function tests that the Docker image
         is passed correctly as an argument without the 'image=' prefix.
-        
+
         This test will fail if Ganga cannot find the job in the registry or
         it cannot intialize the container with the desired Docker image.
         """
@@ -45,7 +46,7 @@ image was not passed correctly as an argument.")
         """
         The DockerImageArg function tests that the Docker image
         is passed correctly as an argument with the 'image=' prefix.
-        
+
         This test will fail if Ganga cannot find the job in the registry or
         it cannot intialize the container with the desired Docker image.
         """
@@ -59,13 +60,13 @@ image was not passed correctly as an argument.")
         j.submit()
         sleep_until_completed(j)
         j.remove()
-        
+
     def test_DockerImageArgWithMode(self):
         """
         The DockerImageArgWithMode function tests that the Docker image
         is passed correctly as an argument with the 'image=' prefix. It
         also test if mode is explicitly set to 'P1'.
-        
+
         This test will fail if Ganga cannot find the job in the registry
         or it cannot intialize the container with the desired Docker image
         and mode.


### PR DESCRIPTION
The following Docker commands now work correctly:

```
d = Docker()
d = Docker('fedora:latest')
d = Docker(image='fedora:latest')
d = Docker(image='fedora:latest', mode='P1')
```

In addition, added unit tests for each of these commands.

Please note that this fix does not remove the `__init__` function from [Docker,py](https://github.com/ganga-devs/ganga/blob/develop/ganga/GangaCore/Lib/Virtualization/Docker.py) as suggested [here](https://github.com/ganga-devs/ganga/issues/2309#issuecomment-1979881949). Instead, it sets default values for the `image` and `mode` parameters in the `__init__` function in Docker.py.