### PR TITLE
Voms filename blows up with DIRAC backend

### DIFF
--- a/ganga/GangaDirac/Lib/Credentials/DiracProxy.py
+++ b/ganga/GangaDirac/Lib/Credentials/DiracProxy.py
@@ -168,7 +168,7 @@ class DiracProxyInfo(VomsProxyInfo):
         """
         base_proxy_name = os.getenv('X509_USER_PROXY') or '/tmp/x509up_u' + str(os.getuid())
         encoded_ext = self.initial_requirements.encoded()
-        if encoded_ext:
+        if encoded_ext and encoded_ext not in base_proxy_name:
             return base_proxy_name + ':' + encoded_ext
         else:
             return base_proxy_name


### PR DESCRIPTION
When appending the voms user information onto `X509_USER_PROXY`, `DiracProxyInfo` does not check whether this has already been done. As a result, the voms file name blows up from repeated appending of the voms user group. An `OSError` subsequently follows from the filename being too long. I've added an additional check to see if the information has already been appended to avoid this.