### PR TITLE
Fix apptainer call in GaudiExec

### DIFF
--- a/ganga/GangaLHCb/Lib/Applications/GaudiExec.py
+++ b/ganga/GangaLHCb/Lib/Applications/GaudiExec.py
@@ -195,8 +195,8 @@ class GaudiExec(IPrepareApp):
         'nMakeCores': SimpleItem(defvalue=1,
                                  doc='Number of cores to be provided via the "-j" option to the "make" command'\
                                      'when building the ganga-input-sandbox'),
-        'apptainerBuild' : SimpleItem(defvalue=False, doc="Run the build command in apptainer"),
-        'containerLocation' : SimpleItem(defvalue='/cvmfs/cernvm-prod.cern.ch/cvm4',
+        'apptainerBuild': SimpleItem(defvalue=False, doc="Run the build command in apptainer"),
+        'containerLocation': SimpleItem(defvalue='/cvmfs/cernvm-prod.cern.ch/cvm4',
                                          doc='Where is the container to use for the build located'),
         # Prepared job object
         'is_prepared': SimpleItem(defvalue=None, strict_sequence=0, visitable=1, copyable=1, hidden=0,
@@ -572,7 +572,7 @@ class GaudiExec(IPrepareApp):
                     cmd_to_run = 'source /cvmfs/lhcb.cern.ch/lib/LbEnv && apptainer exec --env "PATH=$PATH" --bind $PWD --bind /cvmfs:/cvmfs:ro '\
                                  + self.containerLocation + ' ' + cmd_file.name
                     rc, stdout, stderr = _exec_cmd(cmd_to_run, self.directory)
-                except:
+                except BaseException:
                     logger.error('Failed to build the application inside a container. '
                                  'Perhaps the specified container location is not accessible.')
                     raise GangaException('Failed to execute make command')

--- a/ganga/GangaLHCb/Lib/Applications/GaudiExec.py
+++ b/ganga/GangaLHCb/Lib/Applications/GaudiExec.py
@@ -569,7 +569,7 @@ class GaudiExec(IPrepareApp):
             if self.apptainerBuild or 'slc6' in self.platform:
                 try:
                     logger.info('Building inside apptainer: %s' % self.containerLocation)
-                    cmd_to_run = 'apptainer exec --env "PATH=$PATH" --bind $PWD --bind /cvmfs:/cvmfs:ro '\
+                    cmd_to_run = 'source /cvmfs/lhcb.cern.ch/lib/LbEnv && apptainer exec --env "PATH=$PATH" --bind $PWD --bind /cvmfs:/cvmfs:ro '\
                                  + self.containerLocation + ' ' + cmd_file.name
                     rc, stdout, stderr = _exec_cmd(cmd_to_run, self.directory)
                 except:


### PR DESCRIPTION
The `_exec_cmd` function will empty the environment variables, causing `apptainer command not found`, thus suggesting adding an environment setup like other `_exec_cmd` calls. 