### PR TITLE
Update ci_push_testing.yml for almalinux 9

### DIFF
--- a/.github/workflows/ci_push_testing.yml
+++ b/.github/workflows/ci_push_testing.yml
@@ -293,7 +293,7 @@ jobs:
     if: always() && !failure() && !cancelled()
     runs-on: ubuntu-latest
     container:
-      image: centos:7
+      image: almalinux:9
       options: --privileged
     steps:
       - name: Install CVM-FS
@@ -329,7 +329,7 @@ jobs:
     if: always() && !failure() && !cancelled()
     runs-on: ubuntu-latest
     container:
-      image: centos:7
+      image: almalinux:9
       options: --privileged
     steps:
       - name: Install git


### PR DESCRIPTION
centos 7 has passed EOL so no longer usable.
Fixes #2138 