### PR TITLE
fix: added 'pipes' dependency to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,7 @@ install_requires = [
     "docker",
     "pymongo",
     "gdown",
+    "pipes"
 ]
 if sys.platform != 'darwin':
     install_requires.append("htcondor")


### PR DESCRIPTION
Imported here:
 https://github.com/ganga-devs/ganga/blob/41e197d1331f9e3dc36c7792eb030c0b03a4510e/ganga/GangaCore/Core/GangaRepository/SessionLock.py#L19
but not included in the install dependencies. The module `pipe` was not found when I tried to import `ganga.ganga`, so I had to install it manually.