### PR TITLE
Docker fix

### DIFF
--- a/ganga/GangaCore/Dockerfile
+++ b/ganga/GangaCore/Dockerfile
@@ -1,11 +1,15 @@
-FROM python:3.11
+FROM registry.access.redhat.com/ubi9/python-311
 LABEL maintainer "Ulrik Egede <ulrik.egede@monash.edu>"
 ARG ganga_version=8.4.2
+
+# Switch to root user
+USER root
 
 # Add the user UID:1000, GID:1000, home at /home/ganga
 RUN groupadd -r ganga -g 1000 && \
     useradd -u 1000 -r -g ganga -m -d /home/ganga -s /sbin/nologin -c "Ganga user" ganga && \
-    chmod 755 /home/ganga
+    chown -R ganga:ganga /opt/app-root/src && \
+    chmod 755 /home/ganga 
 
 # Set the working directory to ganga home directory
 WORKDIR /home/ganga
@@ -14,6 +18,7 @@ WORKDIR /home/ganga
 RUN python3 -m pip install --upgrade pip setuptools wheel && \
     python3 -m pip install "PySocks!=1.5.7,>=1.5.6" && \
     python3 -m pip install -e git+https://github.com/ganga-devs/ganga.git@$ganga_version#egg=ganga
+
 
 # Specify the user to execute all commands below
 USER ganga

--- a/ganga/GangaCore/Dockerfile
+++ b/ganga/GangaCore/Dockerfile
@@ -1,15 +1,13 @@
-FROM registry.access.redhat.com/ubi9/python-311
+FROM almalinux:9
 LABEL maintainer "Ulrik Egede <ulrik.egede@monash.edu>"
 ARG ganga_version=8.4.2
 
-# Switch to root user
-USER root
+RUN dnf install -y python3 python3-pip git
 
 # Add the user UID:1000, GID:1000, home at /home/ganga
 RUN groupadd -r ganga -g 1000 && \
     useradd -u 1000 -r -g ganga -m -d /home/ganga -s /sbin/nologin -c "Ganga user" ganga && \
-    chown -R ganga:ganga /opt/app-root/src && \
-    chmod 755 /home/ganga 
+    chmod 755 /home/ganga
 
 # Set the working directory to ganga home directory
 WORKDIR /home/ganga
@@ -18,7 +16,6 @@ WORKDIR /home/ganga
 RUN python3 -m pip install --upgrade pip setuptools wheel && \
     python3 -m pip install "PySocks!=1.5.7,>=1.5.6" && \
     python3 -m pip install -e git+https://github.com/ganga-devs/ganga.git@$ganga_version#egg=ganga
-
 
 # Specify the user to execute all commands below
 USER ganga

--- a/ganga/GangaCore/Dockerfile
+++ b/ganga/GangaCore/Dockerfile
@@ -2,7 +2,7 @@ FROM almalinux:9
 LABEL maintainer "Ulrik Egede <ulrik.egede@monash.edu>"
 ARG ganga_version=8.4.2
 
-RUN dnf install -y python3 python3-pip git
+RUN dnf update -y && dnf install -y python3 python3-pip git
 
 # Add the user UID:1000, GID:1000, home at /home/ganga
 RUN groupadd -r ganga -g 1000 && \

--- a/ganga/GangaCore/Dockerfile
+++ b/ganga/GangaCore/Dockerfile
@@ -1,8 +1,6 @@
-FROM centos:7
+FROM python:3.11
 LABEL maintainer "Ulrik Egede <ulrik.egede@monash.edu>"
 ARG ganga_version=8.4.2
-
-RUN yum -y update && yum install -y wget git python3
 
 # Add the user UID:1000, GID:1000, home at /home/ganga
 RUN groupadd -r ganga -g 1000 && \


### PR DESCRIPTION
- centos:7 [deprecated] -> almalinux:9

Error log:

```bash
#0 building with "default" instance using docker driver

#1 [internal] load build definition from Dockerfile
#1 transferring dockerfile: 924B done
#1 DONE 0.0s

#2 [internal] load metadata for docker.io/library/centos:7
#2 DONE 0.7s

#3 [internal] load .dockerignore
#3 transferring context: 2B done
#3 DONE 0.0s

#4 [1/6] FROM docker.io/library/centos:7@sha256:be65f488b7764ad3638f236b7b515b3678369a5124c47b8d32916d6487418ea4
#4 CACHED

#5 [2/6] RUN yum -y update && yum install -y wget git python3
#5 0.447 Loaded plugins: fastestmirror, ovl
#5 0.661 Determining fastest mirrors
#5 0.675 Could not retrieve mirrorlist http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=os&infra=container error was
#5 0.675 14: curl#6 - "Could not resolve host: mirrorlist.centos.org; Unknown error"
#5 0.678 
#5 0.678 
#5 0.678  One of the configured repositories failed (Unknown),
#5 0.678  and yum doesn't have enough cached data to continue. At this point the only
#5 0.678  safe thing yum can do is fail. There are a few ways to work "fix" this:
#5 0.678 
#5 0.678      1. Contact the upstream for the repository and get them to fix the problem.
#5 0.678 
#5 0.678      2. Reconfigure the baseurl/etc. for the repository, to point to a working
#5 0.678         upstream. This is most often useful if you are using a newer
#5 0.678         distribution release than is supported by the repository (and the
#5 0.678         packages for the previous distribution release still work).
#5 0.678 
#5 0.678      3. Run the command with the repository temporarily disabled
#5 0.678             yum --disablerepo=<repoid> ...
#5 0.678 
#5 0.678      4. Disable the repository permanently, so yum won't use it by default. Yum
#5 0.678         will then just ignore the repository until you permanently enable it
#5 0.678         again or use --enablerepo for temporary usage:
#5 0.678 
#5 0.678             yum-config-manager --disable <repoid>
#5 0.678         or
#5 0.678             subscription-manager repos --disable=<repoid>
#5 0.678 
#5 0.678      5. Configure the failing repository to be skipped, if it is unavailable.
#5 0.678         Note that yum will try to contact the repo. when it runs most commands,
#5 0.678         so will have to try and fail each time (and thus. yum will be be much
#5 0.678         slower). If it is a very temporary problem though, this is often a nice
#5 0.678         compromise:
#5 0.678 
#5 0.678             yum-config-manager --save --setopt=<repoid>.skip_if_unavailable=true
#5 0.678 
#5 0.678 Cannot find a valid baseurl for repo: base/7/x86_64
#5 ERROR: process "/bin/sh -c yum -y update && yum install -y wget git python3" did not complete successfully: exit code: 1
------
 > [2/6] RUN yum -y update && yum install -y wget git python3:
0.678 
0.678      5. Configure the failing repository to be skipped, if it is unavailable.
0.678         Note that yum will try to contact the repo. when it runs most commands,
0.678         so will have to try and fail each time (and thus. yum will be be much
0.678         slower). If it is a very temporary problem though, this is often a nice
0.678         compromise:
0.678 
0.678             yum-config-manager --save --setopt=<repoid>.skip_if_unavailable=true
0.678 
0.678 Cannot find a valid baseurl for repo: base/7/x86_64
------
Dockerfile:5
--------------------
   3 |     ARG ganga_version=8.4.2
   4 |     
   5 | >>> RUN yum -y update && yum install -y wget git python3
   6 |     
   7 |     # Add the user UID:1000, GID:1000, home at /home/ganga
--------------------
ERROR: failed to solve: process "/bin/sh -c yum -y update && yum install -y wget git python3" did not complete successfully: exit code: 1
```

