### PR TITLE
Pass container as Apptainer constructor argument

### DIFF
--- a/ganga/GangaND280/ND280Control/runND280RDP.py
+++ b/ganga/GangaND280/ND280Control/runND280RDP.py
@@ -100,8 +100,7 @@ class runND280RDP(IPrepareApp):
 
         job = self.getJobObject()
         if self.container:
-            job.virtualization = Apptainer()
-            job.virtualization.image = self.container
+            job.virtualization = Apptainer(self.container)
 
         if len(self.mounts) > 0:
             job.virtualization.mounts = {mount: mount for mount in self.mounts}


### PR DESCRIPTION
Previously was doing:
a = Apptainer()
a.image = '/path/to/foo.sif'

Now it seems that the base class requires
a = Apptainer('/path/to/foo.sif')

The checking the git history it's not clear to me when this change was introduced.