### PR TITLE
fix: resolve license deprecation warning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ setup(
     version=version(),
     author='Ganga Developers',
     author_email='project-ganga-developers@cern.ch',
-    license='GPL v2',
+    license='GPL-3.0-only',
     scripts=[
         'bin/ganga'],
     package_dir={
@@ -120,7 +120,6 @@ setup(
         'Dirac': ['UltraDict',
                   'psutil']},
     classifiers=[
-        'License :: OSI Approved :: GNU General Public License v2 (GPLv2)',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',


### PR DESCRIPTION
## Summary

This PR eliminates the `SetuptoolsDeprecationWarning` that appears when building or installing the package with setuptools v77+, improving the developer experience and cleaning up package metadata.

## Solution

- **Removed**: Deprecated `License :: OSI Approved :: GNU General Public License v2 (GPLv2)` classifier
- **Added**: Modern `license = GPL-3.0-only` field using standardized SPDX identifier
- **Corrected**: License version from v2 to v3 to match actual `LICENSE_GPL` file content

Closes #2419