### PR TITLE
Updated Developer documentation

### DIFF
--- a/doc/dev/index.rst
+++ b/doc/dev/index.rst
@@ -3,6 +3,128 @@ Guide for developers
 
 This document is intended to detail some of the inner workings of Ganga to both document what we have done as well as make it easier for new developers to get on-board quicker.
 
+Get started with development:
+-----------
+
+Working on the Codebase
+^^^^^^^^^^^^^^^
+To get started with contributing & making changes to the Ganga Codebase:
+
+1. Developers need to clone the repository with:
+
+   .. code-block:: bash
+
+      git clone https://github.com/ganga-devs/ganga.git
+
+2. They need to go into the root of the project with :
+
+   .. code-block:: bash
+
+      cd ganga
+
+3. Then, run the following command to install ganga from the repo as an editable python package with relevant runtime, coverage & test packages :
+
+   .. code-block:: bash
+
+      pip install -e .[dev]
+
+   Now all changes made to the Ganga codebase will be reflected real-time
+
+4. To test their changes, developers can either initiate the ganga shell with the ganga command or invoke it via a python script.
+
+Working on the Documentation
+^^^^^^^^^^^^^^^
+To get started with contributing & making changes to the Ganga Codebase:
+
+1. Developers need to install **Sphinx** Documentation generator. Installation instructions can be found on `their website <https://www.sphinx-doc.org/en/master/usage/installation.html>`_.
+
+   .. note::
+       Since documentation is generated using a **Makefile** in ``the ganga/doc/`` folder, users may also need to install ``make`` on their systems, i.e., a build tool that can run makefiles
+
+2. Developers need to clone the repository with:
+
+   .. code-block:: bash
+
+      git clone https://github.com/ganga-devs/ganga.git
+
+3. They need to go into the docs folder i.e. ``ganga/doc/`` of the project with :
+
+   .. code-block:: bash
+
+      cd ganga/doc
+
+
+4. Then, run the following command to generate documentation in the required format :
+
+   .. code-block:: bash
+
+      make <target>
+
+   .. note::
+
+       The supported list of targets are:
+
+       .. list-table::
+          :widths: 25 75
+          :header-rows: 1
+
+          * - Target
+            - Description
+          * - ``html``
+            - to make standalone HTML files.
+          * - ``dirhtml``
+            - to make HTML files named index.html in directories.
+          * - ``singlehtml``
+            - to make a single large HTML file.
+          * - ``pickle``
+            - to make pickle files.
+          * - ``json``
+            - to make JSON files.
+          * - ``htmlhelp``
+            - to make HTML files and a HTML help project.
+          * - ``qthelp``
+            - to make HTML files and a qthelp project.
+          * - ``applehelp``
+            - to make an Apple Help Book.
+          * - ``devhelp``
+            - to make HTML files and a Devhelp project.
+          * - ``epub``
+            - to make an epub.
+          * - ``latex``
+            - to make LaTeX files, you can set PAPER=a4 or PAPER=letter.
+          * - ``latexpdf``
+            - to make LaTeX files and run them through pdflatex.
+          * - ``latexpdfja``
+            - to make LaTeX files and run them through platex/dvipdfmx.
+          * - ``text``
+            - to make text files.
+          * - ``man``
+            - to make manual pages.
+          * - ``texinfo``
+            - to make Texinfo files.
+          * - ``info``
+            - to make Texinfo files and run them through makeinfo.
+          * - ``gettext``
+            - to make PO message catalogs.
+          * - ``changes``
+            - to make an overview of all changed/added/deprecated items.
+          * - ``xml``
+            - to make Docutils-native XML files.
+          * - ``pseudoxml``
+            - to make pseudoxml-XML files for display purposes.
+          * - ``linkcheck``
+            - to check all external links for integrity.
+          * - ``doctest``
+            - to run all doctests embedded in the documentation (if enabled).
+          * - ``coverage``
+            - to run coverage check of the documentation (if enabled).
+          * - ``apidoc``
+            - to create RST files from source code documentation.
+
+5. This would generate a ``_build/`` folder which would contain the relevant output files.
+
+6. Now, all changes made to the Ganga Documentation can be tested/previewed by re-running above command after making the change.
+
 GangaObject
 -----------
 

--- a/doc/dev/index.rst
+++ b/doc/dev/index.rst
@@ -10,19 +10,27 @@ Working on the Codebase
 ^^^^^^^^^^^^^^^
 To get started with contributing & making changes to the Ganga Codebase:
 
-1. Developers need to clone the repository with:
+1. Developers need to fork the Ganga repository. To do this, go to the `Ganga GitHub Repository <https://github.com/ganga-devs/ganga>`_, click on ``Fork`` button & Create a fork of the original repository.
+
+2. Developers need to clone the Forked repository with:
 
    .. code-block:: bash
 
-      git clone https://github.com/ganga-devs/ganga.git
+      git clone https://github.com/<USERNAME>/ganga.git
 
-2. They need to go into the root of the project with :
+   Where ``<USERNAME>`` is the developer's username.
+
+   .. note::
+
+       The users can also clone the forked repository via ``SSH`` by using ``git clone git@github.com:<USERNAME>/ganga.git`` once their Public & Private ``SSH Keys`` are generated & configured on GitHub.
+
+3. They need to go into the root of the project with :
 
    .. code-block:: bash
 
       cd ganga
 
-3. Then, run the following command to install ganga from the repo as an editable python package with relevant runtime, coverage & test packages :
+4. Then, run the following command to install ganga from the repo as an editable python package with relevant runtime, coverage & test packages :
 
    .. code-block:: bash
 
@@ -30,31 +38,39 @@ To get started with contributing & making changes to the Ganga Codebase:
 
    Now all changes made to the Ganga codebase will be reflected real-time
 
-4. To test their changes, developers can either initiate the ganga shell with the ganga command or invoke it via a python script.
+5. To test their changes, developers can either initiate the ganga shell with the ganga command or invoke it via a python script.
 
 Working on the Documentation
 ^^^^^^^^^^^^^^^
 To get started with contributing & making changes to the Ganga Codebase:
 
-1. Developers need to install **Sphinx** Documentation generator. Installation instructions can be found on `their website <https://www.sphinx-doc.org/en/master/usage/installation.html>`_.
+1. Developers need to fork the Ganga repository. To do this, go to the `Ganga GitHub Repository <https://github.com/ganga-devs/ganga>`_, click on ``Fork`` button & Create a fork of the original repository.
+
+2. Developers need to install **Sphinx** Documentation generator. Installation instructions can be found on `their website <https://www.sphinx-doc.org/en/master/usage/installation.html>`_.
 
    .. note::
        Since documentation is generated using a **Makefile** in ``the ganga/doc/`` folder, users may also need to install ``make`` on their systems, i.e., a build tool that can run makefiles
 
-2. Developers need to clone the repository with:
+3. Developers need to clone the repository with:
 
    .. code-block:: bash
 
-      git clone https://github.com/ganga-devs/ganga.git
+      git clone https://github.com/<USERNAME>/ganga.git
 
-3. They need to go into the docs folder i.e. ``ganga/doc/`` of the project with :
+   Where ``<USERNAME>`` is the developer's username.
+
+   .. note::
+
+       The users can also clone the forked repository via ``SSH`` by using ``git clone git@github.com:<USERNAME>/ganga.git`` once their Public & Private ``SSH Keys`` are generated & configured on GitHub.
+
+4. They need to go into the docs folder i.e. ``ganga/doc/`` of the project with :
 
    .. code-block:: bash
 
       cd ganga/doc
 
 
-4. Then, run the following command to generate documentation in the required format :
+5. Then, run the following command to generate documentation in the required format :
 
    .. code-block:: bash
 
@@ -121,9 +137,9 @@ To get started with contributing & making changes to the Ganga Codebase:
           * - ``apidoc``
             - to create RST files from source code documentation.
 
-5. This would generate a ``_build/`` folder which would contain the relevant output files.
+6. This would generate a ``_build/`` folder which would contain the relevant output files.
 
-6. Now, all changes made to the Ganga Documentation can be tested/previewed by re-running above command after making the change.
+7. Now, all changes made to the Ganga Documentation can be tested/previewed by re-running above command after making the change.
 
 GangaObject
 -----------


### PR DESCRIPTION
Hi @egede , @ Ganga Team,

This PR closes issue #2317.

I have made the relevant changes in the `.rst` files & previewed the output. I also added some more information w.r.t contributing to the Documentation. The Structure is as follows:

> ## Get started with development: 
>
> ### Working on the Codebase
> ...
> *relevant steps with code*
> ...
> 
> ### Working on the Documentation
> ...
> *relevant steps with code*
> ....

 Few of the outputs are as follows

### Output Artifacts
1. **HTML**
  ![image](https://github.com/ganga-devs/ganga/assets/16386226/51316056-f73b-42bc-943c-3af04dd818d6)
  ![image](https://github.com/ganga-devs/ganga/assets/16386226/2768df90-c33e-4898-8da0-19ae380f610d)
  ![image](https://github.com/ganga-devs/ganga/assets/16386226/83a6503a-06d1-4866-bef4-061eeb16c914)
2. **Text**
  ![image](https://github.com/ganga-devs/ganga/assets/16386226/e61f51fb-a529-4605-a032-20c5be0b6bb5)
  ![image](https://github.com/ganga-devs/ganga/assets/16386226/f20a3d5e-438d-48f4-9d89-72b3d2724809)
  ![image](https://github.com/ganga-devs/ganga/assets/16386226/be5366f1-ce73-4330-8df1-e5f3a81168ba)
  ![image](https://github.com/ganga-devs/ganga/assets/16386226/789b2216-7e10-41ae-a140-9512aa9ec776)



### Queries
1. **Running Tests**
  While trying to test via `make doctest`:
  ![image](https://github.com/ganga-devs/ganga/assets/16386226/f9dc4465-187a-47f5-a9b6-265bbd08af37)
  `make coverage` yields the following :
  ![image](https://github.com/ganga-devs/ganga/assets/16386226/efc38675-4f6d-4e59-a0fd-b85755e1c607)
  Please let me know if I need to write any test cases for the documentation as well.

2. **Some Warnings Encountered during Building**
  I built the docs using `make <target>` (where target is `html`,`text` etc.).
  While the docs built successfully & I was able to see my changes, I encountered the following warnings:
  ![image](https://github.com/ganga-devs/ganga/assets/16386226/8cfe5e02-2c76-495b-b448-43a1ca1572f5)
  ![image](https://github.com/ganga-devs/ganga/assets/16386226/19b8feda-89d5-4d32-9e07-92a81c887669)
  ![image](https://github.com/ganga-devs/ganga/assets/16386226/d69698b9-6678-49b8-862e-873005205f1f)
  ![image](https://github.com/ganga-devs/ganga/assets/16386226/d64961fe-b84f-4468-8119-b1ffe2253602)
  As I understand, these warnings are related to paths added using `sys.path()` in `conf.py`  & the formatting in other `.rst` files. Is expected behavior ? or do I need to modify `conf.py` too ?

Please let me know if further adjustments are required before successfully Merging the PR.

Best Regards