### PR TITLE
Bug Fix: logger function is not defined, Typo: logger -> log

### DIFF
--- a/ganga/GangaCore/Core/MonitoringComponent/Local_GangaMC_Service.py
+++ b/ganga/GangaCore/Core/MonitoringComponent/Local_GangaMC_Service.py
@@ -1277,8 +1277,8 @@ class JobRegistry_Monitor(GangaThread):
             except CredentialRenewalError:
                 return False
             except Exception as err:
-                logger.error("Unexpected exception!")
-                logger.error("Error: %s" % err)
+                log.error("Unexpected exception!")
+                log.error("Error: %s" % err)
                 return False
             else:
                 return True


### PR DESCRIPTION
while working on runMonitoring (#2380), a bug was reported on lines 1280 and 1281. 

Previously: "logger" was not defined.
Now: "logger" has been corrected to "log".