### PR TITLE
Update Condor.py

### DIFF
--- a/ganga/GangaCore/Lib/Condor/Condor.py
+++ b/ganga/GangaCore/Lib/Condor/Condor.py
@@ -345,6 +345,7 @@ class Condor(IBackend):
             "",
             "workdir = os.getcwd()",
             "execmd = %s" % repr(exeCmd),
+            "runenv = os.environ.copy()",
             "",
             "###VIRTUALIZATION###",
             "",


### PR DESCRIPTION
The `runenv` is missing from the Condor script which breaks it when using virtualisation.