### PR TITLE
Changed AFS check regex pattern.

### DIFF
--- a/ganga/GangaCore/GPIDev/Credentials/AfsToken.py
+++ b/ganga/GangaCore/GPIDev/Credentials/AfsToken.py
@@ -27,7 +27,7 @@ class AfsTokenInfo(ICredentialInfo):
     should_warn = False
 
     info_pattern = re.compile(
-        r"^User's \(AFS ID \d*\) (rxkad )?tokens for ((?P<id>\w*@)?\S*) \[Expires (?P<expires>.*)\]$", re.MULTILINE)
+        r"^(?:User's \(AFS ID \d+\) (rxkad )?tokens|Tokens) for ((?P<id>[^\s@]+@)?\S+) \[Expires (?P<expires>.+?)\]$", re.MULTILINE)
 
     __slots__ = ('shell', 'cache', 'initial_requirements')
 


### PR DESCRIPTION
fixes:#2271
Changed regex.

It is working fine with these examples.
![image](https://github.com/user-attachments/assets/87540c12-d742-4760-a230-389947e88d89)
![Screenshot from 2025-04-12 12-37-16](https://github.com/user-attachments/assets/bbac45b0-863f-48d6-bb3c-48a0cd8101ca)
![image](https://github.com/user-attachments/assets/8e9bf261-ea96-4c61-869b-5e035c544a02)
For all above examples it gives same output as previous expression.





For this example:
`Tokens for afs@ihep.ac.cn [Expires Jan 24 18:13]`

![image](https://github.com/user-attachments/assets/1a709a85-2b0a-4df7-8d16-f6ebd767610d)


Let me know if any changes needed.