### PR TITLE
added ganga import to executable

### DIFF
--- a/bin/ganga
+++ b/bin/ganga
@@ -68,6 +68,7 @@ except KeyboardInterrupt:
 del standardSetup
 # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+import ganga
 from GangaCore.Core.exceptions import GangaException
 import GangaCore.Runtime
 GangaCore.Runtime._prog = None


### PR DESCRIPTION
Goal: fix an issue with the executable not working when using the [uv](https://github.com/astral-sh/uv) package manager.
Origin of issue:  `ganga` executable adds  `GangaCore` to `sys.path`  using:

https://github.com/ganga-devs/ganga/blob/ee0f0cbfc323ce011154a632587fc5e1d44b5346/bin/ganga#L43-L45
https://github.com/ganga-devs/ganga/blob/ee0f0cbfc323ce011154a632587fc5e1d44b5346/bin/ganga#L56-L59

This assumes the relative path the executable and library is as in the codebase. `uv` breaks that assumption, copying the executable elsewhere.  `__init__.py` in the `ganga` library has:

https://github.com/ganga-devs/ganga/blob/ee0f0cbfc323ce011154a632587fc5e1d44b5346/ganga/__init__.py#L4-L5

So  `import ganga` in the executable fix the issue.