### PR TITLE
Python314 install and run

### DIFF
--- a/ganga/GangaCore/Core/GangaRepository/SessionLock.py
+++ b/ganga/GangaCore/Core/GangaRepository/SessionLock.py
@@ -639,9 +639,9 @@ class SessionLockManager(object):
                         fcntl.lockf(fd, fcntl.LOCK_UN)
                     fd.close()
 
-                if _output is not None:
-                    self.last_count_access = SessionLockManager.LastCountAccess(os.stat(self.cntfn).st_ctime, _output)
-                    return _output
+            if _output is not None:
+                self.last_count_access = SessionLockManager.LastCountAccess(os.stat(self.cntfn).st_ctime, _output)
+                return _output
 
         except OSError as x:
             if x.errno != errno.ENOENT:

--- a/ganga/GangaCore/Core/GangaRepository/SessionLock.py
+++ b/ganga/GangaCore/Core/GangaRepository/SessionLock.py
@@ -192,10 +192,11 @@ class SessionLockRefresher(GangaThread):
                     now = -999.
             else:
                 if self.repos[index] is not None:
-                    raise RepositoryError(self.repos[index],
-                                          "[SessionFileUpdate] Run: Own session file not found! Possibly deleted by another ganga session.\n\
+                    raise RepositoryError(
+                        self.repos[index], "[SessionFileUpdate] Run: Own session file not found! Possibly deleted by another ganga session.\n\
                     Possible reasons could be that this computer has a very high load, or that the system clocks on computers running Ganga are not synchronized.\n\
-                    On computers with very high load and on network filesystems, try to avoid running concurrent ganga sessions for long.\n '%s' : %s" % (this_index_file, x))
+                    On computers with very high load and on network filesystems, try to avoid running concurrent ganga sessions for long.\n '%s' : %s" %
+                        (this_index_file, x))
                 else:
                     from GangaCore.Core.exceptions import GangaException
                     raise GangaException("Error Opening global .session file for this session: %s" % this_index_file)
@@ -226,7 +227,7 @@ class SessionLockRefresher(GangaThread):
             for f in lock_files:
                 # Determine the session file which controls this lock file
                 asf = f.split(".session")[0] + ".session"
-                if not asf in session_files:
+                if asf not in session_files:
                     os.unlink(os.path.join(self.sdir, f))
         except OSError as x:
             # nothing really important, another process deleted the session
@@ -237,25 +238,25 @@ class SessionLockRefresher(GangaThread):
 
     def numberRepos(self):
         try:
-            assert(len(self.fns) == len(self.repos))
+            assert (len(self.fns) == len(self.repos))
         except AssertionError:
             raise RepositoryError("Number of repos is inconsistent with lock files")
         return len(self.fns)
 
     def addRepo(self, fn, repo):
-        #logger.debug("Adding Repo: %s" % repo )
+        # logger.debug("Adding Repo: %s" % repo )
         self.repos.append(repo)
-        #logger.debug("Adding fn: %s" % fn )
+        # logger.debug("Adding fn: %s" % fn )
         self.fns.append(fn)
 
     def removeRepo(self, fn, repo):
-        #logger.debug("Removing fn: %s" % fn )
+        # logger.debug("Removing fn: %s" % fn )
         self.fns.remove(fn)
-        #logger.debug("Removing fn: %s" % fn )
+        # logger.debug("Removing fn: %s" % fn )
         self.repos.remove(repo)
 
         try:
-            assert(len(self.fns) == len(self.repos))
+            assert (len(self.fns) == len(self.repos))
         except AssertionError:
             raise RepositoryError("Number of repos is inconsistent after removing repo!")
 
@@ -308,7 +309,7 @@ def global_disk_lock(f):
                     try:
                         self.afs_lock_require()
                         break
-                    except:
+                    except BaseException:
                         time.sleep(0.1)
 
                 self.safe_LockCheck()
@@ -377,7 +378,7 @@ class SessionLockManager(object):
             this_date = t.strftime("%H.%M_%A_%d_%B_%Y")
             session_name = ".".join(
                 [os.uname()[1], str(this_date), "PID", str(os.getpid()), "session"])
-            #session_name = ".".join([os.uname()[1], str(int(time.time()*1000)), str(os.getpid()), "session"])
+            # session_name = ".".join([os.uname()[1], str(int(time.time()*1000)), str(os.getpid()), "session"])
         else:
             session_name = session_lock_refresher.session_name
 
@@ -392,7 +393,7 @@ class SessionLockManager(object):
         self.session_name = session_name
         self.name = name
         self.realpath = realpath
-        #logger.debug( "Initializing SessionLockManager: " + self.fn )
+        # logger.debug( "Initializing SessionLockManager: " + self.fn )
         self._lock = threading.RLock()
         self.last_count_access = None
         self._stored_session_path = {}
@@ -457,7 +458,7 @@ class SessionLockManager(object):
     @synchronised
     def shutdown(self):
         """Shutdown the thread and locking system (on ganga shutdown or repo error)"""
-        #logger.debug( "Shutting Down SessionLockManager, self.fn = %s" % (self.fn) )
+        # logger.debug( "Shutting Down SessionLockManager, self.fn = %s" % (self.fn) )
         # print "Shutting Down SessionLock"
         self.locked = set()
         try:
@@ -508,7 +509,7 @@ class SessionLockManager(object):
                 oldtime = os.stat(lock_file).st_ctime
                 nowtime = time.time()
                 if abs(int(nowtime) - oldtime) > 10:
-                    #logger.debug( "cleaning global lock" )
+                    # logger.debug( "cleaning global lock" )
                     os.system("fs setacl %s %s rlidwka" % (quote(lock_path), getpass.getuser()))
 
             while True:
@@ -527,7 +528,7 @@ class SessionLockManager(object):
                 with open(lock_file, "w"):
                     pass
 
-            #logger.debug("global capture")
+            # logger.debug("global capture")
         except IOError as x:
             raise RepositoryError(self.repo, "IOError on AFS global lock: %s" % (x,))
 
@@ -536,7 +537,7 @@ class SessionLockManager(object):
             lock_path = str(self.lockfn) + '.afs'
             os.system("fs setacl %s %s rlidwka" % (quote(lock_path), getpass.getuser()))
 
-            #logger.debug("global release")
+            # logger.debug("global release")
         except IOError as x:
             raise RepositoryError(self.repo, "IOError on AFS global lock: %s" % (x,))
 
@@ -578,7 +579,7 @@ class SessionLockManager(object):
             The global lock MUST be held for this function to work, although on NFS additional
             locking is done
             Raises RepositoryError if session file is inaccessible """
-        #logger.debug("Openining Session File: %s " % self.fn )
+        # logger.debug("Openining Session File: %s " % self.fn )
         try:
             # If this fails, we want to shutdown the repository (corruption
             # possible)
@@ -603,10 +604,12 @@ class SessionLockManager(object):
                 raise RepositoryError(
                     self.repo, "Error on session file access '%s': %s" % (self.fn, x))
             else:
-                #logger.debug( "File NOT found %s" %self.fn )
-                raise RepositoryError(self.repo, "SessionWrite: Own session file not found! Possibly deleted by another ganga session.\n\
+                # logger.debug( "File NOT found %s" %self.fn )
+                raise RepositoryError(
+                    self.repo, "SessionWrite: Own session file not found! Possibly deleted by another ganga session.\n\
                                     Possible reasons could be that this computer has a very high load, or that the system clocks on computers running Ganga are not synchronized.\n\
-                                    On computers with very high load and on network filesystems, try to avoid running concurrent ganga sessions for long.\n '%s' : %s" % (self.fn, x))
+                                    On computers with very high load and on network filesystems, try to avoid running concurrent ganga sessions for long.\n '%s' : %s" %
+                    (self.fn, x))
         except IOError as x:
             raise RepositoryError(
                 self.repo, "Error on session file locking '%s': %s" % (self.fn, x))
@@ -702,7 +705,7 @@ class SessionLockManager(object):
         except OSError:
             raise RepositoryError(self.repo, "Job counter deleted! External modification to repository!")
         if not newcount >= self.count:
-            #raise RepositoryError(self.repo, "Counter value decreased - logic error!")
+            # raise RepositoryError(self.repo, "Counter value decreased - logic error!")
             logger.warning("Internal counter increased - probably the count file was deleted.")
             newcount = self.count
         # someone used force_ids (for example old repository imports)
@@ -738,7 +741,7 @@ class SessionLockManager(object):
     @global_disk_lock
     def lock_ids(self, ids):
 
-        #logger.debug( "locking: %s" % ids)
+        # logger.debug( "locking: %s" % ids)
         ids = set(ids)
         try:
             sessions = [sn for sn in os.listdir(self.sdir) if sn.endswith(self.name + ".locks")]
@@ -751,14 +754,14 @@ class SessionLockManager(object):
             if sf == self.fn:
                 continue
             slocked.update(self.session_read(sf))
-        #logger.debug( "locked: %s" % slocked)
+        # logger.debug( "locked: %s" % slocked)
         ids.difference_update(slocked)
         if not GANGA_SWAN_INTEGRATION:
             # If sharing sessions don't update id to locked.
             self.locked.update(ids)
-        #logger.debug( "stored_lock: %s" % self.locked)
+        # logger.debug( "stored_lock: %s" % self.locked)
         self.session_write()
-        #logger.debug( "list: %s" % list(ids))
+        # logger.debug( "list: %s" % list(ids))
         return list(ids)
 
     @synchronised
@@ -766,7 +769,7 @@ class SessionLockManager(object):
     def release_ids(self, ids):
         self.locked.difference_update(ids)
         self.session_write()
-        #logger.debug( "list: %s" % list(ids))
+        # logger.debug( "list: %s" % list(ids))
         return list(ids)
 
     @synchronised
@@ -854,7 +857,7 @@ class SessionLockManager(object):
         WARNING: This is not nice.
         Returns True on success, False on error."""
         failed = False
-        #sessions = [s for s in os.listdir(self.sdir) if s.endswith(".session") and not os.path.join(self.sdir, s) == self.gfn]
+        # sessions = [s for s in os.listdir(self.sdir) if s.endswith(".session") and not os.path.join(self.sdir, s) == self.gfn]
         sessions = [s for s in os.listdir(self.sdir) if s.endswith(
             ".session") and int(str(s).split('.')[-2]) != int(os.getpid())]
         metadata_lock_files = [s for s in os.listdir(self.sdir) if s.endswith("metadata.locks")]
@@ -870,8 +873,8 @@ class SessionLockManager(object):
             try:
                 sf = self._path_helper(session)
                 global session_expiration_timeout
-                if((time.time() - os.stat(sf).st_ctime) > session_expiration_timeout):
-                    if(sf.endswith(".session")):
+                if ((time.time() - os.stat(sf).st_ctime) > session_expiration_timeout):
+                    if (sf.endswith(".session")):
                         logger.debug("Reaping LockFile: %s" % (sf))
                     os.unlink(sf)
             except OSError as x:

--- a/ganga/GangaCore/Core/GangaThread/GangaThread.py
+++ b/ganga/GangaCore/Core/GangaThread/GangaThread.py
@@ -23,8 +23,7 @@ class GangaThread(Thread):
         self.gangaName = str(name)  # want to copy actual not by ref!
         name = 'GANGA_Update_Thread_%s' % name
 
-        Thread.__init__(self, args=list(), name=name, **kwds)
-        self.setDaemon(True)
+        Thread.__init__(self, args=list(), name=name, **kwds, daemon=True)
         self.__should_stop_flag = False
         self.__critical = critical
 

--- a/ganga/GangaCore/Core/MonitoringComponent/Local_GangaMC_Service.py
+++ b/ganga/GangaCore/Core/MonitoringComponent/Local_GangaMC_Service.py
@@ -1350,7 +1350,7 @@ def getStackTrace():
         status = "Available threads:\n"
 
         for worker in ThreadPool:
-            status = status + "  " + worker.getName() + ":\n"
+            status = status + "  " + worker.name + ":\n"
 
             if hasattr(worker, '_frame'):
                 frame = worker._frame

--- a/ganga/GangaCore/Core/MonitoringComponent/Local_GangaMC_Service.py
+++ b/ganga/GangaCore/Core/MonitoringComponent/Local_GangaMC_Service.py
@@ -119,7 +119,7 @@ class MonitoringWorkerThread(GangaThread):
         # sys.settrace(_trace)
         while not self.should_stop():
             log.debug("%s waiting..." % threading.current_thread())
-            #setattr(threading.current_thread(), 'action', None)
+            # setattr(threading.current_thread(), 'action', None)
 
             heartbeat_times[self._thread_name] = time.time()
 
@@ -133,7 +133,7 @@ class MonitoringWorkerThread(GangaThread):
             if self.should_stop():
                 break
 
-            #setattr(threading.current_thread(), 'action', action)
+            # setattr(threading.current_thread(), 'action', action)
             log.debug("Qin's size is currently: %d" % Qin.qsize())
             log.debug("%s running..." % threading.current_thread())
             self._currently_running_command = True
@@ -149,7 +149,7 @@ class MonitoringWorkerThread(GangaThread):
                         self._running_args.append("%s, " % arg)
                     for k, v in action.kwargs:
                         self._running_args.append("%s=%s, " % (str(k), str(v)))
-                except:
+                except BaseException:
                     self._running_cmd = "unknown"
                     self._running_args = []
                 result = action.function(*action.args, **action.kwargs)
@@ -177,8 +177,8 @@ def _makeThreadPool(threadPoolSize=THREAD_POOL_SIZE, daemonic=True):
         for this_thread in ThreadPool:
             log.error("%s running: %s" % (this_thread._thread_name, this_thread._running_cmd))
 
-        #from GangaCore.Core.exceptions import GangaException
-        #raise GangaException("Cannot doubbly init the ThreadPool! ThreadPool already populated with threads")
+        # from GangaCore.Core.exceptions import GangaException
+        # raise GangaException("Cannot doubbly init the ThreadPool! ThreadPool already populated with threads")
         log.error("Found a thread pool already in existance, wiping it and startig again!")
         del ThreadPool[:]
         ThreadPool = []
@@ -197,10 +197,10 @@ def _makeThreadPool(threadPoolSize=THREAD_POOL_SIZE, daemonic=True):
 
 def stop_and_free_thread_pool(fail_cb=None, max_retries=5):
     """
-     Clean shutdown of the thread pool. 
+     Clean shutdown of the thread pool.
      A failed attempt to stop all the worker threads is followed by a call to the supplied callback which
      decides if a new attempt is performed or not.
-     Example for a decision callback:      
+     Example for a decision callback:
           def myfail_cb():
              resp = raw_input("The cleanup procedures did not complete yet. Do you want to wait more?[y/N]")
              return resp.lower()=='y'
@@ -242,7 +242,7 @@ def stop_and_free_thread_pool(fail_cb=None, max_retries=5):
 
 def _purge_actions_queue():
     """
-    Purge Qin: consume the current queued actions 
+    Purge Qin: consume the current queued actions
     Note: the producer (i.e JobRegistry_Monitor) should be stopped before the method is called
     """
     # purge the queue
@@ -307,7 +307,7 @@ def release_when_done(rlock):
 class UpdateDict(object):
 
     """
-    This serves as the Update Table. Is is meant to be used 
+    This serves as the Update Table. Is is meant to be used
     by wrapping it as a SynchronisedObject so as to ensure thread safety.
     """
 
@@ -434,7 +434,8 @@ def autoKill_if_required(jobList_fromset):
 
             if n_completed == 0 and n_failed >= config['autoKillThreshold'] and not config['autoKillThreshold'] == -1:
                 log.warning(
-                    'Killing job %d as too many subjobs have failed with no successful completions. Please check your options!' % j.master.id)
+                    'Killing job %d as too many subjobs have failed with no successful completions. Please check your options!' %
+                    j.master.id)
                 j.master.auto_kill()
         else:
             # Check for max number of resubmissions
@@ -443,7 +444,8 @@ def autoKill_if_required(jobList_fromset):
 
             if n_completed == 0 and n_failed >= config['autoKillThreshold'] and not config['autoKillThreshold'] == -1:
                 log.warning(
-                    'Killing job %d as too many subjobs have failed with no successful completions. Please check your options!' % j.id)
+                    'Killing job %d as too many subjobs have failed with no successful completions. Please check your options!' %
+                    j.id)
                 j.auto_kill()
 
 
@@ -514,8 +516,25 @@ class JobRegistry_Monitor(GangaThread):
     minPollRate = 1.
     global_count = 0
 
-    __slots__ = ('registry_slice', '__sleepCounter', '__updateTimeStamp', 'progressCallback', 'callbackHookDict', 'clientCallbackDict', 'alive', 'enabled', 'steps',
-                 'activeBackends', 'updateJobStatus', 'errors', 'updateDict_ts', '__mainLoopCond', '__cleanUpEvent', '__monStepsTerminatedEvent', 'stopIter', '_runningNow')
+    __slots__ = (
+        'registry_slice',
+        '__sleepCounter',
+        '__updateTimeStamp',
+        'progressCallback',
+        'callbackHookDict',
+        'clientCallbackDict',
+        'alive',
+        'enabled',
+        'steps',
+        'activeBackends',
+        'updateJobStatus',
+        'errors',
+        'updateDict_ts',
+        '__mainLoopCond',
+        '__cleanUpEvent',
+        '__monStepsTerminatedEvent',
+        'stopIter',
+        '_runningNow')
 
     def __init__(self, registry_slice):
         GangaThread.__init__(self, name="JobRegistry_Monitor")
@@ -656,7 +675,7 @@ class JobRegistry_Monitor(GangaThread):
         """
         A single monitoring step in the monitoring loop
         Note:
-        Internally the step does not block, it produces *actions* that are queued to be run 
+        Internally the step does not block, it produces *actions* that are queued to be run
         in the thread pool
         """
         if not self.callbackHookDict:
@@ -715,9 +734,9 @@ class JobRegistry_Monitor(GangaThread):
           jobs: a registry slice to be monitored (None -> all jobs), it may be passed by the user so ._impl is stripped if needed
         Return:
           False, if the loop cannot be started or the timeout occured while waiting for monitoring termination
-          True, if the monitoring steps were successfully executed  
-        Note:         
-          This method is meant to be used in Ganga scripts to request monitoring on demand. 
+          True, if the monitoring steps were successfully executed
+        Note:
+          This method is meant to be used in Ganga scripts to request monitoring on demand.
         """
 
         log.debug("runMonitoring")
@@ -757,8 +776,8 @@ class JobRegistry_Monitor(GangaThread):
                 log.error("Cannot run the monitoring loop. The following credentials are required: %s" % _missingCreds)
                 return False
 
-        #log.debug("jobs: %s" % str(jobs))
-        #log.debug("self.__mainLoopCond: %s" % str(self.__mainLoopCond))
+        # log.debug("jobs: %s" % str(jobs))
+        # log.debug("self.__mainLoopCond: %s" % str(self.__mainLoopCond))
 
         with self.__mainLoopCond:
             log.debug('Monitoring loop lock acquired. Enabling mon loop')
@@ -778,8 +797,8 @@ class JobRegistry_Monitor(GangaThread):
                         'runMonitoring: jobs argument must be a registry slice such as a result of jobs.select() or jobs[i1:i2]')
                     return False
 
-                #self.registry_slice = m_jobs
-                #log.debug("m_jobs: %s" % str(m_jobs))
+                # self.registry_slice = m_jobs
+                # log.debug("m_jobs: %s" % str(m_jobs))
                 self.makeUpdateJobStatusFunction(jobSlice=m_jobs)
 
             log.debug("Enable Loop, Clear Iterators and setCallbackHook")
@@ -925,7 +944,7 @@ class JobRegistry_Monitor(GangaThread):
         # join the worker threads
         _purge_actions_queue()
         stop_and_free_thread_pool(fail_cb, max_retries)
-        ###log.info( 'Monitoring component stopped successfully!' )
+        # log.info( 'Monitoring component stopped successfully!' )
 
         # while self._runningNow is True:
         #    time.sleep(0.5)
@@ -936,7 +955,7 @@ class JobRegistry_Monitor(GangaThread):
     def __cleanUp(self):
         """
         Cleanup function ran in JobRegistry_Monitor thread to disable the monitoring loop
-        updateDict_ts.timeoutCheck can hold timeout locks that need to be released 
+        updateDict_ts.timeoutCheck can hold timeout locks that need to be released
         in order to allow the pool threads to be freed.
         """
 
@@ -1039,7 +1058,7 @@ class JobRegistry_Monitor(GangaThread):
             fixed_ids = jobSlice.ids()
         else:
             fixed_ids = self.registry_slice.ids()
-        #log.debug("Registry: %s" % str(self.registry_slice))
+        # log.debug("Registry: %s" % str(self.registry_slice))
         log.debug("Running over fixed_ids: %s" % str(fixed_ids))
         for i in fixed_ids:
             try:
@@ -1089,9 +1108,9 @@ class JobRegistry_Monitor(GangaThread):
 
         try:
             log.debug("[Update Thread %s] Lock acquired for %s" % (current_thread, getName(backendObj)))
-            #alljobList_fromset = IList(filter(lambda x: x.status in ['submitted', 'running'], jobListSet), self.stopIter)
+            # alljobList_fromset = IList(filter(lambda x: x.status in ['submitted', 'running'], jobListSet), self.stopIter)
             # print alljobList_fromset
-            #masterJobList_fromset = IList(filter(lambda x: (x.master is not None) and (x.status in ['submitting']), jobListSet), self.stopIter)
+            # masterJobList_fromset = IList(filter(lambda x: (x.master is not None) and (x.status in ['submitting']), jobListSet), self.stopIter)
 
             # FIXME We've lost IList and the above method for adding a job which is in a submitted state looks like one that didn't work
             # Come back and fix this once 6.1.3 is out. We can drop features for functionalist here as the lazy loading is fixed in this release
@@ -1131,7 +1150,7 @@ class JobRegistry_Monitor(GangaThread):
                 bunch_size = 0
                 for bunch in all_job_bunches:
                     bunch_size += len(bunch)
-                assert(bunch_size == len(jobList_fromset))
+                assert (bunch_size == len(jobList_fromset))
 
                 all_exceptions = []
 
@@ -1151,7 +1170,7 @@ class JobRegistry_Monitor(GangaThread):
                     try:
                         stripProxy(backendObj).master_updateMonitoringInformation(this_job_list)
                     except Exception as err:
-                        #raise err
+                        # raise err
                         log.debug("Err: %s" % str(err))
                         # We want to catch ALL of the exceptions
                         # This would allow us to continue in the case of errors due to bad job/backend combinations
@@ -1170,13 +1189,13 @@ class JobRegistry_Monitor(GangaThread):
             except BackendError as x:
                 self._handleError(x, x.backend_name, 0)
             except Exception as err:
-                #self._handleError(err, getName(backendObj), 1)
+                # self._handleError(err, getName(backendObj), 1)
                 log.error("Monitoring Error: %s" % str(err))
                 log.debug("Lets not crash here!")
                 return
 
             # FIXME THIS METHOD DOES NOT EXIST
-            #log.debug("[Update Thread %s] Flushing registry %s." % (current_thread, [x.id for x in jobList_fromset]))
+            # log.debug("[Update Thread %s] Flushing registry %s." % (current_thread, [x.id for x in jobList_fromset]))
             # FIXME THIS RETURNS A REGISTRYSLICE OBJECT NOT A REGISTRY, IS THIS CORRECT? SHOULD WE FLUSH
             # COMMENTING OUT AS IT SIMPLY WILL NOT RUN/RESOLVE!
             # this concerns me - rcurrie
@@ -1216,7 +1235,7 @@ class JobRegistry_Monitor(GangaThread):
 
         for jList in activeBackends.values():
 
-            #log.debug("backend: %s" % str(jList))
+            # log.debug("backend: %s" % str(jList))
             backendObj = jList[0].backend
             b_name = getName(backendObj)
             if b_name in config:
@@ -1229,7 +1248,7 @@ class JobRegistry_Monitor(GangaThread):
             #       of the particular backend is satisfied.
             #       This requires backends to hold relevant information on its
             #       credential requirements.
-            #log.debug("addEntry: %s, %s, %s, %s" % (str(backendObj), str(thisMonitor._checkBackend), str(jList), str(pRate)))
+            # log.debug("addEntry: %s, %s, %s, %s" % (str(backendObj), str(thisMonitor._checkBackend), str(jList), str(pRate)))
             thisMonitor.updateDict_ts.addEntry(backendObj, thisMonitor._checkBackend, jList, pRate)
             summary = str([stripProxy(x).getFQID('.') for x in jList])
             log.debug("jList: %s" % str(summary))
@@ -1361,7 +1380,7 @@ def getStackTrace():
 
             status = status + "\n"
         # CANNOT CONVERT TO A STRING!!!
-        #log.info("Queue", str(Qin.queue))
+        # log.info("Queue", str(Qin.queue))
         log.debug("Trace: %s" % str(status))
         return status
     except Exception as err:

--- a/ganga/GangaCore/Lib/Condor/Condor.py
+++ b/ganga/GangaCore/Lib/Condor/Condor.py
@@ -42,8 +42,8 @@ import warnings
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")
     try:
-        import htcondor
-        import classad
+        import htcondor2 as htcondor
+        import classad2 as classad
     except ModuleNotFoundError:
         logger.debug("The htcondor module not available for import. This will cause use of the Condor backend to fail.")
 
@@ -119,6 +119,8 @@ class Condor(IBackend):
 
         # Get the credential into the scheduler
         col = htcondor.Collector()
+
+        # Not sure this is needed in new API
         credd = htcondor.Credd()
         if credential_store.matches(AfsToken()):
             credd.add_user_cred(htcondor.CredTypes.Kerberos, None)
@@ -467,8 +469,8 @@ class Condor(IBackend):
             for _proc in id_dict[_cl][1:]:
                 pr_expr_str = pr_expr_str + " || ProcID == %s" % _proc
             pr_expr = classad.ExprTree(pr_expr_str)
-            cl_expr = cl_expr.and_(pr_expr)
-            expr_tree = expr_tree.or_(cl_expr)
+            cl_expr = classad.ExprTree("(%s) && (%s)" % (cl_expr, pr_expr))
+            expr_tree = classad.ExprTree("(%s) || (%s)" % (expr_tree, cl_expr))
 
         # Now query the scheduler with or job list
         schedd = htcondor.Schedd()

--- a/ganga/GangaCore/Runtime/bootstrap.py
+++ b/ganga/GangaCore/Runtime/bootstrap.py
@@ -1208,6 +1208,7 @@ under certain conditions; type license() for details.
         banner = ''
         cfg.TerminalInteractiveShell.prompts_class = GangaPrompt
         cfg.TerminalInteractiveShell.banner1 = banner
+        cfg.TerminalInteractiveShell.enable_tip = False
 
         # Setting up the confirmation of exit on Ctrl+D this prompt annoys some users(developers)
         from GangaCore.Utility.Config.Config import getConfig
@@ -1216,7 +1217,7 @@ under certain conditions; type license() for details.
         # The customisation of the interactive shell is done in this extension
         cfg.InteractiveShellApp.extensions = ['GangaCore.Runtime.ganga_extension']
 
-        IPython.start_ipython(argv=[], user_ns=local_ns, local_ns=local_ns, module=GangaCore.GPI, config=cfg)
+        IPython.start_ipython(argv=[], user_ns=local_ns, config=cfg)
 
 
 #

--- a/ganga/GangaCore/Runtime/plugins.py
+++ b/ganga/GangaCore/Runtime/plugins.py
@@ -1,3 +1,4 @@
+from GangaCore.Utility.Config.Config import getConfig
 import GangaCore.Utility.logging
 
 logger = GangaCore.Utility.logging.getLogger()

--- a/ganga/GangaCore/Utility/logging/__init__.py
+++ b/ganga/GangaCore/Utility/logging/__init__.py
@@ -400,7 +400,7 @@ class FlushedMemoryHandler(_MemHandler):
         # Errors should be dumped in the correct place with the correct context
         if record.levelno > logging.WARNING:
             return True
-        return (threading.currentThread().getName() == "MainThread") or \
+        return (threading.current_thread().name == "MainThread") or \
             _MemHandler.shouldFlush(self, record)
 
 

--- a/ganga/GangaCore/Utility/stacktracer.py
+++ b/ganga/GangaCore/Utility/stacktracer.py
@@ -14,7 +14,7 @@ import sys
 import threading
 import time
 import traceback
-from datetime import datetime
+from datetime import datetime, timezone
 
 try:
     from pygments import highlight
@@ -56,7 +56,7 @@ def stacktraces():
         trace = traceback.format_stack(stack)
         html.append(highlight_trace(''.join(trace)))
 
-    html.append('<small>' + datetime.utcnow().isoformat() + '</small>')
+    html.append('<small>' + datetime.now(tz=timezone.utc).isoformat() + '</small>')
     html.append('</body>')
     html.append('</html>')
 

--- a/ganga/GangaCore/__init__.py
+++ b/ganga/GangaCore/__init__.py
@@ -341,8 +341,8 @@ conf_config.addOption(
 ipython_config = makeConfig('TextShell_IPython', '''IPython shell configuration''')
 ipython_config.addOption(
     'colourscheme',
-    'LightBG',
-    'Colour scheme to be used by iPython. Options are LightBG, Linux, Neutral, NoColor',
+    'lightbg',
+    'Colour scheme to be used by iPython. Options are lightbg, Linux, Neutral, NoColor',
 )
 
 # ------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,7 @@ install_requires = [
     "pymongo",
     "gdown",
 ]
+
 if sys.platform != 'darwin':
     install_requires.append("htcondor")
 


### PR DESCRIPTION
closes #2407

This PR makes `htcondor` optional as well as fixing deprecation warnings and other little niggles when running Ganga under Python 3.14

-----

**Note: Will need to check that the updates to run under Python3.14 don't prevent ganga running under our min version.**