### PR TITLE
Fix SyntaxError: invalid syntax in doc/fill_gpi.py

### DIFF
--- a/doc/fill_gpi.py
+++ b/doc/fill_gpi.py
@@ -66,7 +66,7 @@ def signature(func, name=None):
     Returns: a string representing its signature as would be written in code
 
     """
-    args, varargs, varkw, defaults = inspect.getargspec(func)
+    args, varargs, varkw, defaults, kwonlyargs, kwonlydefaults, annotations = inspect.getfullargspec(func)
     defaults = defaults or []  # If there are no defaults, set it to an empty list
     defaults = [repr(d) for d in defaults]  # Type to get a useful string representing the default
 

--- a/doc/fill_gpi.py
+++ b/doc/fill_gpi.py
@@ -66,7 +66,7 @@ def signature(func, name=None):
     Returns: a string representing its signature as would be written in code
 
     """
-    args, varargs, varkw, defaults, kwonlyargs, kwonlydefaults, annotations = inspect.getfullargspec(func)
+    args, varargs, varkw, defaults, *_ = inspect.getfullargspec(func)
     defaults = defaults or []  # If there are no defaults, set it to an empty list
     defaults = [repr(d) for d in defaults]  # Type to get a useful string representing the default
 


### PR DESCRIPTION
Building the documentation currently fails on the latest `develop` branch with the following error:

```
Traceback (most recent call last):
  File "/home/arya/Dev/ganga/doc/fill_gpi.py", line 143, in <module>
    print('    .. method:: {signature}'.format(signature=signature(f)), file=cf)
                                                         ^^^^^^^^^^^^
  File "/home/arya/Dev/ganga/doc/fill_gpi.py", line 69, in signature
    args, varargs, varkw, defaults = inspect.getargspec(func)
                                     ^^^^^^^^^^^^^^^^^^
AttributeError: module 'inspect' has no attribute 'getargspec'. Did you mean: 'getargs'?
```

This error is due to the `getargspec` method being deprecated and replaced by `getfullargspec`, as mentioned [here](https://docs.python.org/3/library/inspect.html#inspect.getfullargspec).

Replacing `inspect.getargspec` with `inspect.getfullargspec` solves the error.

I have tested the change on Python 3.7.17 (the oldest version that satisfies the dependencies) and on Python 3.12.3. In both the versions running:

```
cd doc
make html
```

executes successfully and generates the build as expected.
